### PR TITLE
Smaclachlan/solver stats

### DIFF
--- a/demos/heat/demo_heat_dirk.py.rst
+++ b/demos/heat/demo_heat_dirk.py.rst
@@ -1,5 +1,5 @@
-Solving the Heat Equation with Irksome
-======================================
+Solving the Heat Equation with a DIRK in Irksome
+================================================
 
 Let's start with the simple heat equation on :math:`\Omega = [0,10]
 \times [0,10]`, with boundary :math:`\Gamma`:
@@ -39,9 +39,8 @@ manufactured solutions::
 
   from ufl.algorithms.ad import expand_derivatives
 
-We will create the Butcher tableau for the lowest-order Gauss-Legendre
-Runge-Kutta method, which is more commonly known as the implicit
-midpoint rule::
+We will create the Butcher tableau for a three-stage L-stable DIRK
+due to Alexander (SINUM 14(6): 1006-1021, 1977).::
 
   butcher_tableau = Alexander()
   ns = butcher_tableau.num_stages

--- a/demos/heat/demo_heat_dirk.py.rst
+++ b/demos/heat/demo_heat_dirk.py.rst
@@ -1,0 +1,126 @@
+Solving the Heat Equation with Irksome
+======================================
+
+Let's start with the simple heat equation on :math:`\Omega = [0,10]
+\times [0,10]`, with boundary :math:`\Gamma`:
+
+.. math::
+
+   u_t - \Delta u &= f
+
+   u & = 0 \quad \textrm{on}\ \Gamma
+
+for some known function :math:`f`.  At each time :math:`t`, the solution
+to this equation will be some function :math:`u\in V`, for a suitable function
+space :math:`V`.
+
+We transform this into weak form by multiplying by an arbitrary test function
+:math:`v\in V` and integrating over :math:`\Omega`.  We know have the
+variational problem of finding :math:`u:[0,T]\rightarrow V` such
+that
+
+.. math::
+
+   (u_t, v) + (\nabla u, \nabla v) = (f, v)
+
+This demo implements an example used by Solin with a particular choice
+of :math:`f` given below
+
+As usual, we need to import firedrake::
+
+  from firedrake import *
+
+We will also need to import certain items from irksome::
+
+  from irksome import Alexander, Dt, TimeStepper
+
+And we will need a little bit of UFL to support using the method of
+manufactured solutions::
+
+  from ufl.algorithms.ad import expand_derivatives
+
+We will create the Butcher tableau for the lowest-order Gauss-Legendre
+Runge-Kutta method, which is more commonly known as the implicit
+midpoint rule::
+
+  butcher_tableau = Alexander()
+  ns = butcher_tableau.num_stages
+
+Now we define the mesh and piecewise linear approximating space in
+standard Firedrake fashion::
+
+  N = 100
+  x0 = 0.0
+  x1 = 10.0
+  y0 = 0.0
+  y1 = 10.0
+
+  msh = RectangleMesh(N, N, x1, y1)
+  V = FunctionSpace(msh, "CG", 1)
+
+We define variables to store the time step and current time value::
+
+  dt = Constant(10.0 / N)
+  t = Constant(0.0)
+
+This defines the right-hand side using the method of manufactured solutions::
+
+  x, y = SpatialCoordinate(msh)
+  S = Constant(2.0)
+  C = Constant(1000.0)
+  B = (x-Constant(x0))*(x-Constant(x1))*(y-Constant(y0))*(y-Constant(y1))/C
+  R = (x * x + y * y) ** 0.5
+  uexact = B * atan(t)*(pi / 2.0 - atan(S * (R - t)))
+  rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+
+We define the initial condition for the fully discrete problem, which
+will get overwritten at each time step::
+
+  u = interpolate(uexact, V)
+
+Now, we will define the semidiscrete variational problem using
+standard UFL notation, augmented by the ``Dt`` operator from Irksome::
+
+  v = TestFunction(V)
+  F = inner(Dt(u), v)*dx + inner(grad(u), grad(v))*dx - inner(rhs, v)*dx
+  bc = DirichletBC(V, 0, "on_boundary")
+
+We'll just solve each stage with gamg + gmres::
+
+  params = {"mat_type": "aij",
+            "ksp_type": "gmres",
+            "pc_type": "gamg"}
+
+Most of Irksome's magic happens in the :class:`.TimeStepper`.  It
+transforms our semidiscrete form `F` into a fully discrete form for
+the stage unknowns and sets up a variational problem to solve for the
+stages at each time step.::
+
+  stepper = TimeStepper(F, butcher_tableau, t, dt, u, bcs=bc,
+                        solver_parameters=params,
+			stage_type="dirk")
+
+This logic is pretty self-explanatory.  We use the
+:class:`.TimeStepper`'s :meth:`~.TimeStepper.advance` method, which solves the variational
+problem to compute the Runge-Kutta stage values and then updates the solution.::
+
+  while (float(t) < 1.0):
+      if (float(t) + float(dt) > 1.0):
+          dt.assign(1.0 - float(t))
+      stepper.advance()
+      print(float(t))
+      t.assign(float(t) + float(dt))
+
+Now, check the relative :math:`L^2` error::
+
+  print()
+  print(norm(u-uexact)/norm(uexact))
+
+And report the solver statistics::
+
+  num_steps, _, num_lin_its = stepper.solver_stats()
+
+  print(f"{num_steps} steps taken")
+  print(f"{num_lin_its} linear iterations taken")
+  print(f"That's {num_lin_its / num_steps} per time step")
+  print(f"And {num_lin_its / num_steps / 3} average per stage")

--- a/demos/monodomain/demo_monodomain_FHN.py.rst
+++ b/demos/monodomain/demo_monodomain_FHN.py.rst
@@ -20,7 +20,7 @@ for certain positive parameters :math:`\beta` and :math:`\gamma`, and the curren
 
    I_{ion}(u, c) = \tfrac{1}{\epsilon} \left( u - \tfrac{u^3}{3} - c \right)
 
-so that we have an overall system of two equations.  One of them is linear but stiff/diffusive, and theo ther is nonstiff but nonlinear.  This combination makes the system a good candidate for additive partitioning/IMEX-type methods.
+so that we have an overall system of two equations.  One of them is linear but stiff/diffusive, and the other is nonstiff but nonlinear.  This combination makes the system a good candidate for additive partitioning/IMEX-type methods.
 
 
 We start with standard Firedrake/Irksome imports::

--- a/demos/monodomain/demo_monodomain_FHN.py.rst
+++ b/demos/monodomain/demo_monodomain_FHN.py.rst
@@ -1,0 +1,121 @@
+Solving monodomain equations with Fitzhugh-Nagumo reaction and an IMEX method
+=============================================================================
+
+We're solving monodomain (reaction-diffusion) with a particular reaction term::
+
+  import copy
+
+  from firedrake import (And, Constant, File, Function, FunctionSpace,
+                         RectangleMesh, SpatialCoordinate, TestFunctions,
+                         as_matrix, conditional, dx, grad, inner, split)
+  from irksome import Dt, RadauIIA, TimeStepper
+
+  mesh = RectangleMesh(100, 100, 70, 70, quadrilateral=True)
+  polyOrder = 2
+
+  # Set up the function space and test/trial functions.
+  V = FunctionSpace(mesh, "S", polyOrder)
+  Z = V * V
+
+  x, y = SpatialCoordinate(mesh)
+  dt = Constant(0.05)
+  t = Constant(0.0)
+
+  InitialPotential = conditional(x < 3.5, Constant(2.0), Constant(-1.28791))
+  InitialCell = conditional(And(And(31 <= x, x < 39), And(0 <= y, y < 35)),
+                            Constant(2.0), Constant(-0.5758))
+
+  eps = Constant(0.1)
+  beta = Constant(1.0)
+  gamma = Constant(0.5)
+
+  chi = Constant(1.0)
+  capacitance = Constant(1.0)
+
+  sigma1 = sigma2 = 1.0
+
+  sigma = as_matrix([[sigma1, 0.0], [0.0, sigma2]])
+
+
+  # Set up Irksome to be used.
+  butcher_tableau = RadauIIA(2)
+  ns = butcher_tableau.num_stages
+
+  uu = Function(Z)
+  vu, vc = TestFunctions(Z)
+  uu.sub(0).interpolate(InitialPotential)
+  uu.sub(1).interpolate(InitialCell)
+
+  (uCurr, cCurr) = split(uu)
+
+  F1 = (inner(chi * capacitance * Dt(uCurr), vu)*dx
+        + inner(grad(uCurr), sigma * grad(vu))*dx
+        + inner(Dt(cCurr), vc)*dx - inner(eps * uCurr, vc)*dx
+        - inner(beta * eps, vc)*dx + inner(gamma * eps * cCurr, vc)*dx)
+
+  F2 = inner((chi/eps) * (-uCurr + (uCurr**3 / 3) + cCurr), vu)*dx
+
+  params = {"snes_type": "ksponly",
+            "ksp_rtol": 1.e-8,
+            "ksp_monitor": None,
+            "mat_type": "matfree",
+            "ksp_type": "fgmres",
+            "pc_type": "python",
+            "pc_python_type": "irksome.RanaLD",
+            "aux": {
+                "pc_type": "fieldsplit",
+                "pc_fieldsplit_type": "multiplicative"}}
+
+  per_stage = {
+      "ksp_type": "preonly",
+      "pc_type": "fieldsplit",
+      "pc_fieldsplit_type": "additive",
+      "fieldsplit_0": {
+          "ksp_type": "preonly",
+          "pc_type": "gamg",
+      },
+      "fieldsplit_1": {
+          "ksp_type": "preonly",
+          "pc_type": "icc",
+      }}
+
+  for s in range(ns):
+      params["aux"][f"pc_fieldsplit_{s}_fields"] = f"{2*s},{2*s+1}"
+      params["aux"][f"fieldsplit_{s}"] = per_stage
+
+  itparams = copy.deepcopy(params)
+  itparams["ksp_rtol"] = 1.e-4
+
+  stepper = TimeStepper(F1, butcher_tableau, t, dt, uu,
+                        stage_type="imex",
+                        prop_solver_parameters=params,
+                        it_solver_parameters=itparams,
+		        Fexp=F2,
+		        num_its_initial=5,
+		        num_its_per_step=3)
+
+  uFinal, cFinal = uu.split()
+  outfile1 = File("FHN_results/FHN_2d_u.pvd")
+  outfile2 = File("FHN_results/FHN_2d_c.pvd")
+  outfile1.write(uFinal, time=0)
+  outfile2.write(cFinal, time=0)
+
+  for j in range(12):
+      print(f"{float(t)}")
+      stepper.advance()
+      t.assign(float(t) + float(dt))
+      # uCurr, cCurr = split(uu)
+      if (j % 5 == 0):
+          print("Time step", j)
+          outfile1.write(uFinal, time=j * float(dt))
+          outfile2.write(cFinal, time=j * float(dt))
+
+  nsteps, nprop, nit, nnonlinprop, nlinprop, nnonlinit, nlinit = stepper.solver_stats()
+  print(f"Time steps taken: {nsteps}")
+  print(f"  {nprop} propagator steps")
+  print(f"  {nit} iterator steps")
+  print(f"  {nnonlinprop} nonlinear steps in propagators")
+  print(f"  {nlinprop} linear steps in propagators")
+  print(f"  {nnonlinit} nonlinear steps in iterators")
+  print(f"  {nlinit} linear steps in iterators")  
+

--- a/demos/monodomain/demo_monodomain_FHN.py.rst
+++ b/demos/monodomain/demo_monodomain_FHN.py.rst
@@ -1,7 +1,29 @@
 Solving monodomain equations with Fitzhugh-Nagumo reaction and an IMEX method
 =============================================================================
 
-We're solving monodomain (reaction-diffusion) with a particular reaction term::
+We're solving monodomain (reaction-diffusion) with a particular reaction term.
+The basic form of the equation is:
+
+.. math::
+
+   \chi \left( C_m u_t + I_{ion}(u) \right) = \nabla \cdot \sigma \nabla u
+
+where :math:`u` is the membrane potential, :math:`\sigma` is the conductivity tensor, :math:`C_m` is the specific capacitance of the cell membrane, and :math:`\chi` is the surface area to volume ration.  The term :math:`I_{ion}` is current due to ionic flows through channels in the cell membranes, and may couple to a complicated reaction network.  In our case, we take the relatively simple model due to Fitzhugh and Nagumo.  Here, we have a separate concentration variable :math:`c` satisfying the reaction equation:
+
+.. math::
+
+   c_t = \epsilon( u + \beta - \gamma c)
+
+for certain positive parameters :math:`\beta` and :math:`\gamma`, and the current takes the form of:
+
+.. math::
+
+   I_{ion}(u, c) = \tfrac{1}{\epsilon} \left( u - \tfrac{u^3}{3} - c \right)
+
+so that we have an overall system of two equations.  One of them is linear but stiff/diffusive, and theo ther is nonstiff but nonlinear.  This combination makes the system a good candidate for additive partitioning/IMEX-type methods.
+
+
+We start with standard Firedrake/Irksome imports::
 
   import copy
 
@@ -10,10 +32,11 @@ We're solving monodomain (reaction-diffusion) with a particular reaction term::
                          as_matrix, conditional, dx, grad, inner, split)
   from irksome import Dt, RadauIIA, TimeStepper
 
+And we set up the mesh and function space.  Note this demo uses serendipity elements, but could just as easily use Lagrange on quads or triangles.::
+  
   mesh = RectangleMesh(100, 100, 70, 70, quadrilateral=True)
   polyOrder = 2
-
-  # Set up the function space and test/trial functions.
+  
   V = FunctionSpace(mesh, "S", polyOrder)
   Z = V * V
 
@@ -21,9 +44,7 @@ We're solving monodomain (reaction-diffusion) with a particular reaction term::
   dt = Constant(0.05)
   t = Constant(0.0)
 
-  InitialPotential = conditional(x < 3.5, Constant(2.0), Constant(-1.28791))
-  InitialCell = conditional(And(And(31 <= x, x < 39), And(0 <= y, y < 35)),
-                            Constant(2.0), Constant(-0.5758))
+Specify the physical constants and initial conditions::
 
   eps = Constant(0.1)
   beta = Constant(1.0)
@@ -33,28 +54,43 @@ We're solving monodomain (reaction-diffusion) with a particular reaction term::
   capacitance = Constant(1.0)
 
   sigma1 = sigma2 = 1.0
-
   sigma = as_matrix([[sigma1, 0.0], [0.0, sigma2]])
 
+  
+  InitialPotential = conditional(x < 3.5, Constant(2.0), Constant(-1.28791))
+  InitialCell = conditional(And(And(31 <= x, x < 39), And(0 <= y, y < 35)),
+                            Constant(2.0), Constant(-0.5758))
 
-  # Set up Irksome to be used.
-  butcher_tableau = RadauIIA(2)
-  ns = butcher_tableau.num_stages
 
   uu = Function(Z)
   vu, vc = TestFunctions(Z)
   uu.sub(0).interpolate(InitialPotential)
   uu.sub(1).interpolate(InitialCell)
 
-  (uCurr, cCurr) = split(uu)
+  (u, c) = split(uu)
+  
 
-  F1 = (inner(chi * capacitance * Dt(uCurr), vu)*dx
-        + inner(grad(uCurr), sigma * grad(vu))*dx
-        + inner(Dt(cCurr), vc)*dx - inner(eps * uCurr, vc)*dx
-        - inner(beta * eps, vc)*dx + inner(gamma * eps * cCurr, vc)*dx)
+This sets up the Butcher tableau.  All of our IMEX-type methods are
+based on a RadauIIA method for the implicit part.  We use a two-stage method.::
+  
+  butcher_tableau = RadauIIA(2)
+  ns = butcher_tableau.num_stages
 
-  F2 = inner((chi/eps) * (-uCurr + (uCurr**3 / 3) + cCurr), vu)*dx
+To access an IMEX method, we need to separately specify the implicit and explicit parts of the operator.
+The part to be handled implicitly is taken to contain the time derivatives as well::
+  
+  F1 = (inner(chi * capacitance * Dt(u), vu)*dx
+        + inner(grad(u), sigma * grad(vu))*dx
+        + inner(Dt(c), vc)*dx - inner(eps * u, vc)*dx
+        - inner(beta * eps, vc)*dx + inner(gamma * eps * c, vc)*dx)
 
+This is the part to be additively partitioned and handled explicitly::
+	  
+  F2 = inner((chi/eps) * (-u + (u**3 / 3) + c), vu)*dx
+
+If we wanted to use a fully implicit method, we would just take
+F = F1 + F2.  Now, set up solver parameters.  For this problem, the Rana preconditioner applied with a multiplicative field split works very well.::
+  
   params = {"snes_type": "ksponly",
             "ksp_rtol": 1.e-8,
             "ksp_monitor": None,
@@ -65,6 +101,8 @@ We're solving monodomain (reaction-diffusion) with a particular reaction term::
             "aux": {
                 "pc_type": "fieldsplit",
                 "pc_fieldsplit_type": "multiplicative"}}
+
+Each diagonal block to be solved is itself a block-coupled system, with a diffisuve block and a mass matrix on the diagonal.  Hence, we further fieldsplit each diagonal block, using algebraic multigrid for the diffusive block and incomplete Cholesky for the mass matrix.::
 
   per_stage = {
       "ksp_type": "preonly",
@@ -79,13 +117,19 @@ We're solving monodomain (reaction-diffusion) with a particular reaction term::
           "pc_type": "icc",
       }}
 
+This bit of mess specifies how the overall system is split up.  Each stage corresponds to a pair of fields (potential and concentration)::
+      
   for s in range(ns):
       params["aux"][f"pc_fieldsplit_{s}_fields"] = f"{2*s},{2*s+1}"
       params["aux"][f"fieldsplit_{s}"] = per_stage
 
+The partitioned IMEX methods also provide an "iterator" that is used both to start the method (filling in the stage values between the initial condition and first time step taken) and can also be used after a time step to improve the accuracy/stability of the solution.  If the iterator "works", applying it a large number of times will tend to produce the solution to a fully implicit RadauIIA method.  In practice, we can sometimes get away with applying the iterator to a looser tolerance, but we otherwise use the same method as for the propagator.::
+
   itparams = copy.deepcopy(params)
   itparams["ksp_rtol"] = 1.e-4
 
+Now, we access the IMEX method via the :function:`TimeStepper` as with other methods.  Note that we specify somewhat different kwargs, needing to specify the implicit and explicit parts separately as well as separate solver options for propagator and iterator.::
+  
   stepper = TimeStepper(F1, butcher_tableau, t, dt, uu,
                         stage_type="imex",
                         prop_solver_parameters=params,
@@ -104,9 +148,8 @@ We're solving monodomain (reaction-diffusion) with a particular reaction term::
       print(f"{float(t)}")
       stepper.advance()
       t.assign(float(t) + float(dt))
-      # uCurr, cCurr = split(uu)
+
       if (j % 5 == 0):
-          print("Time step", j)
           outfile1.write(uFinal, time=j * float(dt))
           outfile2.write(cFinal, time=j * float(dt))
 

--- a/demos/monodomain/demo_monodomain_FHN.py.rst
+++ b/demos/monodomain/demo_monodomain_FHN.py.rst
@@ -102,7 +102,7 @@ F = F1 + F2.  Now, set up solver parameters.  For this problem, the Rana precond
                 "pc_type": "fieldsplit",
                 "pc_fieldsplit_type": "multiplicative"}}
 
-Each diagonal block to be solved is itself a block-coupled system, with a diffisuve block and a mass matrix on the diagonal.  Hence, we further fieldsplit each diagonal block, using algebraic multigrid for the diffusive block and incomplete Cholesky for the mass matrix.::
+Each diagonal block to be solved is itself a block-coupled system, with a diffusive block and a mass matrix on the diagonal.  Hence, we further fieldsplit each diagonal block, using algebraic multigrid for the diffusive block and incomplete Cholesky for the mass matrix.::
 
   per_stage = {
       "ksp_type": "preonly",

--- a/demos/monodomain/demo_monodomain_FHN.py.rst
+++ b/demos/monodomain/demo_monodomain_FHN.py.rst
@@ -128,7 +128,7 @@ The partitioned IMEX methods also provide an "iterator" that is used both to sta
   itparams = copy.deepcopy(params)
   itparams["ksp_rtol"] = 1.e-4
 
-Now, we access the IMEX method via the :function:`TimeStepper` as with other methods.  Note that we specify somewhat different kwargs, needing to specify the implicit and explicit parts separately as well as separate solver options for propagator and iterator.::
+Now, we access the IMEX method via the `TimeStepper` as with other methods.  Note that we specify somewhat different kwargs, needing to specify the implicit and explicit parts separately as well as separate solver options for propagator and iterator.::
   
   stepper = TimeStepper(F1, butcher_tableau, t, dt, uu,
                         stage_type="imex",

--- a/demos/preconditioning/demo_heat_mg.py.rst
+++ b/demos/preconditioning/demo_heat_mg.py.rst
@@ -107,6 +107,14 @@ And we can advance the solution in time in typical fashion::
       print(float(t), flush=True)
       t.assign(float(t) + float(dt))
 
+After the solve, we can retrieve some statistics about the solver::
+
+  steps, nonlinear_its, linear_its = stepper.solver_stats()
+
+  print("Total number of timesteps was %d" % (steps))
+  print("Average number of nonlinear iterations per timestep was %.2f" % (nonlinear_its/steps))
+  print("Average number of linear iterations per timestep was %.2f" % (linear_its/steps))
+
 Finally, we print out the relative :math:`L^2` error::
 
   print()

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -76,14 +76,14 @@ We now have support for DIRKs:
 .. toctree::
    :maxdepth: 1
 
-   demos/heat/demo_heat_dirk.py
+   demos/demo_heat_dirk.py
 
 Or check out an IMEX-type method for the monodomain equations:
 
 .. toctree::
    :maxdepth: 1
 
-   demos/monodomain/demo_monodomain_FHN.py
+   demos/demo_monodomain_FHN.py
 
 Advanced demos
 --------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -71,6 +71,20 @@ Yes, Irksome can handle nonlinear problems as well:
 
    demos/demo_cahnhilliard.py
 
+We now have support for DIRKs:
+
+.. toctree::
+   :maxdepth: 1
+
+   demos/heat/demo_heat_dirk.py
+
+Or check out an IMEX-type method for the monodomain equations:
+
+.. toctree::
+   :maxdepth: 1
+
+   demos/monodomain/demo_monodomain_FHN.py
+
 Advanced demos
 --------------
 

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -305,5 +305,3 @@ class RadauIIAIMEXMethod:
                 self.num_linear_iterations_prop,
                 self.num_nonlinear_iterations_it,
                 self.num_linear_iterations_it)
-                
-

--- a/irksome/stage.py
+++ b/irksome/stage.py
@@ -309,6 +309,9 @@ class StageValueTimeStepper:
         self.num_fields = len(u0.function_space())
         self.num_stages = len(butcher_tableau.b)
         self.butcher_tableau = butcher_tableau
+        self.num_steps = 0
+        self.num_nonlinear_iterations = 0
+        self.num_linear_iterations = 0
 
         Fbig, update_stuff, UU, bigBCs, gblah, nsp = getFormStage(
             F, butcher_tableau, u0, t, dt, bcs,
@@ -378,4 +381,11 @@ class StageValueTimeStepper:
 
         self.solver.solve()
 
+        self.num_steps += 1
+        self.num_nonlinear_iterations += self.solver.snes.getIterationNumber()
+        self.num_linear_iterations += self.solver.snes.getLinearSolveIterations()
+
         self._update()
+
+    def solver_stats(self):
+        return (self.num_steps, self.num_nonlinear_iterations, self.num_linear_iterations)

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -167,6 +167,9 @@ class StageDerivativeTimeStepper:
         self.num_fields = len(u0.function_space())
         self.num_stages = len(butcher_tableau.b)
         self.butcher_tableau = butcher_tableau
+        self.num_steps = 0
+        self.num_nonlinear_iterations = 0
+        self.num_linear_iterations = 0
 
         bigF, stages, bigBCs, bigNSP, bigBCdata = \
             getForm(F, butcher_tableau, t, dt, u0, bcs, bc_type, splitting, nullspace)
@@ -255,4 +258,10 @@ class StageDerivativeTimeStepper:
         self.solver.solve()
         pop_parent(self.u0.function_space().dm, self.stages.function_space().dm)
 
+        self.num_steps += 1
+        self.num_nonlinear_iterations += self.solver.snes.getIterationNumber()
+        self.num_linear_iterations += self.solver.snes.getLinearSolveIterations()
         self._update()
+
+    def solver_stats(self):
+        return (self.num_steps, self.num_nonlinear_iterations, self.num_linear_iterations)


### PR DESCRIPTION
We provide some simple solver statistics -- each kind of time stepper tracks the number of steps it has taken and the total number of linear/nonlinear iterations it took over those time steps.  Different methods report a different kind of stats (e.g. IMEX needs to report iterations separately for iterator/propagator).