### PR TITLE
move the push/pop of dm

### DIFF
--- a/irksome/getForm.py
+++ b/irksome/getForm.py
@@ -4,7 +4,6 @@ from operator import mul
 import numpy
 from firedrake import (Constant, DirichletBC, Function, TestFunction,
                        interpolate, project, split, MixedVectorSpaceBasis)
-from firedrake.dmhooks import push_parent
 from ufl import diff
 from ufl.algorithms import expand_derivatives
 from ufl.algorithms.analysis import has_exact_type
@@ -183,9 +182,6 @@ def getForm(F, butch, t, dt, u0, bcs=None, bc_type="DAE", splitting=AI,
     num_fields = len(V)
 
     Vbig = reduce(mul, (V for _ in range(num_stages)))
-    # Silence a warning about transfer managers when we
-    # coarsen coefficients in V
-    push_parent(V.dm, Vbig.dm)
 
     vnew = TestFunction(Vbig)
     w = Function(Vbig)

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -2,6 +2,7 @@ from .getForm import getForm, AI
 from firedrake import NonlinearVariationalProblem as NLVP
 from firedrake import NonlinearVariationalSolver as NLVS
 from firedrake import Function, norm
+from firedrake.dmhooks import pop_parent, push_parent
 import numpy
 
 
@@ -69,10 +70,13 @@ class TimeStepper:
                   "bc_type": bc_type,
                   "splitting": splitting,
                   "nullspace": nullspace}
+
+        push_parent(u0.function_space().dm, stages.function_space().dm)
         self.solver = NLVS(problem,
                            appctx=appctx,
                            solver_parameters=solver_parameters,
                            nullspace=bigNSP)
+        pop_parent(u0.function_space().dm, stages.function_space().dm)
 
         if self.num_stages == 1 and self.num_fields == 1:
             self.ws = (stages,)
@@ -127,8 +131,10 @@ class TimeStepper:
         for gdat, gcur, gmethod in self.bigBCdata:
             gmethod(gcur, self.u0)
 
+        push_parent(self.u0.function_space().dm, self.stages.function_space().dm)
         self.solver.solve()
-
+        pop_parent(self.u0.function_space().dm, self.stages.function_space().dm)
+      
         self._update()
 
 

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -134,7 +134,7 @@ class TimeStepper:
         push_parent(self.u0.function_space().dm, self.stages.function_space().dm)
         self.solver.solve()
         pop_parent(self.u0.function_space().dm, self.stages.function_space().dm)
-      
+
         self._update()
 
 


### PR DESCRIPTION
Previously, we pushed the original space's parent onto the big space in RK methods and left it there.  This PR localizes the push/pop operations to the construction and invocation of the NLVS.