### PR TITLE
Wrap up bc args

### DIFF
--- a/irksome/getForm.py
+++ b/irksome/getForm.py
@@ -201,7 +201,7 @@ def getForm(F, butch, t, dt, u0, bcs=None, bc_type=None, splitting=AI,
                               dtype=object)
 
         def bc2gcur(bc, i):
-            gorig = bc._original_arg
+            gorig = as_ufl(bc._original_arg)
             gfoo = expand_derivatives(diff(gorig, t))
             return replace(gfoo, {t: t + c[i] * dt}) + u0_mult[i]*gorig
 

--- a/irksome/stage.py
+++ b/irksome/stage.py
@@ -8,6 +8,7 @@ from firedrake import (Constant, DirichletBC, Function,
                        TestFunction, dx, inner, interpolate, project, split)
 from numpy import vectorize
 from ufl.classes import Zero
+from ufl.constantvalue import as_ufl
 
 from .manipulation import extract_terms, strip_dt_form
 from .tools import AI, IA, getNullspace, is_ode, replace
@@ -226,7 +227,7 @@ def getFormStage(F, butch, u0, t, dt, bcs=None, splitting=None,
                 Vsp = V.sub(sub)
                 Vbigi = lambda i: Vbig[sub+num_fields*i]
 
-        bcarg = bc._original_arg
+        bcarg = as_ufl(bc._original_arg)
         for i in range(num_stages):
             try:
                 gdat = interpolate(bcarg, Vsp)
@@ -277,7 +278,7 @@ def getFormStage(F, butch, u0, t, dt, bcs=None, splitting=None,
             else:
                 Vsp = V.sub(sub)
 
-        bcarg = bc._original_arg
+        bcarg = as_ufl(bc._original_arg)
         try:
             gdat = interpolate(bcarg, Vsp)
             gmethod = lambda gd, gc: gd.interpolate(gc)


### PR DESCRIPTION
A simple test case using stage type value failed when called with a zero DirichletBC, because we weren't wrapping `bc._original_arg` with `as_ufl`.  This should fix that for all places that we use it.