### PR TITLE
Remove ufl.log from Irksome

### DIFF
--- a/irksome/deriv.py
+++ b/irksome/deriv.py
@@ -1,5 +1,4 @@
 from ufl.differentiation import Derivative
-from ufl.log import error
 from ufl.core.ufl_type import ufl_type
 from ufl.corealg.multifunction import MultiFunction
 from ufl.algorithms.map_integrands import map_integrand_dags, map_expr_dag
@@ -64,7 +63,7 @@ class TimeDerivativeRuleDispatcher(MultiFunction):
         return o
 
     def derivative(self, o):
-        error("Missing derivative handler for {0}.".format(type(o).__name__))
+        raise NotImplementedError("Missing derivative handler for {0}.".format(type(o).__name__))
 
     expr = MultiFunction.reuse_if_untouched
 

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -5,7 +5,6 @@ from ufl.algorithms.map_integrands import map_integrand_dags
 from ufl.classes import CoefficientDerivative
 from ufl.constantvalue import as_ufl
 from ufl.corealg.multifunction import MultiFunction
-from ufl.log import error
 from irksome.deriv import TimeDerivative
 
 
@@ -54,7 +53,7 @@ class MyReplacer(MultiFunction):
         super().__init__()
         self.replacements = mapping
         if not all(k.ufl_shape == v.ufl_shape for k, v in mapping.items()):
-            error("Replacement expressions must have the same shape as what they replace.")
+            raise ValueError("Replacement expressions must have the same shape as what they replace.")
 
     def expr(self, o):
         if o in self.replacements:


### PR DESCRIPTION
Removes the two calls to `ufl.log` from Irksome, hopefully fixing #70 