### PR TITLE
Some manipulation on forms containing time derivatives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request_target]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /docs/source/irksome.rst
 __pycache__/
 IRKsome.egg-info/
+/demos/*/*.py

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -253,10 +253,10 @@ texinfo_documents = [
 # -- Options for intersphinx ---------------------------------------------
 
 intersphinx_mapping = {
-    'ufl': ('https://fenics.readthedocs.io/projects/fiat/en/latest/', None),
+    'fiat': ('https://fenics.readthedocs.io/projects/fiat/en/latest/', None),
     'firedrake': ('https://www.firedrakeproject.org', None),
     'ufl': ('https://fenics.readthedocs.io/projects/ufl/en/latest/', None),
-    'python':('https://docs.python.org/3/', None),
+    'python': ('https://docs.python.org/3/', None),
 }
 
 #  -- Options for sphinxcontrib.bibtex ------------------------------------

--- a/irksome/manipulation.py
+++ b/irksome/manipulation.py
@@ -1,0 +1,194 @@
+"""Manipulation of expressions containing :class:`~.TimeDerivative`
+terms.
+
+These can be used to do some basic checking of the suitability of a
+:class:`~ufl.Form` for use in Irksome (via :func:`~.check_integrals`), and
+splitting out terms in the :class:`~ufl.Form` that contain a time
+derivative from those that don't (via :func:`~.extract_terms`).
+"""
+from functools import partial, singledispatch
+from itertools import chain
+from operator import contains, or_
+from typing import Callable, FrozenSet, List, NamedTuple, Tuple, Union
+
+from gem.node import Memoizer
+from tsfc.ufl_utils import ufl_reuse_if_untouched
+from ufl.algebra import Conj, Division, Product, Sum
+from ufl.averaging import CellAvg, FacetAvg
+from ufl.coefficient import Coefficient
+from ufl.constantvalue import Zero
+from ufl.core.expr import Expr
+from ufl.core.operator import Operator
+from ufl.core.terminal import Terminal
+from ufl.corealg.traversal import traverse_unique_terminals
+from ufl.differentiation import Derivative
+from ufl.form import Form
+from ufl.indexed import Indexed
+from ufl.indexsum import IndexSum
+from ufl.integral import Integral
+from ufl.restriction import NegativeRestricted, PositiveRestricted
+from ufl.tensoralgebra import Dot, Inner, Outer
+from ufl.tensors import ComponentTensor, ListTensor
+from ufl.variable import Variable
+
+from irksome.deriv import TimeDerivative
+
+__all__ = ("SplitTimeForm", "check_integrals", "extract_terms")
+
+
+class SplitTimeForm(NamedTuple):
+    """A container for a form split into time terms and a remainder."""
+    time: Form
+    remainder: Form
+
+
+def _filter(o: Expr, self: Memoizer) -> Expr:
+    if not isinstance(o, Expr):
+        raise AssertionError(f"Cannot handle term with type {type(o)}")
+    if self.predicate(o):
+        return Zero(shape=o.ufl_shape,
+                    free_indices=o.ufl_free_indices,
+                    index_dimensions=o.ufl_index_dimensions)
+    else:
+        return ufl_reuse_if_untouched(o, *map(self, o.ufl_operands))
+
+
+def remove_if(expr: Expr, predicate: Callable[[Expr], bool]) -> Expr:
+    """Remove terms from an expression that match a predicate.
+
+    This is done by replacing matching terms by an
+    appropriately-shaped :class:`~.Zero`, so only works to remove
+    terms that are linear in the expression.
+
+    :arg expr: the expression to remove terms from.
+    :arg predicate: a function that indicates if an expression should
+        be kept or not.
+    :returns: A potentially new expression with terms matching the
+        predicate removed."""
+    mapper = Memoizer(_filter)
+    mapper.predicate = predicate
+    return mapper(expr)
+
+
+Result = Union[Tuple[()], Tuple[Coefficient, ...]]
+
+
+@singledispatch
+def _check_time_terms(o, self: Memoizer) -> Result:
+    raise AssertionError
+
+
+@_check_time_terms.register(TimeDerivative)
+def _check_timederiv(o: TimeDerivative, self: Memoizer) -> Result:
+    op, = o.ufl_operands
+    if self(op):
+        # op already has a TimeDerivative applied to it
+        raise ValueError("Can only handle first-order systems")
+    terminals = tuple(set(traverse_unique_terminals(op)))
+    if len(terminals) != 1 or not isinstance(terminals[0], Coefficient):
+        raise ValueError("Time derivative must apply to a single coefficient")
+    return terminals
+
+
+@_check_time_terms.register(Expr)
+def _check_nonlinearop(o: Union[Terminal, Operator], self: Memoizer) -> Result:
+    if any(map(self, o.ufl_operands)):
+        raise ValueError("Can't apply nonlinear operator to time derivative")
+    return ()
+
+
+@_check_time_terms.register(Division)
+def _check_division(o: Division, self: Memoizer) -> Result:
+    a, b = map(self, o.ufl_operands)
+    if b:
+        raise ValueError("Can't divide by time derivative")
+    return a
+
+
+@_check_time_terms.register(Product)
+@_check_time_terms.register(Inner)
+@_check_time_terms.register(Dot)
+@_check_time_terms.register(Outer)
+def _check_product(o: Operator, self: Memoizer) -> Result:
+    a, b = map(self, o.ufl_operands)
+    if a and b:
+        raise ValueError("Can't take product of time derivatives")
+    return a or b
+
+
+@_check_time_terms.register(PositiveRestricted)
+@_check_time_terms.register(NegativeRestricted)
+@_check_time_terms.register(CellAvg)
+@_check_time_terms.register(FacetAvg)
+@_check_time_terms.register(Conj)
+@_check_time_terms.register(Derivative)
+@_check_time_terms.register(Variable)
+@_check_time_terms.register(Sum)
+@_check_time_terms.register(ListTensor)
+def _check_linearop(o: Operator, self: Memoizer) -> Result:
+    return tuple(set(chain(*map(self, o.ufl_operands))))
+
+
+@_check_time_terms.register(Indexed)
+@_check_time_terms.register(IndexSum)
+@_check_time_terms.register(ComponentTensor)
+def _check_indexed(o: Operator, self: Memoizer) -> Result:
+    return self(o.ufl_operands[0])
+
+
+def check_integrals(integrals: List[Integral], expect_time_derivative: bool = True):
+    """Check a list of integrals for linearity in the time derivative.
+
+    :arg integrals: list of integrals.
+    :arg expect_time_derivative: Are we expecting to see a time
+        derivative?
+    :raises ValueError: if we are expecting a time derivative and
+        don't see one, or time derivatives are applied nonlinearly, to
+        more than one coefficient, or more than first order."""
+    mapper = Memoizer(_check_time_terms)
+    time_derivatives = set()
+    for integral in integrals:
+        time_derivatives.update(mapper(integral.integrand()))
+    howmany = int(expect_time_derivative)
+    if len(time_derivatives - {()}) != howmany:
+        raise ValueError(f"Expecting time derivative applied to {howmany}"
+                         f"coeffficients, not {len(time_derivatives - {()})}")
+
+
+def summands(o: Expr) -> FrozenSet[Expr]:
+    """Flatten a sum tree into a set of summands
+
+    :arg o: the expression to flatten.
+    :returns: a frozenset of the summands such that sum(r) == o (up to
+        order of arguments)."""
+    if isinstance(o, Sum):
+        return or_(*map(summands, o.ufl_operands))
+    else:
+        return frozenset([o])
+
+
+def extract_terms(form: Form) -> SplitTimeForm:
+    """Extract terms from a :class:`~ufl.Form`.
+
+    This splits a form (a sum of integrals) into those integrals which
+    do contain a :class:`~.TimeDerivative` and those that don't.
+
+    :arg form: The form to split.
+    :returns: a :class:`~.SplitTimeForm` tuple.
+    :raises ValueError: if the form does not apply anything other than
+        first-order time derivatives to a single coefficient.
+    """
+    time_terms = []
+    rest_terms = []
+    for integral in form.integrals():
+        integrand = integral.integrand()
+        rest = remove_if(integrand, lambda o: isinstance(o, TimeDerivative))
+        time = remove_if(integrand, partial(contains, summands(rest)))
+        if not isinstance(time, Zero):
+            time_terms.append(integral.reconstruct(integrand=time))
+        if not isinstance(rest, Zero):
+            rest_terms.append(integral.reconstruct(integrand=rest))
+
+    check_integrals(time_terms, expect_time_derivative=True)
+    check_integrals(rest_terms, expect_time_derivative=False)
+    return SplitTimeForm(time=Form(time_terms), remainder=Form(rest_terms))

--- a/tests/test_time_form_splitting.py
+++ b/tests/test_time_form_splitting.py
@@ -1,0 +1,127 @@
+import pytest
+from irksome import Dt
+from irksome.manipulation import check_integrals, extract_terms
+from ufl import (Coefficient, FiniteElement, FunctionSpace, Mesh, MixedElement,
+                 TestFunction, VectorElement, dx, grad, inner, sin, triangle)
+from ufl.algorithms.domain_analysis import group_form_integrals
+
+
+def sig(form):
+    form = group_form_integrals(form, form.ufl_domains(),
+                                do_append_everywhere_integrals=True)
+    return form.signature()
+
+
+@pytest.fixture
+def mesh():
+    return Mesh(VectorElement("P", triangle, 1))
+
+
+@pytest.fixture
+def V(mesh):
+    return FunctionSpace(mesh, VectorElement("DP", triangle, 1))
+
+
+@pytest.fixture
+def Q(mesh):
+    return FunctionSpace(mesh, FiniteElement("RT", triangle, 1))
+
+
+@pytest.fixture
+def W(V, Q):
+    mesh = V.ufl_domain()
+    return FunctionSpace(mesh, MixedElement(V.ufl_element(), Q.ufl_element()))
+
+
+def test_can_split(V):
+    u = Coefficient(V)
+
+    v = TestFunction(V)
+
+    c = Coefficient(V)
+
+    F = (inner(c, c)*inner(Dt(u), v) + inner(grad(u), grad(v))
+         + inner(c, v) + inner(Dt(u), v))*dx
+
+    split = extract_terms(F)
+
+    expect_t = (inner(c, c)*inner(Dt(u), v) + inner(Dt(u), v))*dx
+    expect_no_t = inner(grad(u), grad(v))*dx + inner(c, v)*dx
+
+    assert sig(expect_t) == sig(split.time)
+    assert sig(expect_no_t) == sig(split.remainder)
+
+
+def test_can_split_mixed(W):
+    u = Coefficient(W)
+
+    v = TestFunction(W)
+
+    c = Coefficient(W)
+
+    F = (inner(c, c)*inner(Dt(u), v) + inner(grad(u), grad(v))
+         + inner(c, v) + inner(Dt(u), v))*dx
+
+    split = extract_terms(F)
+
+    expect_t = (inner(c, c)*inner(Dt(u), v) + inner(Dt(u), v))*dx
+    expect_no_t = inner(grad(u), grad(v))*dx + inner(c, v)*dx
+
+    assert sig(expect_t) == sig(split.time)
+    assert sig(expect_no_t) == sig(split.remainder)
+
+
+def test_only_first_order(V):
+    u = Coefficient(V)
+
+    v = TestFunction(V)
+
+    c = Coefficient(V)
+
+    F = (inner(c, c)*inner(Dt(Dt(u)), v)
+         + inner(grad(u), grad(v))
+         + inner(c, v)
+         + inner(Dt(u), v))*dx
+
+    with pytest.raises(ValueError):
+        check_integrals(F.integrals(), expect_time_derivative=True)
+
+
+@pytest.mark.parametrize("typ", ["mul", "div", "sin"])
+def test_Dt_linear(V, typ):
+    u = Coefficient(V)
+
+    v = TestFunction(V)
+
+    c = Coefficient(V)
+
+    F = (inner(grad(u), grad(v)) + inner(c, v) + inner(Dt(u), v))*dx
+
+    if typ == "mul":
+        F += inner(Dt(u), c)*inner(Dt(u), v)*dx
+    elif typ == "div":
+        F += inner(Dt(u), v)/Dt(u)[0]*dx
+    elif typ == "sin":
+        F += inner(sin(Dt(u)[0]), v[0])*dx
+
+    with pytest.raises(ValueError):
+        check_integrals(F.integrals(), expect_time_derivative=True)
+
+
+def test_expecting_time_derivative(V):
+    u = Coefficient(V)
+
+    v = TestFunction(V)
+
+    c = Coefficient(V)
+
+    F = (inner(grad(u), grad(v)) + inner(c, v))*dx
+
+    with pytest.raises(ValueError):
+        check_integrals(F.integrals(), expect_time_derivative=True)
+
+    check_integrals(F.integrals(), expect_time_derivative=False)
+
+    F += inner(Dt(u), v)*dx
+    with pytest.raises(ValueError):
+        check_integrals(F.integrals(), expect_time_derivative=False)


### PR DESCRIPTION
I can cull the type annotations if you like, though I found them somewhat useful when writing the code.

There's a little bit of cleanup here, and then the main thing is `extract_terms` which splits a form into two, a bit with (linear) time-derivatives in it, and the remainder (that must contain no time-derivatives.

@rckirby, @ScottMacLachlan, I think this will be useful for the automated Galerkin-in-time.