### PR TITLE
Bclabels

### DIFF
--- a/irksome/getForm.py
+++ b/irksome/getForm.py
@@ -90,8 +90,6 @@ def getForm(F, butch, t, dt, u0, bcs=None):
             repl[TimeDerivative(ubit)] = kbits_np[i, j]
 
         Fnew += replace(F, repl)
-    from petsc4py import PETSc
-    PETSc.Sys.Print(Fnew)
 
     bcnew = []
     gblah = []

--- a/irksome/getForm.py
+++ b/irksome/getForm.py
@@ -80,11 +80,6 @@ def getForm(F, butch, t, dt, u0, bcs=None):
 
     Ak = A @ kbits_np
 
-    # Let's splat out time derivatives in F
-    # print(F)
-    # F = apply_time_derivatives(F, t, [u0])
-    # print(F)
-
     Fnew = Zero()
 
     for i in range(num_stages):
@@ -95,6 +90,8 @@ def getForm(F, butch, t, dt, u0, bcs=None):
             repl[TimeDerivative(ubit)] = kbits_np[i, j]
 
         Fnew += replace(F, repl)
+    from petsc4py import PETSc
+    PETSc.Sys.Print(Fnew)
 
     bcnew = []
     gblah = []
@@ -102,8 +99,8 @@ def getForm(F, butch, t, dt, u0, bcs=None):
     if bcs is None:
         bcs = []
     for bc in bcs:
-        if bc.domain_args[0] == "on_boundary":
-            boundary = "on_boundary"
+        if isinstance(bc.domain_args[0], str):
+            boundary = bc.domain_args[0]
         else:
             boundary = ()
             for j in bc.domain_args[1][1]:


### PR DESCRIPTION
When a `DirichletBC` was labeled with a string other than `on_boundary`, Irksome broke.  This fixes that.