### PR TITLE
Rckirby/derogue setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This package works with Firedrake to generate Runge-Kutta methods from a semi-di
 
 A long-standing critique of fully implicit RK methods, especially for PDE, is that they require a very large algebraic solve for all stages concurrently.  However, we can use Firedrake's solver infrastructure to address this issue, and also recover most of the comparative efficiency of DIRK or explicit methods.
 
-The core of Irksome is based on UFL manipulation and so should be adaptable to work with FEniCS or other UFL-based packages, but the current version works only with Firedrake.
+The core of Irksome is based on UFL manipulation and so should be adaptable to work with FEniCS or other UFL-based packages, but the current version works only with Firedrake.  As such, it requires a working Irksome installation.  We recommend installing Irksome via the `--install irksome` option.  Given a preexisting Firedrake installation, one may obtain Irksome with options to `firedrake-update`.

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,5 @@
-import sys
 from setuptools import setup
 
-if "clean" in sys.argv[1:]:
-    pass
-else:
-    try:
-        import firedrake # noqa
-    except ImportError:
-        raise Exception("Firedrake needs to be installed and activated. "
-                        "Please visit firedrakeproject.org")
 setup(
     name='IRKsome',
     version='0.0.1',


### PR DESCRIPTION
This removes a bit of code in the installer that @JDBetteridge reports can create problems.
The (minor) downside is that one could install Irksome without Firedrake, which doesn't do much... We also update the README.md to nudge people to install with `firedrake-install`/`firedrake-update`.