### PR TITLE
Smaclachlan/unconstant

### DIFF
--- a/demos/bbm/demo_bbm.py.rst
+++ b/demos/bbm/demo_bbm.py.rst
@@ -32,7 +32,7 @@ We are mainly interested in accuracy and in conserving these quantities reasonab
 Firedrake imports::
 
   from firedrake import *
-  from irksome import Dt, GaussLegendre, TimeStepper
+  from irksome import Dt, GaussLegendre, MeshConstant, TimeStepper
 
 This function seems to be left out of UFL, but solitary wave solutions for BBM need it::
 
@@ -46,8 +46,9 @@ Set up problem parameters, etc::
   h = L / N
   msh = PeriodicIntervalMesh(N, L)
 
-  t = Constant(0)
-  dt = Constant(10*h)
+  MC = MeshConstant(msh)
+  t = MC.Constant(0)
+  dt = MC.Constant(10*h)
 
   x, = SpatialCoordinate(msh)
 

--- a/demos/cahnhilliard/demo_cahnhilliard.py.rst
+++ b/demos/cahnhilliard/demo_cahnhilliard.py.rst
@@ -36,7 +36,7 @@ Boilerplate imports::
   from firedrake import *
   import numpy as np
   import os
-  from irksome import Dt, GaussLegendre, TimeStepper
+  from irksome import Dt, GaussLegendre, MeshConstant, TimeStepper
 
 We create a directory to store some output pictures::
 
@@ -71,9 +71,10 @@ conditions is a Nitsche-type method.  Here is the parameter::
 
 Set up the time variables and a seeded initial condition::
 
-  dt = Constant(5.0e-6)
-  T = Constant(5.0e-6)
-  t = Constant(0.0)
+  MC = MeshConstant(msh)
+  dt = MC.Constant(5.0e-6)
+  T = MC.Constant(5.0e-6)
+  t = MC.Constant(0.0)
 
   np.random.seed(42)
   c = Function(V)

--- a/demos/demo_nitsche_heat.py
+++ b/demos/demo_nitsche_heat.py
@@ -2,7 +2,7 @@ from firedrake import *  # noqa: F403
 
 from ufl.algorithms.ad import expand_derivatives
 
-from irksome import LobattoIIIC, Dt, TimeStepper
+from irksome import LobattoIIIC, Dt, MeshConstant, TimeStepper
 
 ButcherTableau = LobattoIIIC(2)
 ns = ButcherTableau.num_stages
@@ -12,8 +12,9 @@ msh = UnitSquareMesh(N, N)
 V = FunctionSpace(msh, "CG", 1)
 x, y = SpatialCoordinate(msh)
 
-dt = Constant(10.0 / N, domain=msh)
-t = Constant(0.0, domain=msh)
+MC = MeshConstnt(msh)
+dt = MC.Constant(10.0 / N)
+t = MC.Constant(0.0)
 
 # This will give the exact solution at any time t.  We just have
 # to t.assign(time_we_want)

--- a/demos/dirk/demo_dirk_parameters.py.rst
+++ b/demos/dirk/demo_dirk_parameters.py.rst
@@ -70,15 +70,16 @@ Zhang, given by Butcher tableau:
 Imports from Firedrake and Irksome::
 
   from firedrake import *
-  from irksome import QinZhang, Dt, TimeStepper
+  from irksome import QinZhang, Dt, MeshConstant, TimeStepper
 
 We configure the discretization::
 
   N = 10
   msh = UnitSquareMesh(N, N)
 
-  t = Constant(0.0)
-  dt = Constant(1.0/N)
+  MC = MeshConstant(msh)
+  t = MC.Constant(0.0)
+  dt = MC.Constant(1.0/N)
 
   V = FunctionSpace(msh, "RT", 2)
   W = FunctionSpace(msh, "DG", 1)

--- a/demos/heat/demo_heat.py.rst
+++ b/demos/heat/demo_heat.py.rst
@@ -32,7 +32,7 @@ As usual, we need to import firedrake::
 
 We will also need to import certain items from irksome::
 
-  from irksome import GaussLegendre, Dt, TimeStepper
+  from irksome import GaussLegendre, Dt, MeshConstant, TimeStepper
 
 And we will need a little bit of UFL to support using the method of
 manufactured solutions::
@@ -60,8 +60,9 @@ standard Firedrake fashion::
 
 We define variables to store the time step and current time value::
 
-  dt = Constant(10.0 / N)
-  t = Constant(0.0)
+  MC = MeshConstant(msh)
+  dt = MC.Constant(10.0 / N)
+  t = MC.Constant(0.0)
 
 This defines the right-hand side using the method of manufactured solutions::
 

--- a/demos/heat/demo_heat_dirk.py.rst
+++ b/demos/heat/demo_heat_dirk.py.rst
@@ -32,7 +32,7 @@ As usual, we need to import firedrake::
 
 We will also need to import certain items from irksome::
 
-  from irksome import Alexander, Dt, TimeStepper
+  from irksome import Alexander, Dt, MeshConstant, TimeStepper
 
 And we will need a little bit of UFL to support using the method of
 manufactured solutions::
@@ -59,8 +59,9 @@ standard Firedrake fashion::
 
 We define variables to store the time step and current time value::
 
-  dt = Constant(10.0 / N)
-  t = Constant(0.0)
+  MC = MeshConstant(msh)
+  dt = MC.Constant(10.0 / N)
+  t = MC.Constant(0.0)
 
 This defines the right-hand side using the method of manufactured solutions::
 

--- a/demos/heat/demo_mixed_heat.py.rst
+++ b/demos/heat/demo_mixed_heat.py.rst
@@ -29,7 +29,7 @@ Note that this gives us a differential-algebraic system at the fully discrete le
 Standard imports, although we're using a different RK scheme this time::
 
   from firedrake import *
-  from irksome import LobattoIIIC, Dt, TimeStepper
+  from irksome import LobattoIIIC, Dt, MeshConstant, TimeStepper
   from ufl.algorithms.ad import expand_derivatives
 
   butcher_tableau = LobattoIIIC(2)
@@ -49,8 +49,9 @@ Build the mesh and approximating spaces::
 
 Create time and time-step variables::
 
-  dt = Constant(10.0 / N)
-  t = Constant(0.0)
+  MC = MeshConstant(msh)
+  dt = MC.Constant(10.0 / N)
+  t = MC.Constant(0.0)
 
 As in the first heat demo, we build the RHS via the method of
 manufactured solutions::

--- a/demos/lowlevel/demo_lowlevel_homogbc.py.rst
+++ b/demos/lowlevel/demo_lowlevel_homogbc.py.rst
@@ -14,7 +14,7 @@ Imports::
   from firedrake import *
   from ufl.algorithms.ad import expand_derivatives
 
-  from irksome import GaussLegendre, getForm, Dt
+  from irksome import GaussLegendre, getForm, Dt, MeshConstant
 
 Note that we imported :func:`.getForm` rather than :class:`.TimeStepper`.  That's the
 lower-level function inside Irksome that manipulates UFL and boundary conditions.
@@ -24,9 +24,6 @@ Continuing::
   butcher_tableau = GaussLegendre(1)
   N = 64
 
-  dt = Constant(10 / N)
-  t = Constant(0.0)
-  
   x0 = 0.0
   x1 = 10.0
   y0 = 0.0
@@ -36,6 +33,10 @@ Continuing::
   V = FunctionSpace(msh, "CG", 1)
   x, y = SpatialCoordinate(msh)
 
+  MC = MeshConstant(msh)
+  dt = MC.Constant(10 / N)
+  t = MC.Constant(0.0)
+  
   S = Constant(2.0)
   C = Constant(1000.0)
 

--- a/demos/lowlevel/demo_lowlevel_inhomogbc.py.rst
+++ b/demos/lowlevel/demo_lowlevel_inhomogbc.py.rst
@@ -11,16 +11,17 @@ Imports::
   from firedrake import *
   from ufl.algorithms.ad import expand_derivatives
 
-  from irksome import GaussLegendre, getForm, Dt
+  from irksome import GaussLegendre, getForm, Dt, MeshConstant
   
   butcher_tableau = GaussLegendre(2)
   N = 64
 
-  dt = Constant(10 / N)
-  t = Constant(0.0)
-  
   msh = UnitSquareMesh(N, N)
 
+  MC = MeshConstant(msh)
+  dt = MC.Constant(10 / N)
+  t = MC.Constant(0.0)
+  
   V = FunctionSpace(msh, "CG", 1)
   x, y = SpatialCoordinate(msh)
 

--- a/demos/lowlevel/demo_lowlevel_mixed_heat.py.rst
+++ b/demos/lowlevel/demo_lowlevel_mixed_heat.py.rst
@@ -7,7 +7,7 @@ problems on mixed function spaces.  This demo peels back the :class:`TimeStepper
 Imports::
 
   from firedrake import *
-  from irksome import LobattoIIIC, Dt, getForm
+  from irksome import LobattoIIIC, Dt, getForm, MeshConstant
   from ufl.algorithms.ad import expand_derivatives
 
   butcher_tableau = LobattoIIIC(2)
@@ -25,8 +25,9 @@ Build the mesh and approximating spaces::
   W = FunctionSpace(msh, "DG", 1)
   Z = V * W
 
-  dt = Constant(10.0 / N)
-  t = Constant(0.0)
+  MC = MeshConstant(msh)
+  dt = MC.Constant(10.0 / N)
+  t = MC.Constant(0.0)
 
   x, y = SpatialCoordinate(msh)
 

--- a/demos/mixed_wave/demo_RTwave.py.rst
+++ b/demos/mixed_wave/demo_RTwave.py.rst
@@ -36,7 +36,7 @@ Here is some typical Firedrake boilerplate and the construction of a simple
 mesh and the approximating spaces::
 
   from firedrake import *
-  from irksome import GaussLegendre, Dt, TimeStepper
+  from irksome import GaussLegendre, Dt, MeshConstant, TimeStepper
 
   N = 10
 
@@ -65,8 +65,9 @@ UFL expression and evaluating it at each time step::
 
 The time and time step variables::
 
-  t = Constant(0.0)
-  dt = Constant(1.0/N)
+  MC = MeshConstant(msh)
+  t = MC.Constant(0.0)
+  dt = MC.Constant(1.0/N)
 
 The two-stage Gauss-Legendre method is, like all instances of that family,
 A-stable and symplectic.  This gives us a fourth order method in time, although

--- a/demos/monodomain/demo_monodomain_FHN.py.rst
+++ b/demos/monodomain/demo_monodomain_FHN.py.rst
@@ -30,7 +30,7 @@ We start with standard Firedrake/Irksome imports::
   from firedrake import (And, Constant, File, Function, FunctionSpace,
                          RectangleMesh, SpatialCoordinate, TestFunctions,
                          as_matrix, conditional, dx, grad, inner, split)
-  from irksome import Dt, RadauIIA, TimeStepper
+  from irksome import Dt, MeshConstant, RadauIIA, TimeStepper
 
 And we set up the mesh and function space.  Note this demo uses serendipity elements, but could just as easily use Lagrange on quads or triangles.::
   
@@ -41,8 +41,9 @@ And we set up the mesh and function space.  Note this demo uses serendipity elem
   Z = V * V
 
   x, y = SpatialCoordinate(mesh)
-  dt = Constant(0.05)
-  t = Constant(0.0)
+  MC = MeshConstant(mesh)
+  dt = MC.Constant(0.05)
+  t = MC.Constant(0.0)
 
 Specify the physical constants and initial conditions::
 

--- a/demos/navier_stokes/demo_nse_unsteady.py
+++ b/demos/navier_stokes/demo_nse_unsteady.py
@@ -1,5 +1,5 @@
 from firedrake import *  # noqa: F403
-from irksome import GaussLegendre, getForm, Dt, TimeStepper
+from irksome import GaussLegendre, getForm, Dt, MeshConstant, TimeStepper
 import numpy
 
 
@@ -37,8 +37,9 @@ u, p = split(up)
 
 n= FacetNormal(msh)
 
-dt = Constant(1.0/1600)
-t = Constant(0.0)
+MC = MeshConstant(msh)
+dt = MC.Constant(1.0/1600)
+t = MC.Constant(0.0)
 nu = Constant(0.001)
 rho=1.0
 r=0.05

--- a/demos/navier_stokes/navier_stokes_demo.py
+++ b/demos/navier_stokes/navier_stokes_demo.py
@@ -1,5 +1,5 @@
 from firedrake import *  # noqa: F403
-from irksome import LobattoIIIC, getForm, Dt, TimeStepper
+from irksome import LobattoIIIC, getForm, Dt, MeshConstant, TimeStepper
 import numpy
 
 ButcherTableau = LobattoIIIC(3)
@@ -36,8 +36,9 @@ u, p = split(up)
 
 n= FacetNormal(msh)
 
-dt = Constant(1.0/1600)
-t = Constant(0.0)
+MC = MeshConstant(msh)
+dt = MC.Constant(1.0/1600)
+t = MC.Constant(0.0)
 nu = Constant(0.001)
 rho=1.0
 r=0.05

--- a/demos/preconditioning/demo_heat_mg.py.rst
+++ b/demos/preconditioning/demo_heat_mg.py.rst
@@ -17,7 +17,7 @@ of :math:`f` given below
 We perform similar imports and setup as before::
 
   from firedrake import *
-  from irksome import GaussLegendre, Dt, TimeStepper
+  from irksome import GaussLegendre, Dt, MeshConstant, TimeStepper
   from ufl.algorithms.ad import expand_derivatives
   butcher_tableau = GaussLegendre(2)
 
@@ -45,8 +45,9 @@ are just as for the regular heat equation demo::
 
   V = FunctionSpace(msh, "CG", 1)
 
-  dt = Constant(10.0 / N)
-  t = Constant(0.0)
+  MC = MeshConstant(msh)
+  dt = MC.Constant(10.0 / N)
+  t = MC.Constant(0.0)
 
   x, y = SpatialCoordinate(msh)
   S = Constant(2.0)

--- a/demos/preconditioning/demo_heat_pc.py.rst
+++ b/demos/preconditioning/demo_heat_pc.py.rst
@@ -42,13 +42,11 @@ Common set-up for the problem::
 
   from firedrake import *  # noqa: F403
   from ufl.algorithms.ad import expand_derivatives
-  from irksome import LobattoIIIC, TimeStepper, Dt
+  from irksome import LobattoIIIC, TimeStepper, Dt, MeshConstant
 
   butcher_tableau = LobattoIIIC(3)
 
   N = 64
-  dt = Constant(10. / N)
-  t = Constant(0.0)
 
   x0 = 0.0
   x1 = 10.0
@@ -56,6 +54,11 @@ Common set-up for the problem::
   y1 = 10.0
 
   msh = RectangleMesh(N, N, x1, y1)
+
+  MC = MeshConstant(msh)
+  dt = MC.Constant(10. / N)
+  t = MC.Constant(0.0)
+
   V = FunctionSpace(msh, "CG", 1)
   x, y = SpatialCoordinate(msh)
 

--- a/demos/preconditioning/demo_heat_rana.py.rst
+++ b/demos/preconditioning/demo_heat_rana.py.rst
@@ -41,13 +41,11 @@ Common set-up for the problem::
 
   from firedrake import *  # noqa: F403
   from ufl.algorithms.ad import expand_derivatives
-  from irksome import LobattoIIIC, TimeStepper, Dt
+  from irksome import LobattoIIIC, TimeStepper, Dt, MeshConstant
 
   butcher_tableau = LobattoIIIC(3)
 
   N = 16
-  dt = Constant(10. / N)
-  t = Constant(0.0)
 
   x0 = 0.0
   x1 = 10.0
@@ -55,6 +53,11 @@ Common set-up for the problem::
   y1 = 10.0
 
   msh = RectangleMesh(N, N, x1, y1)
+
+  MC = MeshConstant(msh)
+  dt = MC.Constant(10. / N)
+  t = MC.Constant(0.0)
+
   V = FunctionSpace(msh, "CG", 1)
   x, y = SpatialCoordinate(msh)
 

--- a/irksome/__init__.py
+++ b/irksome/__init__.py
@@ -13,3 +13,4 @@ from .imex import RadauIIAIMEXMethod          # noqa: F401
 from .pc import RanaBase, RanaDU, RanaLD      # noqa: F401
 from .stage import StageValueTimeStepper      # noqa: F401
 from .stepper import TimeStepper              # noqa: F401
+from .tools import MeshConstant               # noqa: F401

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -1,5 +1,5 @@
 import numpy
-from firedrake import MixedVectorSpaceBasis, split
+from firedrake import Function, FunctionSpace, MixedVectorSpaceBasis, split
 from ufl.algorithms.analysis import extract_type, has_exact_type
 from ufl.algorithms.map_integrands import map_integrand_dags
 from ufl.classes import CoefficientDerivative
@@ -106,3 +106,13 @@ def is_ode(f, u):
     Dtbits = set(b.ufl_operands[0] for b in blah)
     ubits = set(split(u))
     return Dtbits == ubits
+
+
+# Utility class for constants on a mesh
+class MeshConstant(object):
+    def __init__(self, msh):
+        self.msh = msh
+        self.V = FunctionSpace(msh, 'R', 0)
+
+    def Constant(self, val=0.0):
+        return Function(self.V).assign(val)

--- a/tests/demos/test_demos_run.py
+++ b/tests/demos/test_demos_run.py
@@ -8,7 +8,7 @@ import sys
 
 cwd = abspath(dirname(__file__))
 demo_dir = join(cwd, "..", "..", "demos")
-pylit = join(os.environ["VIRTUAL_ENV"], "src", "firedrake", "pylit", "pylit.py")
+pylit = "pylit"
 
 
 # Discover the demo files by globbing the demo directory

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -5,7 +5,7 @@ from firedrake import (diff, div, dx, errornorm, exp, grad,
                        Constant, DirichletBC, FunctionSpace,
                        SpatialCoordinate, TestFunction, UnitIntervalMesh)
 
-from irksome import Dt, TimeStepper, GaussLegendre
+from irksome import Dt, MeshConstant, TimeStepper, GaussLegendre
 from irksome.tools import IA
 from ufl.algorithms import expand_derivatives
 
@@ -24,8 +24,9 @@ def heat(n, deg, time_stages, stage_type="deriv", splitting=IA):
     V = FunctionSpace(msh, "CG", deg)
     x, = SpatialCoordinate(msh)
 
-    t = Constant(0.0, domain=msh)
-    dt = Constant(2.0 / N, domain=msh)
+    MC = MeshConstant(msh)
+    t = MC.Constant(0.0)
+    dt = MC.Constant(2.0 / N)
 
     uexact = exp(-t) * sin(pi * x)
     rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))

--- a/tests/test_appctx.py
+++ b/tests/test_appctx.py
@@ -1,5 +1,5 @@
-from firedrake import dx, inner, Constant, Function, FunctionSpace, TestFunction, UnitIntervalMesh
-from irksome import Dt, GaussLegendre, TimeStepper
+from firedrake import dx, inner, Function, FunctionSpace, TestFunction, UnitIntervalMesh
+from irksome import Dt, GaussLegendre, MeshConstant, TimeStepper
 
 
 def test_appctx():
@@ -11,8 +11,10 @@ def test_appctx():
     F = inner(Dt(u) + u, v) * dx
 
     bt = GaussLegendre(1)
-    t = Constant(0.0)
-    dt = Constant(0.1)
+
+    MC = MeshConstant(msh)
+    t = MC.Constant(0.0)
+    dt = MC.Constant(0.1)
 
     stepper = TimeStepper(F, bt, t, dt, u, appctx={"hello": "world"})
     assert "hello" in stepper.solver._ctx.appctx

--- a/tests/test_curl.py
+++ b/tests/test_curl.py
@@ -1,6 +1,6 @@
 import pytest
 from firedrake import *
-from irksome import GaussLegendre, Dt, TimeStepper
+from irksome import GaussLegendre, Dt, MeshConstant, TimeStepper
 from irksome.tools import AI, IA
 from ufl.algorithms.ad import expand_derivatives
 
@@ -17,8 +17,9 @@ def curltest(N, deg, butcher_tableau, splitting):
     Ve = FiniteElement("N1curl", msh.ufl_cell(), 2, variant="integral")
     V = FunctionSpace(msh, Ve)
 
-    dt = Constant(0.1 / N)
-    t = Constant(0.0)
+    MC = MeshConstant(msh)
+    dt = MC.Constant(0.1 / N)
+    t = MC.Constant(0.0)
 
     x, y = SpatialCoordinate(msh)
 

--- a/tests/test_dirichletbc.py
+++ b/tests/test_dirichletbc.py
@@ -1,7 +1,7 @@
 import pytest
 from firedrake import *
 from math import isclose
-from irksome import LobattoIIIA, GaussLegendre, Dt, TimeStepper
+from irksome import LobattoIIIA, GaussLegendre, Dt, MeshConstant, TimeStepper
 from ufl.algorithms.ad import expand_derivatives
 
 
@@ -18,8 +18,9 @@ def test_1d_heat_dirichletbc(butcher_tableau, stage_type):
     x1 = 10.0
     msh = IntervalMesh(N, x1)
     V = FunctionSpace(msh, "CG", 1)
-    dt = Constant(10.0 / N)
-    t = Constant(0.0)
+    MC = MeshConstant(msh)
+    dt = MC.Constant(10.0 / N)
+    t = MC.Constant(0.0)
     (x,) = SpatialCoordinate(msh)
 
     # Method of manufactured solutions copied from Heat equation demo.

--- a/tests/test_dirk.py
+++ b/tests/test_dirk.py
@@ -1,6 +1,6 @@
 import pytest
 from firedrake import *
-from irksome import Alexander, Dt, TimeStepper
+from irksome import Alexander, Dt, MeshConstant, TimeStepper
 from math import isclose
 from ufl.algorithms.ad import expand_derivatives
 from ufl import replace
@@ -17,8 +17,9 @@ def test_1d_heat_dirichletbc(butcher_tableau):
     x1 = 10.0
     msh = IntervalMesh(N, x1)
     V = FunctionSpace(msh, "CG", 1)
-    dt = Constant(1.0 / N)
-    t = Constant(0.0)
+    MC = MeshConstant(msh)
+    dt = MC.Constant(1.0 / N)
+    t = MC.Constant(0.0)
     (x,) = SpatialCoordinate(msh)
 
     # Method of manufactured solutions copied from Heat equation demo.
@@ -70,8 +71,9 @@ def test_1d_heat_neumannbc(butcher_tableau):
     N = 20
     msh = UnitIntervalMesh(N)
     V = FunctionSpace(msh, "CG", 1)
-    dt = Constant(1.0 / N)
-    t = Constant(0.0)
+    MC = MeshConstant(msh)
+    dt = MC.Constant(1.0 / N)
+    t = MC.Constant(0.0)
     (x,) = SpatialCoordinate(msh)
 
     uexact = cos(pi*x)*exp(-(pi**2)*t)
@@ -111,8 +113,9 @@ def test_1d_heat_homogdbc(butcher_tableau):
     N = 20
     msh = UnitIntervalMesh(N)
     V = FunctionSpace(msh, "CG", 1)
-    dt = Constant(1.0 / N)
-    t = Constant(0.0)
+    MC = MeshConstant(msh)
+    dt = MC.Constant(1.0 / N)
+    t = MC.Constant(0.0)
     (x,) = SpatialCoordinate(msh)
 
     uexact = sin(pi*x)*exp(-(pi**2)*t)
@@ -156,8 +159,9 @@ def test_1d_vectorheat_componentBC(butcher_tableau):
     N = 20
     msh = UnitIntervalMesh(N)
     V = VectorFunctionSpace(msh, "CG", 1, dim=2)
-    dt = Constant(1.0 / N)
-    t = Constant(0.0)
+    MC = MeshConstant(msh)
+    dt = MC.Constant(1.0 / N)
+    t = MC.Constant(0.0)
     (x,) = SpatialCoordinate(msh)
 
     uexact = as_vector([sin(pi*x/2)*exp(-(pi**2)*t/4),
@@ -219,8 +223,9 @@ def test_stokes_bcs(butcher_tableau, bctype):
     Ze = MixedElement([Ve, Pe])
     Z = FunctionSpace(mesh, Ze)
 
-    t = Constant(0.0)
-    dt = Constant(1.0/N)
+    MC = MeshConstant(mesh)
+    t = MC.Constant(0.0)
+    dt = MC.Constant(1.0/N)
     (x, y) = SpatialCoordinate(mesh)
 
     uexact = as_vector([x*t + y**2, -y*t+t*(x**2)])

--- a/tests/test_inhomogbc.py
+++ b/tests/test_inhomogbc.py
@@ -1,15 +1,16 @@
 import pytest
 from firedrake import *
 from ufl.algorithms.ad import expand_derivatives
-from irksome import Dt, TimeStepper, RadauIIA, GaussLegendre
+from irksome import Dt, MeshConstant, TimeStepper, RadauIIA, GaussLegendre
 from irksome.tools import AI, IA
 
 
 def heat_inhomog(N, deg, butcher_tableau, stage_type, splitting):
-    dt = Constant(1.0 / N)
-    t = Constant(0.0)
-
     msh = UnitSquareMesh(N, N)
+
+    MC = MeshConstant(msh)
+    dt = MC.Constant(1.0 / N)
+    t = MC.Constant(0.0)
 
     V = FunctionSpace(msh, "CG", 1)
     x, y = SpatialCoordinate(msh)

--- a/tests/test_pc.py
+++ b/tests/test_pc.py
@@ -1,9 +1,9 @@
 import numpy
 import pytest
-from firedrake import (Constant, DirichletBC, FunctionSpace, SpatialCoordinate,
+from firedrake import (DirichletBC, FunctionSpace, SpatialCoordinate,
                        TestFunction, UnitSquareMesh, diff, div, dx, errornorm,
                        grad, inner, interpolate)
-from irksome import Dt, LobattoIIIC, RadauIIA, TimeStepper
+from irksome import Dt, MeshConstant, LobattoIIIC, RadauIIA, TimeStepper
 from ufl.algorithms.ad import expand_derivatives
 
 # Tests that various PCs are actually getting the right answer.
@@ -21,10 +21,12 @@ def Fubc(V, uexact, rhs):
 
 def heat(butcher_tableau):
     N = 4
-    dt = Constant(1.0 / N)
-    t = Constant(0.0)
-
     msh = UnitSquareMesh(N, N)
+
+    MC = MeshConstant(msh)
+    dt = MC.Constant(1.0 / N)
+    t = MC.Constant(0.0)
+
     deg = 2
     V = FunctionSpace(msh, "CG", deg)
 

--- a/tests/test_rtcf.py
+++ b/tests/test_rtcf.py
@@ -1,6 +1,6 @@
 import pytest
 from firedrake import *
-from irksome import GaussLegendre, Dt, TimeStepper
+from irksome import GaussLegendre, Dt, MeshConstant, TimeStepper
 from irksome.tools import AI, IA
 from ufl.algorithms.ad import expand_derivatives
 
@@ -17,8 +17,9 @@ def RTCFtest(N, deg, butcher_tableau, splitting=AI):
     Ve = FiniteElement("RTCF", msh.ufl_cell(), 2)
     V = FunctionSpace(msh, Ve)
 
-    dt = Constant(0.1 / N)
-    t = Constant(0.0)
+    MC = MeshConstant(msh)
+    dt = MC.Constant(0.1 / N)
+    t = MC.Constant(0.0)
 
     x, y = SpatialCoordinate(msh)
 

--- a/tests/test_split.py
+++ b/tests/test_split.py
@@ -5,7 +5,7 @@ from firedrake import (Constant, DirichletBC, FiniteElement, Function,
                        UnitSquareMesh, VectorElement, VectorSpaceBasis, action,
                        as_vector, assemble, derivative, div, dot, dx,
                        errornorm, grad, inner, interpolate, pi, sin, split)
-from irksome import Dt, RadauIIA, TimeStepper
+from irksome import Dt, MeshConstant, RadauIIA, TimeStepper
 from irksome.tools import AI, IA
 
 
@@ -19,8 +19,9 @@ def test_diffreact(splitting):
     k = 2
     bt = RadauIIA(k)
 
-    dt = Constant(1.0 / N)
-    t = Constant(0.0)
+    MC = MeshConstant(msh)
+    dt = MC.Constant(1.0 / N)
+    t = MC.Constant(0.0)
     (x,) = SpatialCoordinate(msh)
 
     uIC = 2 + sin(2 * pi * x)
@@ -119,8 +120,9 @@ def NavierStokesSplitTest(N, num_stages, Fimp, Fexp):
     Ze = MixedElement([Ve, Pe])
     Z = FunctionSpace(mesh, Ze)
 
-    t = Constant(0.0)
-    dt = Constant(0.5 / N)
+    MC = MeshConstant(mesh)
+    t = MC.Constant(0.0)
+    dt = MC.Constant(0.5 / N)
 
     z_imp = Function(Z)
     z_split = Function(Z)

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -18,7 +18,9 @@ def StokesTest(N, butcher_tableau, stage_type="deriv", splitting=AI):
     Ze = MixedElement([Ve, Pe])
     Z = FunctionSpace(mesh, Ze)
 
-    t = Constant(0.0)
+    Tspace = FunctionSpace(mesh, 'R', 0)
+    t = Function(Tspace)
+    t.assign(0)
     dt = Constant(1.0/N)
     (x, y) = SpatialCoordinate(mesh)
 
@@ -115,7 +117,9 @@ def NSETest(butch, stage_type, splitting):
                          "pc_type": "lu",
                          "pc_factor_mat_solver_type": "mumps"}
 
-    t = Constant(0.0)
+    Tspace = FunctionSpace(M, 'R', 0)
+    t = Function(Tspace)
+    t.assign(0)
     dt = Constant(1.0/N)
     stepper = TimeStepper(F, butch,
                           t, dt, up,

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -1,6 +1,6 @@
 import pytest
 from firedrake import *
-from irksome import Dt, LobattoIIIC, RadauIIA, TimeStepper
+from irksome import Dt, LobattoIIIC, MeshConstant, RadauIIA, TimeStepper
 from irksome.tools import AI, IA
 from ufl.algorithms import expand_derivatives
 
@@ -18,10 +18,9 @@ def StokesTest(N, butcher_tableau, stage_type="deriv", splitting=AI):
     Ze = MixedElement([Ve, Pe])
     Z = FunctionSpace(mesh, Ze)
 
-    Tspace = FunctionSpace(mesh, 'R', 0)
-    t = Function(Tspace)
-    t.assign(0)
-    dt = Constant(1.0/N)
+    MC = MeshConstant(mesh)
+    t = MC.Constant(0.0)
+    dt = MC.Constant(1.0/N)
     (x, y) = SpatialCoordinate(mesh)
 
     uexact = as_vector([x*t + y**2, -y*t+t*(x**2)])
@@ -117,10 +116,9 @@ def NSETest(butch, stage_type, splitting):
                          "pc_type": "lu",
                          "pc_factor_mat_solver_type": "mumps"}
 
-    Tspace = FunctionSpace(M, 'R', 0)
-    t = Function(Tspace)
-    t.assign(0)
-    dt = Constant(1.0/N)
+    MC = MeshConstant(M)
+    t = MC.Constant(0.0)
+    dt = MC.Constant(1.0/N)
     stepper = TimeStepper(F, butch,
                           t, dt, up,
                           bcs=bcs,

--- a/tests/test_subdomainbc.py
+++ b/tests/test_subdomainbc.py
@@ -1,15 +1,16 @@
 import pytest
 from firedrake import *
-from irksome import GaussLegendre, Dt, TimeStepper
+from irksome import GaussLegendre, Dt, MeshConstant, TimeStepper
 from irksome.tools import AI, IA
 from ufl.algorithms.ad import expand_derivatives
 
 
 def heat_subdomainbc(N, deg, butcher_tableau, splitting=AI):
-    dt = Constant(1.0 / N)
-    t = Constant(0.0)
-
     msh = UnitSquareMesh(N, N)
+
+    MC = MeshConstant(msh)
+    dt = MC.Constant(1.0 / N)
+    t = MC.Constant(0.0)
 
     V = FunctionSpace(msh, "CG", deg)
     x, y = SpatialCoordinate(msh)
@@ -43,10 +44,11 @@ def heat_subdomainbc(N, deg, butcher_tableau, splitting=AI):
 
 
 def heat_componentbc(N, deg, butcher_tableau, splitting=AI):
-    dt = Constant(1.0 / N)
-    t = Constant(0.0)
-
     msh = UnitIntervalMesh(N)
+
+    MC = MeshConstant(msh)
+    dt = MC.Constant(1.0 / N)
+    t = MC.Constant(0.0)
 
     V = VectorFunctionSpace(msh, "CG", deg, dim=2)
     (x,) = SpatialCoordinate(msh)

--- a/tests/test_vecbc.py
+++ b/tests/test_vecbc.py
@@ -1,15 +1,16 @@
 import pytest
 from firedrake import *
-from irksome import GaussLegendre, Dt, TimeStepper
+from irksome import GaussLegendre, Dt, MeshConstant, TimeStepper
 from irksome.tools import AI, IA
 
 
 def elastodynamics(N, deg, butcher_tableau, splitting=AI):
-    dt = Constant(1.0 / N)
-    t = Constant(0.0)
-
     msh = UnitSquareMesh(N, N)
     x, y = SpatialCoordinate(msh)
+
+    MC = MeshConstant(msh)
+    dt = MC.Constant(1.0 / N)
+    t = MC.Constant(0.0)
 
     V = VectorFunctionSpace(msh, "CG", 1)
     VV = V * V

--- a/tests/test_wave_energy.py
+++ b/tests/test_wave_energy.py
@@ -2,9 +2,9 @@ import pytest
 import numpy as np
 from firedrake import (inner, dx, UnitIntervalMesh, FunctionSpace,
                        assemble, TestFunctions, SpatialCoordinate,
-                       Constant, project, as_vector, sin, pi, split)
+                       project, as_vector, sin, pi, split)
 
-from irksome import Dt, TimeStepper, GaussLegendre
+from irksome import Dt, MeshConstant, TimeStepper, GaussLegendre
 from irksome.tools import AI, IA
 
 # test the energy conservation of the 1d wave equation in mixed form
@@ -26,8 +26,9 @@ def wave(n, deg, butcher_tableau, splitting=AI):
 
     x, = SpatialCoordinate(msh)
 
-    t = Constant(0.0)
-    dt = Constant(2.0 / N)
+    MC = MeshConstant(msh)
+    t = MC.Constant(0.0)
+    dt = MC.Constant(2.0 / N)
 
     up = project(as_vector([0, sin(pi*x)]), Z)
     u, p = split(up)


### PR DESCRIPTION
Using `Constant` for time and dt is now not supported by firedrake, so this PR introduces a `MeshConstant` in `irksome/tools.py` and uses that instead.

Also fixes a change to install `pylit` via pip instead of within the firedrake src dir.