### PR TITLE
Manipulating time derivative forms

### DIFF
--- a/irksome/manipulation.py
+++ b/irksome/manipulation.py
@@ -76,7 +76,7 @@ Result = Union[Tuple[()], Tuple[Coefficient, ...]]
 
 @singledispatch
 def _check_time_terms(o, self: Memoizer) -> Result:
-    raise AssertionError
+    raise AssertionError(f"Unhandled type {type(o)}")
 
 
 @_check_time_terms.register(TimeDerivative)
@@ -153,7 +153,8 @@ def check_integrals(integrals: List[Integral], expect_time_derivative: bool = Tr
     howmany = int(expect_time_derivative)
     if len(time_derivatives - {()}) != howmany:
         raise ValueError(f"Expecting time derivative applied to {howmany}"
-                         f"coeffficients, not {len(time_derivatives - {()})}")
+                         f"coefficients, not {len(time_derivatives - {()})}")
+    return integrals
 
 
 def summands(o: Expr) -> FrozenSet[Expr]:
@@ -190,6 +191,6 @@ def extract_terms(form: Form) -> SplitTimeForm:
         if not isinstance(rest, Zero):
             rest_terms.append(integral.reconstruct(integrand=rest))
 
-    check_integrals(time_terms, expect_time_derivative=True)
-    check_integrals(rest_terms, expect_time_derivative=False)
+    time_terms = check_integrals(time_terms, expect_time_derivative=True)
+    rest_terms = check_integrals(rest_terms, expect_time_derivative=False)
     return SplitTimeForm(time=Form(time_terms), remainder=Form(rest_terms))

--- a/irksome/manipulation.py
+++ b/irksome/manipulation.py
@@ -137,7 +137,7 @@ def _check_indexed(o: Operator, self: Memoizer) -> Result:
     return self(o.ufl_operands[0])
 
 
-def check_integrals(integrals: List[Integral], expect_time_derivative: bool = True):
+def check_integrals(integrals: List[Integral], expect_time_derivative: bool = True) -> List[Integral]:
     """Check a list of integrals for linearity in the time derivative.
 
     :arg integrals: list of integrals.

--- a/tests/test_time_form_splitting.py
+++ b/tests/test_time_form_splitting.py
@@ -71,6 +71,28 @@ def test_can_split_mixed(W):
     assert sig(expect_no_t) == sig(split.remainder)
 
 
+def test_can_split_mixed_split(W):
+    u = Coefficient(W)
+    from ufl import split as splt
+    u0, u1 = splt(u)
+
+    v = TestFunction(W)
+    v0, v1 = splt(v)
+
+    c = Coefficient(W)
+
+    F = (inner(c, c)*inner(Dt(u0), v0) + inner(grad(u), grad(v))
+         + inner(c, v) + inner(Dt(u), v))*dx
+
+    split = extract_terms(F)
+
+    expect_t = (inner(c, c)*inner(Dt(u0), v0) + inner(Dt(u), v))*dx
+    expect_no_t = inner(grad(u), grad(v))*dx + inner(c, v)*dx
+
+    assert sig(expect_t) == sig(split.time)
+    assert sig(expect_no_t) == sig(split.remainder)
+
+
 def test_only_first_order(V):
     u = Coefficient(V)
 


### PR DESCRIPTION
Previously, the facility to split terms with time derivatives from the rest of a form was broken in the case of taking `Dt` of a piece of a mixed function space.  This fixes that and adds a test to check.