### PR TITLE
Rckirby/redo stages

### DIFF
--- a/irksome/ButcherTableaux.py
+++ b/irksome/ButcherTableaux.py
@@ -24,10 +24,6 @@ class ButcherTableau(object):
         self.btilde = btilde
         self.c = c
         self.order = order
-        try:
-            self.Ainv = numpy.linalg.inv(A)
-        except numpy.linalg.LinAlgError:
-            self.Ainv = None
 
     @property
     def num_stages(self):

--- a/irksome/getForm.py
+++ b/irksome/getForm.py
@@ -163,7 +163,7 @@ def getForm(F, butch, t, dt, u0, bcs=None, bc_type="DAE", splitting=AI):
     except numpy.linalg.LinAlgError:
         raise NotImplementedError("We require A = A1 A2 with A2 invertible")
 
-    A1 = numpy.array([[Constant(aa) for aa in arow] for arow in bA1],
+    A1 = numpy.array([[ConstantOrZero(aa) for aa in arow] for arow in bA1],
                      dtype=object)
     if bA1inv is not None:
         A1inv = numpy.array([[ConstantOrZero(aa) for aa in arow] for arow in bA1inv],

--- a/irksome/getForm.py
+++ b/irksome/getForm.py
@@ -158,8 +158,10 @@ def getForm(F, butch, t, dt, u0, bcs=None, bc_type="DAE", splitting=AI):
         bA1inv = None
     try:
         bA2inv = numpy.linalg.inv(bA2)
+        A2inv = numpy.array([[ConstantOrZero(aa) for aa in arow] for arow in bA2inv],
+                            dtype=object)
     except numpy.linalg.LinAlgError:
-        bA2inv = None
+        raise NotImplementedError("We require A = A1 A2 with A2 invertible")
 
     A1 = numpy.array([[Constant(aa) for aa in arow] for arow in bA1],
                      dtype=object)
@@ -168,8 +170,6 @@ def getForm(F, butch, t, dt, u0, bcs=None, bc_type="DAE", splitting=AI):
                             dtype=object)
     else:
         A1inv = None
-    A2inv = numpy.array([[ConstantOrZero(aa) for aa in arow] for arow in bA2inv],
-                        dtype=object)
 
     num_stages = butch.num_stages
     num_fields = len(V)

--- a/irksome/getForm.py
+++ b/irksome/getForm.py
@@ -87,8 +87,8 @@ def AI(A):
     return (A, numpy.eye(*A.shape, dtype=A.dtype))
 
 
-def IAinv(A):
-    return (numpy.eye(*A.shape, dtype=A.dtype), numpy.linalg.inv(A))
+def IA(A):
+    return (numpy.eye(*A.shape, dtype=A.dtype), A)
 
 
 def getForm(F, butch, t, dt, u0, bcs=None, bc_type="DAE", splitting=AI):

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -159,13 +159,13 @@ class AdaptiveTimeStepper(TimeStepper):
         dtc = float(self.dt)
         delb = self.delb
 
-        ks = self.ks
+        ws = self.ws
         nf = self.num_fields
         for e in self.error_func.dat:
             e.data[:] = 0.0
         for s in range(self.num_stages):
             for i, e in enumerate(self.error_func.dat):
-                e.data[:] += dtc * delb[i] * ks[nf*s+i].dat.data_ro
+                e.data[:] += dtc * delb[i] * ws[nf*s+i].dat.data_ro
         return norm(self.error_func)
 
     def advance(self):

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -64,7 +64,7 @@ class TimeStepper:
         A1, A2 = splitting(butcher_tableau.A)
         try:
             self.updateb = numpy.linalg.solve(A2.T, butcher_tableau.b)
-        except LinearAlgebraError:
+        except numpy.linalg.LinAlgError:
             raise NotImplementedError("A=A1 A2 splitting needs A2 invertible")
         boo = numpy.zeros(self.updateb.shape, dtype=self.updateb.dtype)
         boo[-1] = 1

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -1,4 +1,4 @@
-from .getForm import getForm, AI, IA
+from .getForm import getForm, AI
 from firedrake import NonlinearVariationalProblem as NLVP
 from firedrake import NonlinearVariationalSolver as NLVS
 from firedrake import Function, norm
@@ -40,7 +40,7 @@ class TimeStepper:
     """
     def __init__(self, F, butcher_tableau, t, dt, u0, bcs=None,
                  solver_parameters=None, bc_type="DAE", splitting=AI):
-        self.splitting=splitting
+        self.splitting = splitting
         self.u0 = u0
         self.t = t
         self.dt = dt
@@ -75,7 +75,7 @@ class TimeStepper:
         # FIXME: Lift this outside of the update
         A1, A2 = self.splitting(self.butcher_tableau.A)
         b = numpy.linalg.solve(A2.T, b)
-        
+
         ks = self.ks
         for s in range(ns):
             for i, u0d in enumerate(u0.dat):

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -74,7 +74,7 @@ class TimeStepper:
 
         # FIXME: Lift this outside of the update
         A1, A2 = self.splitting(self.butcher_tableau.A)
-        b = numpy.linalg.solve(A2, b)
+        b = numpy.linalg.solve(A2.T, b)
         
         ks = self.ks
         for s in range(ns):

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -62,7 +62,10 @@ class TimeStepper:
             self.ws = stages.split()
 
         A1, A2 = splitting(butcher_tableau.A)
-        self.updateb = numpy.linalg.solve(A2.T, butcher_tableau.b)
+        try:
+            self.updateb = numpy.linalg.solve(A2.T, butcher_tableau.b)
+        except LinearAlgebraError:
+            raise NotImplementedError("A=A1 A2 splitting needs A2 invertible")
         boo = numpy.zeros(self.updateb.shape, dtype=self.updateb.dtype)
         boo[-1] = 1
         if numpy.allclose(self.updateb, boo):

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -62,19 +62,22 @@ class TimeStepper:
         else:
             self.ks = stages.split()
 
+        A1, A2 = splitting(butcher_tableau.A)
+        self.updateb = numpy.linalg.solve(A2.T, butcher_tableau.b)
+
+    # FIXME: This can be set in the constructor to handle the
+    # special case where updateb is only nonzero in the last entry
+    # by putting two internal update functions and pointing self._update
+    # to the right one.
     def _update(self):
         """Assuming the algebraic problem for the RK stages has been
         solved, updates the solution.  This will not typically be
         called by an end user."""
-        b = self.butcher_tableau.b
+        b = self.updateb
         dtc = float(self.dt)
         u0 = self.u0
         ns = self.num_stages
         nf = self.num_fields
-
-        # FIXME: Lift this outside of the update
-        A1, A2 = self.splitting(self.butcher_tableau.A)
-        b = numpy.linalg.solve(A2.T, b)
 
         ks = self.ks
         for s in range(ns):

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -1,4 +1,4 @@
-from .getForm import getForm, AI, IAinv
+from .getForm import getForm, AI, IA
 from firedrake import NonlinearVariationalProblem as NLVP
 from firedrake import NonlinearVariationalSolver as NLVS
 from firedrake import Function, norm

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -40,7 +40,6 @@ class TimeStepper:
     """
     def __init__(self, F, butcher_tableau, t, dt, u0, bcs=None,
                  solver_parameters=None, bc_type="DAE", splitting=AI):
-        self.splitting = splitting
         self.u0 = u0
         self.t = t
         self.dt = dt

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -1,4 +1,4 @@
-from .getForm import getForm
+from .getForm import getForm, AI, IAinv
 from firedrake import NonlinearVariationalProblem as NLVP
 from firedrake import NonlinearVariationalSolver as NLVS
 from firedrake import Function, norm
@@ -38,7 +38,7 @@ class TimeStepper:
 
     """
     def __init__(self, F, butcher_tableau, t, dt, u0, bcs=None,
-                 solver_parameters=None, bc_type="DAE"):
+                 solver_parameters=None, bc_type="DAE", splitting=AI):
         self.u0 = u0
         self.t = t
         self.dt = dt

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -91,7 +91,9 @@ class TimeStepper:
     def _update_A2Tmb(self):
         """Assuming the algebraic problem for the RK stages has been
         solved, updates the solution.  This will not typically be
-        called by an end user."""
+        called by an end user.  This handles the common but highly
+        specialized case of `w = Ak` or `A = I A` splitting where
+        A2^{-T} b = e_{num_stages}"""
         dtc = float(self.dt)
         u0 = self.u0
         ns = self.num_stages

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -9,9 +9,9 @@ from irksome import Dt, TimeStepper, GaussLegendre
 from irksome.getForm import AI, IA
 from ufl.algorithms import expand_derivatives
 
+
 # test the accuracy of the 1d heat equation using CG elements
 # and Gauss-Legendre time integration
-
 def heat(n, deg, time_stages, splitting=IA):
     N = 2**n
     msh = UnitIntervalMesh(N)

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -53,10 +53,10 @@ def heat(n, deg, time_stages, splitting=IA):
 
     return errornorm(uexact, u) / norm(uexact)
 
-
-@pytest.mark.parametrize(('deg', 'convrate', 'time_stages', 'splitting'),
-                         [(1, 1.78, i, splt) for i in (1, 2) for splt in (AI, IA)]
-                         + [(2, 2.8, i, splt) for i in (2, 3) for splt in (AI, IA)])
+@pytest.mark.parametrize("splitting", (AI, IA))
+@pytest.mark.parametrize(('deg', 'convrate', 'time_stages'),
+                         [(1, 1.78, i) for i in (1, 2)]
+                         + [(2, 2.8, i) for i in (2, 3)])
 def test_heat_eq(deg, convrate, time_stages, splitting):
     diff = np.array([heat(i, deg, time_stages) for i in range(3, 6)])
     conv = np.log2(diff[:-1] / diff[1:])

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -6,13 +6,13 @@ from firedrake import (diff, div, dx, errornorm, exp, grad,
                        SpatialCoordinate, TestFunction, UnitIntervalMesh)
 
 from irksome import Dt, TimeStepper, GaussLegendre
+from irksome.getForm import AI, IAinv
 from ufl.algorithms import expand_derivatives
 
 # test the accuracy of the 1d heat equation using CG elements
 # and Gauss-Legendre time integration
 
-
-def heat(n, deg, time_stages):
+def heat(n, deg, time_stages, splitting=IAinv):
     N = 2**n
     msh = UnitIntervalMesh(N)
 
@@ -42,7 +42,8 @@ def heat(n, deg, time_stages):
     bc = DirichletBC(V, 0, "on_boundary")
 
     stepper = TimeStepper(F, butcher_tableau, t, dt, u,
-                          bcs=bc, solver_parameters=params)
+                          bcs=bc, solver_parameters=params,
+                          splitting=splitting)
 
     while (float(t) < 1.0):
         if (float(t) + float(dt) > 1.0):

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -53,6 +53,7 @@ def heat(n, deg, time_stages, splitting=IA):
 
     return errornorm(uexact, u) / norm(uexact)
 
+
 @pytest.mark.parametrize("splitting", (AI, IA))
 @pytest.mark.parametrize(('deg', 'convrate', 'time_stages'),
                          [(1, 1.78, i) for i in (1, 2)]

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -54,10 +54,10 @@ def heat(n, deg, time_stages, splitting=IA):
     return errornorm(uexact, u) / norm(uexact)
 
 
-@pytest.mark.parametrize(('deg', 'convrate', 'time_stages'),
-                         [(1, 1.78, i) for i in (1, 2)]
-                         + [(2, 2.8, i) for i in (2, 3)])
-def test_heat_eq(deg, convrate, time_stages):
+@pytest.mark.parametrize(('deg', 'convrate', 'time_stages', 'splitting'),
+                         [(1, 1.78, i, splt) for i in (1, 2) for splt in (AI, IA)]
+                         + [(2, 2.8, i, splt) for i in (2, 3) for splt in (AI, IA)])
+def test_heat_eq(deg, convrate, time_stages, splitting):
     diff = np.array([heat(i, deg, time_stages) for i in range(3, 6)])
     conv = np.log2(diff[:-1] / diff[1:])
     assert (conv > convrate).all()

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -6,13 +6,13 @@ from firedrake import (diff, div, dx, errornorm, exp, grad,
                        SpatialCoordinate, TestFunction, UnitIntervalMesh)
 
 from irksome import Dt, TimeStepper, GaussLegendre
-from irksome.getForm import AI, IAinv
+from irksome.getForm import AI, IA
 from ufl.algorithms import expand_derivatives
 
 # test the accuracy of the 1d heat equation using CG elements
 # and Gauss-Legendre time integration
 
-def heat(n, deg, time_stages, splitting=IAinv):
+def heat(n, deg, time_stages, splitting=IA):
     N = 2**n
     msh = UnitIntervalMesh(N)
 

--- a/tests/test_curl.py
+++ b/tests/test_curl.py
@@ -50,11 +50,11 @@ def curltest(N, deg, butcher_tableau, splitting):
     return norm(u-uexact)
 
 
-@pytest.mark.parametrize(('deg', 'N', 'time_stages'),
-                         [(1, 2**j, i) for j in range(2, 4)
-                          for i in (1, 2)]
-                         + [(2, 2**j, i) for j in range(2, 4)
-                            for i in (2, 3)])
-def test_curl(deg, N, time_stages):
+@pytest.mark.parametrize(('deg', 'N', 'time_stages', 'splitting'),
+                         [(1, 2**j, i, splt) for j in range(2, 4)
+                          for i in (1, 2) for splt in (AI, IA)]
+                         + [(2, 2**j, i, splt) for j in range(2, 4)
+                            for i in (2, 3) for splt in (AI, IA)])
+def test_curl(deg, N, time_stages, splitting):
     error = curltest(N, deg, GaussLegendre(time_stages), AI)
     assert abs(error) < 1e-10

--- a/tests/test_curl.py
+++ b/tests/test_curl.py
@@ -49,12 +49,11 @@ def curltest(N, deg, butcher_tableau, splitting):
 
     return norm(u-uexact)
 
-
-@pytest.mark.parametrize(('deg', 'N', 'time_stages', 'splitting'),
-                         [(1, 2**j, i, splt) for j in range(2, 4)
-                          for i in (1, 2) for splt in (AI, IA)]
-                         + [(2, 2**j, i, splt) for j in range(2, 4)
-                            for i in (2, 3) for splt in (AI, IA)])
+@pytest.mark.parametrize("splitting", (AI, IA))
+@pytest.mark.parametrize('N', [2**j for j in range(2, 4)])
+@pytest.mark.parametrize(('deg', 'time_stages'),
+                         [(1, i) for i in (1, 2)]
+                         + [(2, i) for i in (2, 3)])
 def test_curl(deg, N, time_stages, splitting):
     error = curltest(N, deg, GaussLegendre(time_stages), AI)
     assert abs(error) < 1e-10

--- a/tests/test_curl.py
+++ b/tests/test_curl.py
@@ -49,6 +49,7 @@ def curltest(N, deg, butcher_tableau, splitting):
 
     return norm(u-uexact)
 
+
 @pytest.mark.parametrize("splitting", (AI, IA))
 @pytest.mark.parametrize('N', [2**j for j in range(2, 4)])
 @pytest.mark.parametrize(('deg', 'time_stages'),

--- a/tests/test_curl.py
+++ b/tests/test_curl.py
@@ -1,6 +1,7 @@
 import pytest
 from firedrake import *
 from irksome import GaussLegendre, Dt, TimeStepper
+from irksome.getForm import AI, IA
 from ufl.algorithms.ad import expand_derivatives
 
 
@@ -9,7 +10,7 @@ def curlcross(a, b):
     return as_vector([-curla*b[1], curla*b[0]])
 
 
-def curltest(N, deg, butcher_tableau):
+def curltest(N, deg, butcher_tableau, splitting):
 
     msh = UnitSquareMesh(N, N)
 
@@ -36,7 +37,8 @@ def curltest(N, deg, butcher_tableau):
                 "pc_type": "lu"}
 
     stepper = TimeStepper(F, butcher_tableau, t, dt, u, bcs=bc,
-                          solver_parameters=luparams)
+                          solver_parameters=luparams,
+                          splitting=splitting)
 
     while (float(t) < 0.1):
         if (float(t) + float(dt) > 0.1):
@@ -54,5 +56,5 @@ def curltest(N, deg, butcher_tableau):
                          + [(2, 2**j, i) for j in range(2, 4)
                             for i in (2, 3)])
 def test_curl(deg, N, time_stages):
-    error = curltest(N, deg, GaussLegendre(time_stages))
+    error = curltest(N, deg, GaussLegendre(time_stages), AI)
     assert abs(error) < 1e-10

--- a/tests/test_inhomogbc.py
+++ b/tests/test_inhomogbc.py
@@ -42,11 +42,11 @@ def heat_inhomog(N, deg, butcher_tableau, splitting=AI):
     return norm(u-uexact)
 
 
-@pytest.mark.parametrize(('deg', 'N', 'time_stages', 'splitting'),
-                         [(1, 2**j, i, splt) for j in range(2, 4)
-                          for i in (1, 2) for splt in (IA, AI)]
-                         + [(2, 2**j, i, splt) for j in range(2, 4)
-                            for i in (2, 3) for splt in (IA, AI)])
+@pytest.mark.parametrize('splitting', (AI, IA))
+@pytest.mark.parametrize('N', [2**j for j in range(2, 4)])
+@pytest.mark.parametrize(('deg', 'time_stages'),
+                         [(1, i) for i in (1, 2)]
+                         + [(2, i) for i in (2, 3)])
 def test_inhomog_bc(deg, N, time_stages, splitting):
     error = heat_inhomog(N, deg, GaussLegendre(time_stages), splitting)
     assert abs(error) < 1e-10

--- a/tests/test_inhomogbc.py
+++ b/tests/test_inhomogbc.py
@@ -2,9 +2,10 @@ import pytest
 from firedrake import *
 from ufl.algorithms.ad import expand_derivatives
 from irksome import GaussLegendre, Dt, TimeStepper
+from irksome.getForm import AI, IA
 
 
-def heat_inhomog(N, deg, butcher_tableau):
+def heat_inhomog(N, deg, butcher_tableau, splitting=AI):
     dt = Constant(1.0 / N)
     t = Constant(0.0)
 
@@ -29,7 +30,8 @@ def heat_inhomog(N, deg, butcher_tableau):
                 "pc_type": "lu"}
 
     stepper = TimeStepper(F, butcher_tableau, t, dt, u, bcs=bc,
-                          solver_parameters=luparams)
+                          solver_parameters=luparams,
+                          splitting=splitting)
 
     while (float(t) < 1.0):
         if (float(t) + float(dt) > 1.0):
@@ -40,11 +42,11 @@ def heat_inhomog(N, deg, butcher_tableau):
     return norm(u-uexact)
 
 
-@pytest.mark.parametrize(('deg', 'N', 'time_stages'),
-                         [(1, 2**j, i) for j in range(2, 4)
-                          for i in (1, 2)]
-                         + [(2, 2**j, i) for j in range(2, 4)
-                            for i in (2, 3)])
-def test_inhomog_bc(deg, N, time_stages):
-    error = heat_inhomog(N, deg, GaussLegendre(time_stages))
+@pytest.mark.parametrize(('deg', 'N', 'time_stages', 'splitting'),
+                         [(1, 2**j, i, splt) for j in range(2, 4)
+                          for i in (1, 2) for splt in (IA, AI)]
+                         + [(2, 2**j, i, splt) for j in range(2, 4)
+                            for i in (2, 3) for splt in (IA, AI)])
+def test_inhomog_bc(deg, N, time_stages, splitting):
+    error = heat_inhomog(N, deg, GaussLegendre(time_stages), splitting)
     assert abs(error) < 1e-10

--- a/tests/test_rtcf.py
+++ b/tests/test_rtcf.py
@@ -48,12 +48,11 @@ def RTCFtest(N, deg, butcher_tableau, splitting=AI):
 
     return norm(u-uexact)
 
-
-@pytest.mark.parametrize(('deg', 'N', 'time_stages', 'splitting'),
-                         [(1, 2**j, i, splt) for j in range(2, 4)
-                          for i in (1, 2) for splt in (AI, IA)]
-                         + [(2, 2**j, i, splt) for j in range(2, 4)
-                            for i in (2, 3) for splt in (AI, IA)])
+@pytest.mark.parametrize('splitting', (AI, IA))
+@pytest.mark.parametrize('N', [2**j for j in range(2, 4)])
+@pytest.mark.parametrize(('deg', 'time_stages'),
+                         [(1, i) for i in (1, 2)]
+                         + [(2, i) for i in (2, 3)])
 def test_RTCF(deg, N, time_stages, splitting):
     error = RTCFtest(N, deg, GaussLegendre(time_stages), splitting)
     assert abs(error) < 1e-10

--- a/tests/test_rtcf.py
+++ b/tests/test_rtcf.py
@@ -48,6 +48,7 @@ def RTCFtest(N, deg, butcher_tableau, splitting=AI):
 
     return norm(u-uexact)
 
+
 @pytest.mark.parametrize('splitting', (AI, IA))
 @pytest.mark.parametrize('N', [2**j for j in range(2, 4)])
 @pytest.mark.parametrize(('deg', 'time_stages'),

--- a/tests/test_rtcf.py
+++ b/tests/test_rtcf.py
@@ -1,6 +1,7 @@
 import pytest
 from firedrake import *
 from irksome import GaussLegendre, Dt, TimeStepper
+from irksome.getForm import AI, IA
 from ufl.algorithms.ad import expand_derivatives
 
 
@@ -9,7 +10,7 @@ def curlcross(a, b):
     return as_vector([-curla*b[1], curla*b[0]])
 
 
-def RTCFtest(N, deg, butcher_tableau):
+def RTCFtest(N, deg, butcher_tableau, splitting=AI):
 
     msh = UnitSquareMesh(N, N, quadrilateral=True)
 
@@ -35,7 +36,8 @@ def RTCFtest(N, deg, butcher_tableau):
                 "pc_type": "lu"}
 
     stepper = TimeStepper(F, butcher_tableau, t, dt, u, bcs=bc,
-                          solver_parameters=luparams)
+                          solver_parameters=luparams,
+                          splitting=splitting)
 
     while (float(t) < 0.1):
         if (float(t) + float(dt) > 0.1):
@@ -47,11 +49,11 @@ def RTCFtest(N, deg, butcher_tableau):
     return norm(u-uexact)
 
 
-@pytest.mark.parametrize(('deg', 'N', 'time_stages'),
-                         [(1, 2**j, i) for j in range(2, 4)
-                          for i in (1, 2)]
-                         + [(2, 2**j, i) for j in range(2, 4)
-                            for i in (2, 3)])
-def test_RTCF(deg, N, time_stages):
-    error = RTCFtest(N, deg, GaussLegendre(time_stages))
+@pytest.mark.parametrize(('deg', 'N', 'time_stages', 'splitting'),
+                         [(1, 2**j, i, splt) for j in range(2, 4)
+                          for i in (1, 2) for splt in (AI, IA)]
+                         + [(2, 2**j, i, splt) for j in range(2, 4)
+                            for i in (2, 3) for splt in (AI, IA)])
+def test_RTCF(deg, N, time_stages, splitting):
+    error = RTCFtest(N, deg, GaussLegendre(time_stages), splitting)
     assert abs(error) < 1e-10

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -2,6 +2,7 @@ import pytest
 from firedrake import *
 
 from irksome import Dt, TimeStepper, LobattoIIIC
+from irksome.getForm import AI, IA
 from ufl.algorithms import expand_derivatives
 
 # test the accuracy of the 2d Stokes heat equation using CG elements
@@ -10,7 +11,7 @@ from ufl.algorithms import expand_derivatives
 # a time derivative on it.
 
 
-def StokesTest(N, butcher_tableau):
+def StokesTest(N, butcher_tableau, splitting=AI):
     mesh = UnitSquareMesh(N, N)
 
     Ve = VectorElement("CG", mesh.ufl_cell(), 2)
@@ -69,11 +70,12 @@ def StokesTest(N, butcher_tableau):
     return errornorm(uexact, u)
 
 
-@pytest.mark.parametrize(('N', 'time_stages'),
-                         [(2**j, i) for j in range(2, 4)
-                          for i in (2, 3)])
-def test_Stokes(N, time_stages):
-    error = StokesTest(N, LobattoIIIC(time_stages))
+@pytest.mark.parametrize(('N', 'time_stages', 'splitting'),
+                         [(2**j, i, splt) for j in range(2, 4)
+                          for i in (2, 3)
+                          for splt in (AI, IA)])
+def test_Stokes(N, time_stages, splitting):
+    error = StokesTest(N, LobattoIIIC(time_stages), splitting)
     assert abs(error) < 1e-10
 
 

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -70,10 +70,9 @@ def StokesTest(N, butcher_tableau, splitting=AI):
     return errornorm(uexact, u)
 
 
-@pytest.mark.parametrize(('N', 'time_stages', 'splitting'),
-                         [(2**j, i, splt) for j in range(2, 4)
-                          for i in (2, 3)
-                          for splt in (AI, IA)])
+@pytest.mark.parametrize('splitting', (AI, IA))
+@pytest.mark.parametrize('N', [2**j for j in range(2, 4)])
+@pytest.mark.parametrize('time_stages', (2, 3))
 def test_Stokes(N, time_stages, splitting):
     error = StokesTest(N, LobattoIIIC(time_stages), splitting)
     assert abs(error) < 1e-10

--- a/tests/test_subdomainbc.py
+++ b/tests/test_subdomainbc.py
@@ -41,6 +41,7 @@ def heat_subdomainbc(N, deg, butcher_tableau, splitting=AI):
 
     return norm(u-uexact)
 
+
 @pytest.mark.parametrize('splitting', (AI, IA))
 @pytest.mark.parametrize('N', [2**j for j in range(2, 4)])
 @pytest.mark.parametrize(('deg', 'time_stages'),

--- a/tests/test_subdomainbc.py
+++ b/tests/test_subdomainbc.py
@@ -1,10 +1,11 @@
 import pytest
 from firedrake import *
 from irksome import GaussLegendre, Dt, TimeStepper
+from irksome.getForm import AI, IA
 from ufl.algorithms.ad import expand_derivatives
 
 
-def heat_subdomainbc(N, deg, butcher_tableau):
+def heat_subdomainbc(N, deg, butcher_tableau, splitting=AI):
     dt = Constant(1.0 / N)
     t = Constant(0.0)
 
@@ -41,11 +42,11 @@ def heat_subdomainbc(N, deg, butcher_tableau):
     return norm(u-uexact)
 
 
-@pytest.mark.parametrize(('deg', 'N', 'time_stages'),
-                         [(1, 2**j, i) for j in range(2, 4)
-                          for i in (1, 2)]
-                         + [(2, 2**j, i) for j in range(2, 4)
-                            for i in (2, 3)])
-def test_subdomainbc(deg, N, time_stages):
-    error = heat_subdomainbc(N, deg, GaussLegendre(time_stages))
+@pytest.mark.parametrize(('deg', 'N', 'time_stages', 'splitting'),
+                         [(1, 2**j, i, splt) for j in range(2, 4)
+                          for i in (1, 2) for splt in (AI, IA)]
+                         + [(2, 2**j, i, splt) for j in range(2, 4)
+                            for i in (2, 3) for splt in (AI, IA)])
+def test_subdomainbc(deg, N, time_stages, splitting):
+    error = heat_subdomainbc(N, deg, GaussLegendre(time_stages), splitting)
     assert abs(error) < 1e-10

--- a/tests/test_subdomainbc.py
+++ b/tests/test_subdomainbc.py
@@ -41,12 +41,11 @@ def heat_subdomainbc(N, deg, butcher_tableau, splitting=AI):
 
     return norm(u-uexact)
 
-
-@pytest.mark.parametrize(('deg', 'N', 'time_stages', 'splitting'),
-                         [(1, 2**j, i, splt) for j in range(2, 4)
-                          for i in (1, 2) for splt in (AI, IA)]
-                         + [(2, 2**j, i, splt) for j in range(2, 4)
-                            for i in (2, 3) for splt in (AI, IA)])
+@pytest.mark.parametrize('splitting', (AI, IA))
+@pytest.mark.parametrize('N', [2**j for j in range(2, 4)])
+@pytest.mark.parametrize(('deg', 'time_stages'),
+                         [(1, i) for i in (1, 2)]
+                         + [(2, i) for i in (2, 3)])
 def test_subdomainbc(deg, N, time_stages, splitting):
     error = heat_subdomainbc(N, deg, GaussLegendre(time_stages), splitting)
     assert abs(error) < 1e-10

--- a/tests/test_wave_energy.py
+++ b/tests/test_wave_energy.py
@@ -5,12 +5,13 @@ from firedrake import (inner, dx, UnitIntervalMesh, FunctionSpace,
                        Constant, project, as_vector, sin, pi, split)
 
 from irksome import Dt, TimeStepper, GaussLegendre
+from irksome.getForm import AI, IA
 
 # test the energy conservation of the 1d wave equation in mixed form
 # various time steppers.
 
 
-def wave(n, deg, butcher_tableau):
+def wave(n, deg, butcher_tableau, splitting=AI):
     N = 2**n
     msh = UnitIntervalMesh(N)
 
@@ -39,7 +40,8 @@ def wave(n, deg, butcher_tableau):
     E = 0.5 * (inner(u, u)*dx + inner(p, p)*dx)
 
     stepper = TimeStepper(F, butcher_tableau, t, dt, up,
-                          solver_parameters=params)
+                          solver_parameters=params,
+                          splitting=splitting)
 
     energies = []
 
@@ -53,12 +55,12 @@ def wave(n, deg, butcher_tableau):
     return np.array(energies)
 
 
-@pytest.mark.parametrize(('deg', 'N', 'time_stages'),
-                         [(1, 2**j, i) for j in range(2, 4)
-                          for i in (1, 2)]
-                         + [(2, 2**j, i) for j in range(2, 4)
-                            for i in (2, 3)])
-def test_wave_eq(deg, N, time_stages):
-    energy = wave(N, deg, GaussLegendre(time_stages))
+@pytest.mark.parametrize(('deg', 'N', 'time_stages', 'splitting'),
+                         [(1, 2**j, i, splt) for j in range(2, 4)
+                          for i in (1, 2) for splt in (AI, IA)]
+                         + [(2, 2**j, i, splt) for j in range(2, 4)
+                            for i in (2, 3) for splt in (AI, IA)])
+def test_wave_eq(deg, N, time_stages, splitting):
+    energy = wave(N, deg, GaussLegendre(time_stages), splitting)
     print(energy)
     assert np.allclose(energy[1:], energy[:-1])

--- a/tests/test_wave_energy.py
+++ b/tests/test_wave_energy.py
@@ -55,11 +55,11 @@ def wave(n, deg, butcher_tableau, splitting=AI):
     return np.array(energies)
 
 
-@pytest.mark.parametrize(('deg', 'N', 'time_stages', 'splitting'),
-                         [(1, 2**j, i, splt) for j in range(2, 4)
-                          for i in (1, 2) for splt in (AI, IA)]
-                         + [(2, 2**j, i, splt) for j in range(2, 4)
-                            for i in (2, 3) for splt in (AI, IA)])
+@pytest.mark.parametrize('splitting', (AI, IA))
+@pytest.mark.parametrize('N', [2**j for j in range(2, 4)])
+@pytest.mark.parametrize(('deg', 'time_stages'),
+                         [(1, i) for i in (1, 2)]
+                         + [(2, i) for i in (2, 3)])
 def test_wave_eq(deg, N, time_stages, splitting):
     energy = wave(N, deg, GaussLegendre(time_stages), splitting)
     print(energy)


### PR DESCRIPTION
This PR enables the common reformulation to solve for stage variables `w = Ak` instead of `k`, which makes the mass matrix more dense but makes the stiffness part block diagonal.  This form is used in many contemporary preconditioning papers.

The main technique is introducing an optional argument into `getForm` that factors the Butcher matrix `A` into a pair of matrices `A = A1 A2`.  The classical RK method (default) puts `A1 = A` and `A2 = I` and the reformulation uses the reverse.  The new code should (untested) supports other choices like `A = L U`, although it is unclear whether there would be any mathematical and/or computational advantage to such approaches.  

In many cases for RK methods of collocation type the `A = I A` factorization also leads to a much faster update of the solution (increment the current state by `dt` times the final stage variable, and the `Stepper` constructor detects this case and assigns a member `_update` method accordingly.