### PR TITLE
manipulation: Some minor fixes

### DIFF
--- a/irksome/manipulation.py
+++ b/irksome/manipulation.py
@@ -75,7 +75,7 @@ Result = Union[Tuple[()], Tuple[Coefficient, ...]]
 
 @singledispatch
 def _check_time_terms(o, self: Memoizer) -> Result:
-    raise AssertionError
+    raise AssertionError(f"Unhandled type {type(o)}")
 
 
 @_check_time_terms.register(TimeDerivative)
@@ -136,7 +136,7 @@ def _check_indexed(o: Operator, self: Memoizer) -> Result:
     return self(o.ufl_operands[0])
 
 
-def check_integrals(integrals: List[Integral], expect_time_derivative: bool = True):
+def check_integrals(integrals: List[Integral], expect_time_derivative: bool = True) -> List[Integral]:
     """Check a list of integrals for linearity in the time derivative.
 
     :arg integrals: list of integrals.
@@ -152,7 +152,8 @@ def check_integrals(integrals: List[Integral], expect_time_derivative: bool = Tr
     howmany = int(expect_time_derivative)
     if len(time_derivatives - {()}) != howmany:
         raise ValueError(f"Expecting time derivative applied to {howmany}"
-                         f"coeffficients, not {len(time_derivatives - {()})}")
+                         f"coefficients, not {len(time_derivatives - {()})}")
+    return integrals
 
 
 def summands(o: Expr) -> FrozenSet[Expr]:
@@ -189,6 +190,6 @@ def extract_terms(form: Form) -> SplitTimeForm:
         if not isinstance(rest, Zero):
             rest_terms.append(integral.reconstruct(integrand=rest))
 
-    check_integrals(time_terms, expect_time_derivative=True)
-    check_integrals(rest_terms, expect_time_derivative=False)
+    time_terms = check_integrals(time_terms, expect_time_derivative=True)
+    rest_terms = check_integrals(rest_terms, expect_time_derivative=False)
     return SplitTimeForm(time=Form(time_terms), remainder=Form(rest_terms))


### PR DESCRIPTION
Squash a typo and make assertions provide more meaningful error
messages.

Additionally, ensure that calling check_integrals is required by
returning the checked integrals (rather than asserting correctness as
a side condition that can be elided).