### PR TITLE
Rckirby/kwargs

### DIFF
--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -2,7 +2,6 @@ import numpy
 from firedrake import NonlinearVariationalProblem as NLVP
 from firedrake import NonlinearVariationalSolver as NLVS
 from firedrake.dmhooks import pop_parent, push_parent
-from ufl.classes import Zero
 from .dirk_stepper import DIRKTimeStepper
 from .getForm import AI, getForm
 from .stage import StageValueTimeStepper
@@ -58,7 +57,8 @@ def TimeStepper(F, butcher_tableau, t, dt, u0, **kwargs):
         "dirk": ["stage_type", "bcs", "nullspace", "solver_parameters", "appctx"],
         "imex": ["Fexp", "stage_type", "bcs", "nullspace",
                  "it_solver_parameters", "prop_solver_parameters",
-                 "splitting", "appctx"]}
+                 "splitting", "appctx",
+                 "num_its_initial", "num_its_per_step"]}
 
     stage_type = kwargs.get("stage_type", "deriv")
     for cur_kwarg in kwargs.keys():
@@ -106,10 +106,14 @@ def TimeStepper(F, butcher_tableau, t, dt, u0, **kwargs):
         it_solver_parameters = kwargs.get("it_solver_parameters")
         prop_solver_parameters = kwargs.get("prop_solver_parameters")
         nullspace = kwargs.get("nullspace")
+        num_its_initial = kwargs.get("num_its_initial", 0)
+        num_its_per_step = kwargs.get("num_its_per_step", 0)
+
         return RadauIIAIMEXMethod(
             F, Fexp, butcher_tableau, t, dt, u0, bcs,
             it_solver_parameters, prop_solver_parameters,
-            splitting, appctx, nullspace)
+            splitting, appctx, nullspace,
+            num_its_initial, num_its_per_step)
 
 
 class StageDerivativeTimeStepper:

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -45,11 +45,13 @@ def test_diffreact(splitting):
         solver_parameters=luparams,
         stage_type="value")
 
-    imex_stepper = RadauIIAIMEXMethod(
-        Fimp, Fexp, bt, t, dt, u_split, bcs=bcs,
-        splitting=splitting,
+    imex_stepper = TimeStepper(
+        Fimp, bt, t, dt, u_split,
+        stage_type="imex",
+        bcs=bcs, splitting=splitting,
         it_solver_parameters=luparams,
-        prop_solver_parameters=luparams)
+        prop_solver_parameters=luparams,
+        Fexp=Fexp)
 
     num_iter_init = 10
     for i in range(num_iter_init):
@@ -164,10 +166,18 @@ def NavierStokesSplitTest(N, num_stages, Fimp, Fexp):
         stage_type="value",
         bcs=bcs, solver_parameters=lunl, nullspace=nsp)
 
-    imex_stepper = RadauIIAIMEXMethod(
-        F_imp, F_exp, butcher_tableau, t, dt, z_split,
-        bcs=bcs, nullspace=nsp,
-        it_solver_parameters=lulin, prop_solver_parameters=lulin)
+    imex_stepper = TimeStepper(
+        F_imp, butcher_tableau, t, dt, z_split,
+        stage_type="imex", nullspace=nsp,
+        bcs=bcs,
+        it_solver_parameters=lulin,
+        prop_solver_parameters=lulin,
+        Fexp=F_exp)
+
+    # imex_stepper = RadauIIAIMEXMethod(
+    #     F_imp, Fexp, butcher_tableau, t, dt, z_split,
+    #     bcs=bcs, nullspace=nsp,
+    #     it_solver_parameters=lulin, prop_solver_parameters=lulin)
 
     num_iter_init = 10
     for i in range(num_iter_init):


### PR DESCRIPTION
Unify access to various methods (RK with different stage types, dirks, imex) all inside the `TimeStepper` interface, clean up kwarg checking.