### PR TITLE
Improve idiot-proofing of setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,14 @@
+import sys
 from setuptools import setup
-try:
-    import firedrake # noqa
-except ImportError:
-    raise Exception("Firedrake needs to be installed and activated. "
-                    "Please visit firedrakeproject.org")
+
+if "clean" in sys.argv[1:]:
+    pass
+else:
+    try:
+        import firedrake # noqa
+    except ImportError:
+        raise Exception("Firedrake needs to be installed and activated. "
+                        "Please visit firedrakeproject.org")
 setup(
     name='IRKsome',
     version='0.0.1',


### PR DESCRIPTION
I broke my firedrake install, then was foiled in running `firedrake-update` because Irksome's `setup.py` tried to `import firedrake` when `python setup.py clean` was called.  With this change, that no longer happens.