### PR TITLE
Passing nullspace through to treat DAEs like Stokes

### DIFF
--- a/demos/lowlevel/demo_lowlevel_homogbc.py.rst
+++ b/demos/lowlevel/demo_lowlevel_homogbc.py.rst
@@ -54,7 +54,7 @@ Continuing::
 
 Now, we use the :func:`.getForm` function, which processes the semidiscrete problem::
 
-  Fnew, k, bcnew, bcdata = getForm(F, butcher_tableau, t, dt, u, bcs=bc)
+  Fnew, k, bcnew, nspnew, bcdata = getForm(F, butcher_tableau, t, dt, u, bcs=bc)
 
 This returns several things:
 
@@ -64,6 +64,8 @@ This returns several things:
   problem was originally posed
 * ``bcnew`` is a list of new :class:`~firedrake.bcs.DirichletBC` that need to
   be enforced on the variational problem for the stages
+* ``nspnew`` is a new :class:`~firedrake.MixedVectorSpaceBasis` that
+  can be used to express the nullspace of `Fnew`
 * ``bcdata`` contains information needed to update the boundary
   conditions.  It is a list of pairs of the form (``f``, ``expr``), where
   ``f`` is a :class:`~firedrake.function.Function` and ``expr`` is an
@@ -88,7 +90,7 @@ We can set up a new nonlinear variational problem and create a solver
 for it in standard Firedrake fashion::
 
   prob = NonlinearVariationalProblem(Fnew, k, bcs=bcnew)
-  solver = NonlinearVariationalSolver(prob, solver_parameters=luparams)
+  solver = NonlinearVariationalSolver(prob, solver_parameters=luparams, nullspace=nspnew)
 
 We'll need to split the stage variable so that we can update the
 solution after solving for the stages at each time step::

--- a/demos/lowlevel/demo_lowlevel_inhomogbc.py.rst
+++ b/demos/lowlevel/demo_lowlevel_inhomogbc.py.rst
@@ -37,7 +37,7 @@ Imports::
 As with the homogeneous BC case, we use the `getForm` method to
 process the semidiscrete problem::
 
-  Fnew, k, bcnew, bcdata = getForm(F, butcher_tableau, t, dt, u, bcs=bc)
+  Fnew, k, bcnew, nspnew, bcdata = getForm(F, butcher_tableau, t, dt, u, bcs=bc)
 
 Recall that `getForm` produces:
 
@@ -64,7 +64,7 @@ and solver::
               "pc_type": "lu"}
 
   prob = NonlinearVariationalProblem(Fnew, k, bcs=bcnew)
-  solver = NonlinearVariationalSolver(prob, solver_parameters=luparams)
+  solver = NonlinearVariationalSolver(prob, solver_parameters=luparams, nullspace=nspnew)
 
   ks = k.split()
 

--- a/demos/lowlevel/demo_lowlevel_mixed_heat.py.rst
+++ b/demos/lowlevel/demo_lowlevel_mixed_heat.py.rst
@@ -51,7 +51,7 @@ Build the mesh and approximating spaces::
 
 Because we aren't concerned with any strongly-enforced boundary conditions, we drop that information in calling `get_form`::
 
-  Fnew, k, _, _ = getForm(F, butcher_tableau, t, dt, sigu)
+  Fnew, k, _, _, _ = getForm(F, butcher_tableau, t, dt, sigu)
 
 We set up the variational problem and solver using a sparse direct method::
 

--- a/irksome/pc.py
+++ b/irksome/pc.py
@@ -56,6 +56,7 @@ class RanaBase(AuxiliaryOperatorPC):
         bcs = appctx["bcs"]
         bc_type = appctx["bc_type"]
         splitting = appctx["splitting"]
+        nullspace = appctx["nullspace"]
 
         # Make a modified Butcher tableau, probably with some kind
         # of sparser structure (e.g. LD part of LDU factorization)
@@ -64,8 +65,8 @@ class RanaBase(AuxiliaryOperatorPC):
         butcher_new.A = Atilde
 
         # Get the UFL for the system with the modified Butcher tableau
-        Fnew, w, bcnew, _ = getForm(F, butcher_new, t, dt, u0, bcs,
-                                    bc_type, splitting)
+        Fnew, w, bcnew, bignsp, _ = getForm(F, butcher_new, t, dt, u0, bcs,
+                                    bc_type, splitting, nullspace)
 
         # Now we get the Jacobian for the modified system,
         # which becomes the auxiliary operator!

--- a/irksome/pc.py
+++ b/irksome/pc.py
@@ -66,7 +66,7 @@ class RanaBase(AuxiliaryOperatorPC):
 
         # Get the UFL for the system with the modified Butcher tableau
         Fnew, w, bcnew, bignsp, _ = getForm(F, butcher_new, t, dt, u0, bcs,
-                                    bc_type, splitting, nullspace)
+                                            bc_type, splitting, nullspace)
 
         # Now we get the Jacobian for the modified system,
         # which becomes the auxiliary operator!

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -169,11 +169,11 @@ class AdaptiveTimeStepper(TimeStepper):
     """
     def __init__(self, F, butcher_tableau, t, dt, u0,
                  tol=1.e-6, dtmin=1.e-5, bcs=None, solver_parameters=None,
-                 bc_type="DAE", nullspace=None):
+                 bc_type="DAE", splitting=AI, nullspace=None):
         assert butcher_tableau.btilde is not None
         super(AdaptiveTimeStepper, self).__init__(F, butcher_tableau,
-                                                  t, dt, u0, bcs,
-                                                  solver_parameters, bc_type, nullspace)
+                                                  t, dt, u0, bcs, solver_parameters,
+                                                  bc_type, splitting, nullspace)
         self.tol = tol
         self.dt_min = dtmin
         self.delb = butcher_tableau.b - butcher_tableau.btilde

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -76,7 +76,7 @@ def StokesTest(N, butcher_tableau, splitting=AI):
 @pytest.mark.parametrize('time_stages', (2, 3))
 def test_Stokes(N, time_stages, splitting):
     error = StokesTest(N, LobattoIIIC(time_stages), splitting)
-    assert abs(error) < 1e-10
+    assert abs(error) < 2e-10
 
 
 if __name__ == "__main__":

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -40,8 +40,8 @@ def StokesTest(N, butcher_tableau, splitting=AI):
          - inner(u_rhs, v)*dx
          - inner(p_rhs, q)*dx)
 
-    bcs = [DirichletBC(Z.sub(0), uexact, "on_boundary"),
-           DirichletBC(Z.sub(1), pexact, "on_boundary")]
+    bcs = [DirichletBC(Z.sub(0), uexact, "on_boundary")]
+    nsp = [(1,VectorSpaceBasis(constant=True))]
 
     u, p = z.split()
     u.interpolate(uexact)
@@ -53,12 +53,13 @@ def StokesTest(N, butcher_tableau, splitting=AI):
           "snes_monitor": None,
           "snes_rtol": 1e-8,
           "snes_atol": 1e-8,
+          "snes_force_iteration": 1,
           "ksp_type": "preonly",
           "pc_type": "lu",
           "pc_factor_mat_solver_type": "mumps"}
 
     stepper = TimeStepper(F, butcher_tableau, t, dt, z,
-                          bcs=bcs, solver_parameters=lu)
+                          bcs=bcs, solver_parameters=lu, nullspace=nsp)
 
     while (float(t) < 1.0):
         if (float(t) + float(dt) > 1.0):
@@ -67,7 +68,7 @@ def StokesTest(N, butcher_tableau, splitting=AI):
         t.assign(float(t) + float(dt))
 
     (u, p) = z.split()
-    return errornorm(uexact, u)
+    return errornorm(uexact, u) + errornorm(pexact, p)
 
 
 @pytest.mark.parametrize('splitting', (AI, IA))
@@ -79,4 +80,4 @@ def test_Stokes(N, time_stages, splitting):
 
 
 if __name__ == "__main__":
-    test_Stokes(4, 2)
+    test_Stokes(4, 2, AI)

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -41,7 +41,7 @@ def StokesTest(N, butcher_tableau, splitting=AI):
          - inner(p_rhs, q)*dx)
 
     bcs = [DirichletBC(Z.sub(0), uexact, "on_boundary")]
-    nsp = [(1,VectorSpaceBasis(constant=True))]
+    nsp = [(1, VectorSpaceBasis(constant=True))]
 
     u, p = z.split()
     u.interpolate(uexact)


### PR DESCRIPTION
This adds functionality for treating certain nullspaces in Irksome, aimed at the case of DAEs, where the nullspace is associated with a constraint.

Given the original product space, we take in an indexed list of subspace indices and nullspace bases, then construct the `MixedVectorSpaceBasis` over the Irksome product space, matching components of that space to this list.  I'm not sure this is the most elegant implementation, but it seems to work.  (I'm open to suggestions here, though!)

I've modified the `test_stokes.py` code to include the nullspace for Stokes in this way, and verified that passing `nullspace=None` in the call to `stepper` produces failing tests (pressure errors are large, but constant, as expected), while including the nullspace produces the desired results.

This would seem to resolve #23.

Note to self (because it tripped me up when testing on an old install): this requires https://github.com/firedrakeproject/firedrake/pull/1930 , where the treatment of nontrivial `MixedVectorSpaceBasis` was fixed.