### PR TITLE
fixing subdomain BCs and adding tests

### DIFF
--- a/irksome/getForm.py
+++ b/irksome/getForm.py
@@ -90,7 +90,6 @@ def getForm(F, butch, t, dt, u0, bcs=None):
          onto the corresponding f in order for Firedrake to pick up that
          time-dependent boundary conditions need to be re-applied.
 """
-
     v = F.arguments()[0]
     V = v.function_space()
     assert V == u0.function_space()
@@ -151,15 +150,6 @@ def getForm(F, butch, t, dt, u0, bcs=None):
     if bcs is None:
         bcs = []
     for bc in bcs:
-        if isinstance(bc.domain_args[0], str):
-            boundary = bc.domain_args[0]
-        else:
-            boundary = ()
-            try:
-                for j in bc.sub_domain:
-                    boundary += j
-            except TypeError:
-                boundary = (bc.sub_domain,)
         gfoo = expand_derivatives(diff(bc._original_arg, t))
         if len(V) == 1:
             for i in range(num_stages):
@@ -169,7 +159,7 @@ def getForm(F, butch, t, dt, u0, bcs=None):
                 except NotImplementedError:
                     gdat = project(gcur, V)
                 gblah.append((gdat, gcur))
-                bcnew.append(DirichletBC(Vbig[i], gdat, boundary))
+                bcnew.append(DirichletBC(Vbig[i], gdat, bc.sub_domain))
         else:
             sub = bc.function_space_index()
             for i in range(num_stages):
@@ -180,6 +170,6 @@ def getForm(F, butch, t, dt, u0, bcs=None):
                     gdat = project(gcur, V)
                 gblah.append((gdat, gcur))
                 bcnew.append(DirichletBC(Vbig[sub + num_fields * i],
-                                         gdat, boundary))
+                                         gdat, bc.sub_domain))
 
     return Fnew, k, bcnew, gblah

--- a/tests/test_curl.py
+++ b/tests/test_curl.py
@@ -1,0 +1,58 @@
+import pytest
+from firedrake import *
+from irksome import GaussLegendre, Dt, TimeStepper
+from ufl.algorithms.ad import expand_derivatives
+
+
+def curlcross(a, b):
+    curla = a[1].dx(0) - a[0].dx(1)
+    return as_vector([-curla*b[1], curla*b[0]])
+
+
+def curltest(N, deg, butcher_tableau):
+
+    msh = UnitSquareMesh(N, N)
+
+    Ve = FiniteElement("N1curl", msh.ufl_cell(), 2, variant="integral")
+    V = FunctionSpace(msh, Ve)
+
+    dt = Constant(0.1 / N)
+    t = Constant(0.0)
+
+    x, y = SpatialCoordinate(msh)
+
+    uexact = as_vector([t + 2*t*x + 4*t*y + 3*t*(y**2) + 2*t*x*y, 7*t + 5*t*x + 6*t*y - 3*t*x*y - 2*t*(x**2)])
+    rhs = expand_derivatives(diff(uexact, t)) + curl(curl(uexact))
+
+    u = interpolate(uexact, V)
+
+    v = TestFunction(V)
+    n = FacetNormal(msh)
+    F = inner(Dt(u), v)*dx + inner(curl(u), curl(v))*dx - inner(curlcross(uexact, n), v)*ds - inner(rhs, v)*dx
+    bc = DirichletBC(V, uexact, [1, 2])
+
+    luparams = {"mat_type": "aij",
+                "ksp_type": "preonly",
+                "pc_type": "lu"}
+
+    stepper = TimeStepper(F, butcher_tableau, t, dt, u, bcs=bc,
+                          solver_parameters=luparams)
+
+    while (float(t) < 0.1):
+        if (float(t) + float(dt) > 0.1):
+            dt.assign(0.1 - float(t))
+        stepper.advance()
+        print(float(t))
+        t.assign(float(t) + float(dt))
+
+    return norm(u-uexact)
+
+
+@pytest.mark.parametrize(('deg', 'N', 'time_stages'),
+                         [(1, 2**j, i) for j in range(2, 4)
+                          for i in (1, 2)]
+                         + [(2, 2**j, i) for j in range(2, 4)
+                            for i in (2, 3)])
+def test_curl(deg, N, time_stages):
+    error = curltest(N, deg, GaussLegendre(time_stages))
+    assert abs(error) < 1e-10

--- a/tests/test_subdomainbc.py
+++ b/tests/test_subdomainbc.py
@@ -1,0 +1,51 @@
+import pytest
+from firedrake import *
+from irksome import GaussLegendre, Dt, TimeStepper
+from ufl.algorithms.ad import expand_derivatives
+
+
+def heat_subdomainbc(N, deg, butcher_tableau):
+    dt = Constant(1.0 / N)
+    t = Constant(0.0)
+
+    msh = UnitSquareMesh(N, N)
+
+    V = FunctionSpace(msh, "CG", 2)
+    x, y = SpatialCoordinate(msh)
+
+    uexact = t*(x+y)
+    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+
+    u = interpolate(uexact, V)
+
+    v = TestFunction(V)
+    n = FacetNormal(msh)
+    F = inner(Dt(u), v)*dx + inner(grad(u), grad(v))*dx - inner(rhs, v)*dx - inner(dot(grad(uexact), n), v)*ds
+
+    bc = DirichletBC(V, uexact, [1, 2])
+
+    luparams = {"mat_type": "aij",
+                "snes_type": "ksponly",
+                "ksp_type": "preonly",
+                "pc_type": "lu"}
+
+    stepper = TimeStepper(F, butcher_tableau, t, dt, u, bcs=bc,
+                          solver_parameters=luparams)
+
+    while (float(t) < 1.0):
+        if (float(t) + float(dt) > 1.0):
+            dt.assign(1.0 - float(t))
+        stepper.advance()
+        t.assign(float(t) + float(dt))
+
+    return norm(u-uexact)
+
+
+@pytest.mark.parametrize(('deg', 'N', 'time_stages'),
+                         [(1, 2**j, i) for j in range(2, 4)
+                          for i in (1, 2)]
+                         + [(2, 2**j, i) for j in range(2, 4)
+                            for i in (2, 3)])
+def test_subdomainbc(deg, N, time_stages):
+    error = heat_subdomainbc(N, deg, GaussLegendre(time_stages))
+    assert abs(error) < 1e-10


### PR DESCRIPTION
Boundary conditions defined only on some faces of the boundary were not being read by Irksome as separate faces but rather edges.  Changes were made to getForm.py on how the for loop reads in specifies face id numbers.  A 2d heat test and a 2d curl test are added to validate changes made in getForm.py. 