### PR TITLE
Change TypeError to AttributeError

### DIFF
--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -28,8 +28,8 @@ def getNullspace(V, Vbig, butch, nullspace):
     else:
         try:
             nullspace.sort()
-        except TypeError:
-            raise TypeError("Nullspace entries must be of form (idx, VSP), where idx is a non-negative integer")
+        except AttributeError:
+            raise AttributeError("Nullspace entries must be of form (idx, VSP), where idx is a non-negative integer")
         if (nullspace[-1][0] > num_fields) or (nullspace[0][0] < 0):
             raise ValueError("At least one index for nullspaces is out of range")
         nspnew = []


### PR DESCRIPTION
This is a fix for #46 , changing the `TypeError` to an `AttributeError`.  My only question is whether there's a reasonable use case where `nullspace.sort()` will throw a `TypeError` and we should be catching both...  Thoughts?