### PR TITLE
Implement DAE-style BCs

### DIFF
--- a/demos/lowlevel/demo_lowlevel_inhomogbc.py.rst
+++ b/demos/lowlevel/demo_lowlevel_inhomogbc.py.rst
@@ -76,7 +76,7 @@ boundary conditions at each time step::
           dt.assign(1.0 - float(t))
 
       for (gdat, gcur, gmethod) in bcdata:
-          gmethod(gcur)
+          gmethod(gcur,u)
 
       solver.solve()
 

--- a/irksome/ButcherTableaux.py
+++ b/irksome/ButcherTableaux.py
@@ -24,6 +24,10 @@ class ButcherTableau(object):
         self.btilde = btilde
         self.c = c
         self.order = order
+        try:
+            self.Ainv = numpy.linalg.inv(A)
+        except numpy.linalg.LinAlgError:
+            self.Ainv = None
 
     @property
     def num_stages(self):

--- a/irksome/getForm.py
+++ b/irksome/getForm.py
@@ -71,18 +71,15 @@ class DAEBCStageDataMixedSpace(BCStageData):
         gcur = 0
         for j in range(num_stages):
             gcur += Ainv[i, j] * replace(gorig, {t: t + c[j]*dt})
-            try:
-                gdat = interpolate(gcur-u0_mult[i]*u0.sub(sub), V.sub(sub))
+        try:
+            gdat = interpolate(gcur-u0_mult[i]*u0.sub(sub), V.sub(sub))
 
-                def gmethod(g, u):
-                    # print("in gmethod")
-                    # print(id(gdat))
-                    # print(gdat.ufl_shape, g.ufl_shape, u.sub(sub).ufl_shape)
-                    # print("end gmethod")
-                    return gdat.interpolate(g-u0_mult[i]*u.sub(sub))
-            except:  # noqa: E722
-                gdat = project(gcur-u0_mult[i]*u0.sub(sub), V.sub(sub))
-                gmethod = lambda g, u: gdat.project(g-u0_mult[i]*u.sub(sub))
+            def gmethod(g, u):
+                return gdat.interpolate(g-u0_mult[i]*u.sub(sub))
+
+        except:  # noqa: E722
+            gdat = project(gcur-u0_mult[i]*u0.sub(sub), V.sub(sub))
+            gmethod = lambda g, u: gdat.project(g-u0_mult[i]*u.sub(sub))
         super().__init__(gdat, gcur, gmethod)
 
 

--- a/irksome/getForm.py
+++ b/irksome/getForm.py
@@ -79,7 +79,7 @@ class DAEBCStageDataNonMixedSpace(BCStageData):
             gmethod = lambda g, u: gdat.project(g-u0_mult[i]*u)
         super().__init__(gdat, gcur, gmethod)
 
-        
+
 class DAEBCStageDataMixedSpace(BCStageData):
     def __init__(self, V, sub, gorig, u0, Ainv, i, u0_mult, c, t, dt):
         num_stages = len(c)

--- a/irksome/getForm.py
+++ b/irksome/getForm.py
@@ -228,13 +228,10 @@ def getForm(F, butch, t, dt, u0, bcs=None, bc_type="DAE"):
         for bc in bcs:
             gorig = as_ufl(bc._original_arg)
 
-            if len(V) == 1:
-                Vsp = V
-                offset = lambda i: i
-            else:
-                sub = bc.function_space_index()
-                Vsp = V.sub(sub)
-                offset = lambda i: sub + num_fields * i
+            sub = 0 if len(V) == 1 else bc.function_space_index()
+            Vsp = V if len(V) == 1 else V.sub(sub)
+            offset = lambda i: sub + num_fields * i
+
             for i in range(num_stages):
                 blah = DAEBCStageData(Vsp, butch, gorig, u0, i, t, dt)
                 gdat, gcur, gmethod = blah.gstuff

--- a/irksome/getForm.py
+++ b/irksome/getForm.py
@@ -73,17 +73,18 @@ class DAEBCStageDataMixedSpace(BCStageData):
             gcur += Ainv[i, j] * replace(gorig, {t: t + c[j]*dt})
             try:
                 gdat = interpolate(gcur-u0_mult[i]*u0.sub(sub), V.sub(sub))
+
                 def gmethod(g, u):
                     # print("in gmethod")
                     # print(id(gdat))
                     # print(gdat.ufl_shape, g.ufl_shape, u.sub(sub).ufl_shape)
                     # print("end gmethod")
                     return gdat.interpolate(g-u0_mult[i]*u.sub(sub))
-            except:
+            except:  # noqa: E722
                 gdat = project(gcur-u0_mult[i]*u0.sub(sub), V.sub(sub))
                 gmethod = lambda g, u: gdat.project(g-u0_mult[i]*u.sub(sub))
         super().__init__(gdat, gcur, gmethod)
-    
+
 
 def getForm(F, butch, t, dt, u0, bcs=None, bc_type="DAE"):
     """Given a time-dependent variational form and a

--- a/irksome/getForm.py
+++ b/irksome/getForm.py
@@ -180,8 +180,6 @@ def getForm(F, butch, t, dt, u0, bcs=None, bc_type="DAE"):
     bcnew = []
     gblah = []
 
-    c = numpy.array([Constant(ci) for ci in butch.c])
-
     if bcs is None:
         bcs = []
     if bc_type == "ODE":

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -123,7 +123,7 @@ class AdaptiveTimeStepper(TimeStepper):
     """
     def __init__(self, F, butcher_tableau, t, dt, u0,
                  tol=1.e-6, dtmin=1.e-5, bcs=None, solver_parameters=None,
-                 bc_type="ODE"):
+                 bc_type="DAE"):
         assert butcher_tableau.btilde is not None
         super(AdaptiveTimeStepper, self).__init__(F, butcher_tableau,
                                                   t, dt, u0, bcs,

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -26,13 +26,19 @@ class TimeStepper:
             the strongly-enforced boundary conditions.  Irksome will
             manipulate these to obtain boundary conditions for each
             stage of the RK method.
+    :arg bc_type: How to manipulate the strongly-enforced boundary
+            conditions to derive the stage boundary conditions.
+            Should be a string, either "DAE", which implements BCs as
+            constraints in the style of a differential-algebraic
+            equation, or "ODE", which takes the time derivative of the
+            boundary data and evaluates this for the stage values
     :arg solver_parameters: A :class:`dict` of solver parameters that
             will be used in solving the algebraic problem associated
             with each time step.
 
     """
     def __init__(self, F, butcher_tableau, t, dt, u0, bcs=None,
-                 solver_parameters=None):
+                 solver_parameters=None, bc_type="DAE"):
         self.u0 = u0
         self.t = t
         self.dt = dt
@@ -41,7 +47,7 @@ class TimeStepper:
         self.butcher_tableau = butcher_tableau
 
         bigF, stages, bigBCs, bigBCdata = \
-            getForm(F, butcher_tableau, t, dt, u0, bcs)
+            getForm(F, butcher_tableau, t, dt, u0, bcs, bc_type)
 
         self.stages = stages
         self.bigBCs = bigBCs
@@ -79,7 +85,7 @@ class TimeStepper:
         """Advances the system from time `t` to time `t + dt`.
         Note: overwrites the value `u0`."""
         for gdat, gcur, gmethod in self.bigBCdata:
-            gmethod(gcur)
+            gmethod(gcur, self.u0)
 
         self.solver.solve()
 
@@ -116,11 +122,12 @@ class AdaptiveTimeStepper(TimeStepper):
             with each time step.
     """
     def __init__(self, F, butcher_tableau, t, dt, u0,
-                 tol=1.e-6, dtmin=1.e-5, bcs=None, solver_parameters=None):
+                 tol=1.e-6, dtmin=1.e-5, bcs=None, solver_parameters=None,
+                 bc_type="ODE"):
         assert butcher_tableau.btilde is not None
         super(AdaptiveTimeStepper, self).__init__(F, butcher_tableau,
                                                   t, dt, u0, bcs,
-                                                  solver_parameters)
+                                                  solver_parameters, bc_type)
         self.tol = tol
         self.dt_min = dtmin
         self.delb = butcher_tableau.b - butcher_tableau.btilde
@@ -160,7 +167,7 @@ class AdaptiveTimeStepper(TimeStepper):
         print("\tTrying dt=", float(self.dt))
         while 1:
             for gdat, gcur, gmethod in self.bigBCdata:
-                gmethod(gcur)
+                gmethod(gcur, self.u0)
 
             self.solver.solve()
             err = self._estimate_error()

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -85,6 +85,7 @@ class TimeStepper:
         """Advances the system from time `t` to time `t + dt`.
         Note: overwrites the value `u0`."""
         for gdat, gcur, gmethod in self.bigBCdata:
+            print(gdat.ufl_shape, gcur.ufl_shape)
             gmethod(gcur, self.u0)
 
         self.solver.solve()

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -85,7 +85,6 @@ class TimeStepper:
         """Advances the system from time `t` to time `t + dt`.
         Note: overwrites the value `u0`."""
         for gdat, gcur, gmethod in self.bigBCdata:
-            print(gdat.ufl_shape, gcur.ufl_shape)
             gmethod(gcur, self.u0)
 
         self.solver.solve()

--- a/tests/test_dirichletbc.py
+++ b/tests/test_dirichletbc.py
@@ -46,8 +46,9 @@ def test_1d_heat_dirichletbc(butcher_tableau):
     ]
 
     luparams = {"mat_type": "aij", "ksp_type": "preonly", "pc_type": "lu"}
+    # For LobattoIIIA, need to use ODE-style BCs
     stepper = TimeStepper(
-        F, butcher_tableau, t, dt, u, bcs=bc, solver_parameters=luparams
+        F, butcher_tableau, t, dt, u, bcs=bc, solver_parameters=luparams, bc_type="ODE"
     )
 
     t_end = 2.0

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -1,0 +1,82 @@
+import pytest
+import numpy as np
+from firedrake import *
+
+from irksome import Dt, TimeStepper, LobattoIIIC
+from ufl.algorithms import expand_derivatives
+
+# test the accuracy of the 1d heat equation using CG elements
+# and Gauss-Legendre time integration
+
+
+def StokesTest(N, butcher_tableau):
+    mesh = UnitSquareMesh(N,N)
+
+    Ve = VectorElement("CG", mesh.ufl_cell(), 2)
+    Pe = FiniteElement("CG", mesh.ufl_cell(), 1)
+    Ze = MixedElement([Ve, Pe])
+    Z = FunctionSpace(mesh, Ze)
+
+    t = Constant(0.0)
+    dt = Constant(1.0/N)
+    (x,y) = SpatialCoordinate(mesh)
+
+    uexact = as_vector([x*t + y**2,-y*t+t*(x**2)])
+    pexact = Constant(0, domain=mesh)
+
+    u_rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact)) + grad(pexact)
+    p_rhs = -div(uexact)
+
+    z = Function(Z)
+    test_z = TestFunction(Z)
+    (u, p) = split(z)
+    (v, q) = split(test_z)
+    F = (  inner(Dt(u),v)*dx
+         + inner(grad(u), grad(v))*dx
+         - inner(p, div(v))*dx
+         - inner(q, div(u))*dx
+         - inner(u_rhs, v)*dx
+         - inner(p_rhs, q)*dx
+        )
+    
+    bcs = [
+           DirichletBC(Z.sub(0), uexact, "on_boundary"),
+           DirichletBC(Z.sub(1), pexact, "on_boundary")
+          ]
+
+    u,p = z.split()
+    u.interpolate(uexact)
+
+    lu = {
+       "mat_type": "aij",
+       "snes_type": "newtonls",
+       "snes_linesearch_type": "l2",
+       "snes_linesearch_monitor": None,
+       "snes_monitor": None,
+       "snes_rtol": 1e-8,
+       "snes_atol": 1e-8,
+       "ksp_type": "preonly",
+       "pc_type": "lu",
+       "pc_factor_mat_solver_type": "mumps",
+         }
+
+    stepper = TimeStepper(F, butcher_tableau, t, dt, z,
+                          bcs=bcs, solver_parameters=lu)
+
+    while (float(t) < 1.0):
+        if (float(t) + float(dt) > 1.0):
+            dt.assign(1.0 - float(t))
+        stepper.advance()
+        t.assign(float(t) + float(dt))
+
+    (u,p) = z.split()
+    return errornorm(uexact, u)
+
+@pytest.mark.parametrize(('N', 'time_stages'),
+                         [(2**j, i) for j in range(2, 4)
+                          for i in (2, 3)])
+def test_Stokes(N, time_stages):
+    error = StokesTest(N, LobattoIIIC(time_stages))
+    assert abs(error) < 1e-10
+
+

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -4,8 +4,10 @@ from firedrake import *
 from irksome import Dt, TimeStepper, LobattoIIIC
 from ufl.algorithms import expand_derivatives
 
-# test the accuracy of the 1d heat equation using CG elements
-# and Gauss-Legendre time integration
+# test the accuracy of the 2d Stokes heat equation using CG elements
+# and LobattoIIIC time integration.  Particular issue being tested is
+# enforcement of the pressure BC, which is a field that doesn't have
+# a time derivative on it.
 
 
 def StokesTest(N, butcher_tableau):

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 from firedrake import *
 
 from irksome import Dt, TimeStepper, LobattoIIIC
@@ -10,7 +9,7 @@ from ufl.algorithms import expand_derivatives
 
 
 def StokesTest(N, butcher_tableau):
-    mesh = UnitSquareMesh(N,N)
+    mesh = UnitSquareMesh(N, N)
 
     Ve = VectorElement("CG", mesh.ufl_cell(), 2)
     Pe = FiniteElement("CG", mesh.ufl_cell(), 1)
@@ -19,9 +18,9 @@ def StokesTest(N, butcher_tableau):
 
     t = Constant(0.0)
     dt = Constant(1.0/N)
-    (x,y) = SpatialCoordinate(mesh)
+    (x, y) = SpatialCoordinate(mesh)
 
-    uexact = as_vector([x*t + y**2,-y*t+t*(x**2)])
+    uexact = as_vector([x*t + y**2, -y*t+t*(x**2)])
     pexact = Constant(0, domain=mesh)
 
     u_rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact)) + grad(pexact)
@@ -31,34 +30,29 @@ def StokesTest(N, butcher_tableau):
     test_z = TestFunction(Z)
     (u, p) = split(z)
     (v, q) = split(test_z)
-    F = (  inner(Dt(u),v)*dx
+    F = (inner(Dt(u), v)*dx
          + inner(grad(u), grad(v))*dx
          - inner(p, div(v))*dx
          - inner(q, div(u))*dx
          - inner(u_rhs, v)*dx
-         - inner(p_rhs, q)*dx
-        )
-    
-    bcs = [
-           DirichletBC(Z.sub(0), uexact, "on_boundary"),
-           DirichletBC(Z.sub(1), pexact, "on_boundary")
-          ]
+         - inner(p_rhs, q)*dx)
 
-    u,p = z.split()
+    bcs = [DirichletBC(Z.sub(0), uexact, "on_boundary"),
+           DirichletBC(Z.sub(1), pexact, "on_boundary")]
+
+    u, p = z.split()
     u.interpolate(uexact)
 
-    lu = {
-       "mat_type": "aij",
-       "snes_type": "newtonls",
-       "snes_linesearch_type": "l2",
-       "snes_linesearch_monitor": None,
-       "snes_monitor": None,
-       "snes_rtol": 1e-8,
-       "snes_atol": 1e-8,
-       "ksp_type": "preonly",
-       "pc_type": "lu",
-       "pc_factor_mat_solver_type": "mumps",
-         }
+    lu = {"mat_type": "aij",
+          "snes_type": "newtonls",
+          "snes_linesearch_type": "l2",
+          "snes_linesearch_monitor": None,
+          "snes_monitor": None,
+          "snes_rtol": 1e-8,
+          "snes_atol": 1e-8,
+          "ksp_type": "preonly",
+          "pc_type": "lu",
+          "pc_factor_mat_solver_type": "mumps"}
 
     stepper = TimeStepper(F, butcher_tableau, t, dt, z,
                           bcs=bcs, solver_parameters=lu)
@@ -69,8 +63,9 @@ def StokesTest(N, butcher_tableau):
         stepper.advance()
         t.assign(float(t) + float(dt))
 
-    (u,p) = z.split()
+    (u, p) = z.split()
     return errornorm(uexact, u)
+
 
 @pytest.mark.parametrize(('N', 'time_stages'),
                          [(2**j, i) for j in range(2, 4)

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -80,3 +80,5 @@ def test_Stokes(N, time_stages):
     assert abs(error) < 1e-10
 
 
+if __name__ == "__main__":
+    test_Stokes(4, 2)


### PR DESCRIPTION
The existing approach to implementing BCs in Irksome is to treat the boundary data as an ODE, implementing `du/dt(x,t) = g'(t)` for a point, x, where a DirichletBC is strongly enforced.

This PR adds functionality to implement the BCs as if they are terms in a DAE, by setting the BCs for the stage values to enforce that the solution reconstruction corresponding each stage should match the BC at the stage time.  For some schemes (LobattoIIIC and RadauIIA, for example), this results is the solution matching the DirichletBC at each timestep.  The theoretical order for this approach matches the stage order of the scheme, while the old approach is limited to (at best) third order.

The old code is preserved, with a switch added in the call to `TimeStepper` or `GetForm` to select between the two approaches.  In the initial commit, all tests are run with the new approach, except for one that touches the LobattoIIIA class of Butcher Tableaux, for which the DAE approach is ill-defined.  One issue for discussion is how many tests to preserve for both approaches.

Finally, this also attempts to fix an oversight in the old approach, whereby it was assumed that the BCs were satisfied by the initial data.  Now, the difference between the solution data at the prior timestep and the prescribed Dirichlet data enters into the stage BCs.