### PR TITLE
.split() -> .subfunctions

### DIFF
--- a/irksome/dirk_stepper.py
+++ b/irksome/dirk_stepper.py
@@ -188,7 +188,7 @@ class DIRKTimeStepper:
         AA = bt.A
         CC = bt.c
         BB = bt.b
-        gsplit = g.split()
+        gsplit = g.subfunctions
         for i in range(self.num_stages):
             # update a, c constants tucked into the variational problem
             # for the current stage
@@ -198,7 +198,7 @@ class DIRKTimeStepper:
             # variational form
             g.assign(u0)
             for j in range(i):
-                ksplit = ks[j].split()
+                ksplit = ks[j].subfunctions
                 for (gbit, kbit) in zip(gsplit, ksplit):
                     gbit += dtc * float(AA[i, j]) * kbit
 
@@ -234,7 +234,7 @@ class DIRKTimeStepper:
 
         # update the solution with now-computed stage values.
         for i in range(self.num_stages):
-            for (u0bit, kbit) in zip(u0.split(), ks[i].split()):
+            for (u0bit, kbit) in zip(u0.subfunctions, ks[i].subfunctions):
                 u0bit += dtc * float(BB[i]) * kbit
 
         self.num_steps += 1

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -211,7 +211,7 @@ class RadauIIAIMEXMethod:
 
         self.UU = UU
         self.UU_old = UU_old = Function(UU.function_space())
-        self.UU_old_split = UU_old.split()
+        self.UU_old_split = UU_old.subfunctions
         self.bigBCs = bigBCs
         self.bcdat = gblah
 
@@ -250,7 +250,7 @@ class RadauIIAIMEXMethod:
         pop_parent(self.u0.function_space().dm, self.UU.function_space().dm)
 
         num_fields = len(self.u0.function_space())
-        u0split = u0.split()
+        u0split = u0.subfunctions
         for i, u0bit in enumerate(u0split):
             for s in range(self.num_stages):
                 ii = s * num_fields + i
@@ -277,7 +277,7 @@ class RadauIIAIMEXMethod:
 
         ns = self.num_stages
         nf = self.num_fields
-        u0split = self.u0.split()
+        u0split = self.u0.subfunctions
         for i, u0bit in enumerate(u0split):
             u0bit.assign(self.UU_old_split[(ns-1)*nf + i])
 

--- a/irksome/stage.py
+++ b/irksome/stage.py
@@ -358,11 +358,11 @@ class StageValueTimeStepper:
     def _update_stiff_acc(self):
         u0 = self.u0
 
-        UUs = self.UU.split()
+        UUs = self.UU.subfunctions
         nf = self.num_fields
         ns = self.num_stages
 
-        u0bits = u0.split()
+        u0bits = u0.subfunctions
         for i, u0bit in enumerate(u0bits):
             u0bit.assign(UUs[nf*(ns-1)+i])
 
@@ -371,8 +371,8 @@ class StageValueTimeStepper:
         for gdat, gcur, gmethod in update_bcs_gblah:
             gmethod(gdat, gcur)
         self.update_solver.solve()
-        u0bits = self.u0.split()
-        unewbits = unew.split()
+        u0bits = self.u0.subfunctions
+        unewbits = unew.subfunctions
         for u0bit, unewbit in zip(u0bits, unewbits):
             u0bit.assign(unewbit)
 

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -202,7 +202,7 @@ class StageDerivativeTimeStepper:
         if self.num_stages == 1 and self.num_fields == 1:
             self.ws = (stages,)
         else:
-            self.ws = stages.split()
+            self.ws = stages.subfunctions
 
         A1, A2 = splitting(butcher_tableau.A)
         try:
@@ -227,7 +227,7 @@ class StageDerivativeTimeStepper:
         nf = self.num_fields
 
         ws = self.ws
-        u0bits = u0.split()
+        u0bits = u0.subfunctions
         for s in range(ns):
             for i, u0bit in enumerate(u0bits):
                 u0bit += dtc * float(b[s]) * ws[nf*s+i]
@@ -244,7 +244,7 @@ class StageDerivativeTimeStepper:
         nf = self.num_fields
 
         ws = self.ws
-        u0bits = u0.split()
+        u0bits = u0.subfunctions
         for i, u0bit in enumerate(u0bits):
             u0bit += dtc * ws[nf*(ns-1)+i]
 

--- a/tests/test_dirk.py
+++ b/tests/test_dirk.py
@@ -246,9 +246,9 @@ def test_stokes_bcs(butcher_tableau, bctype):
     nsp = [(1, VectorSpaceBasis(constant=True))]
     nsp_dirk = MixedVectorSpaceBasis(Z, [Z.sub(0), VectorSpaceBasis(constant=True)])
 
-    u, p = z.split()
+    u, p = z.subfunctions
     u.interpolate(uexact)
-    u_dirk, p_dirk = z_dirk.split()
+    u_dirk, p_dirk = z_dirk.subfunctions
     u_dirk.interpolate(uexact)
 
     bcs = bctype(Z, uexact)

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -176,9 +176,9 @@ def NavierStokesSplitTest(N, num_stages, Fimp, Fexp):
         imp_stepper.advance()
         imex_stepper.advance()
         t.assign(float(t) + float(dt))
-        uimp, pimp = z_imp.split()
+        uimp, pimp = z_imp.subfunctions
         pimp -= assemble(pimp*dx)
-        usplit, psplit = z_split.split()
+        usplit, psplit = z_split.subfunctions
         psplit -= assemble(psplit*dx)
         print(errornorm(uimp, usplit), errornorm(pimp, psplit))
 

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -42,7 +42,7 @@ def StokesTest(N, butcher_tableau, stage_type="deriv", splitting=AI):
     bcs = [DirichletBC(Z.sub(0), uexact, "on_boundary")]
     nsp = [(1, VectorSpaceBasis(constant=True))]
 
-    u, p = z.split()
+    u, p = z.subfunctions
     u.interpolate(uexact)
 
     lu = {"mat_type": "aij",
@@ -67,7 +67,7 @@ def StokesTest(N, butcher_tableau, stage_type="deriv", splitting=AI):
         stepper.advance()
         t.assign(float(t) + float(dt))
 
-    (u, p) = z.split()
+    (u, p) = z.subfunctions
 
     # check error mod the constants
     perr = norm(pexact - p - assemble((pexact-p) * dx))
@@ -125,7 +125,7 @@ def NSETest(butch, stage_type, splitting):
                           nullspace=nullspace)
 
     tfinal = 1.0
-    u, p = up.split()
+    u, p = up.subfunctions
     while (float(t) < tfinal):
         if (float(t) + float(dt) > tfinal):
             dt.assign(1.0 - float(t))

--- a/tests/test_vecbc.py
+++ b/tests/test_vecbc.py
@@ -15,11 +15,11 @@ def elastodynamics(N, deg, butcher_tableau, splitting=AI):
     VV = V * V
 
     uu1 = Function(VV)
-    u1, udot1 = uu1.split()
+    u1, udot1 = uu1.subfunctions
     u1.interpolate(as_vector([sin(pi*x)*sin(pi*y), sin(pi*x) * sin(pi*y)]))
 
     uu2 = Function(VV)
-    u2, udot2 = uu2.split()
+    u2, udot2 = uu2.subfunctions
     u2.interpolate(as_vector([sin(pi*x)*sin(pi*y), sin(pi*x) * sin(pi*y)]))
 
     u1, udot1 = split(uu1)


### PR DESCRIPTION
This addresses the deprecation of `.split()` in UFL raised in Issue #64 