### PR TITLE
Missed one hardcoded pylit

### DIFF
--- a/demos/Makefile
+++ b/demos/Makefile
@@ -1,4 +1,4 @@
 .PHONY: demos
 
 demos:
-	for file in */*.py.rst; do ${VIRTUAL_ENV}/src/firedrake/pylit/pylit.py $$file; done
+	for file in */*.py.rst; do pylit $$file; done


### PR DESCRIPTION
Like the title says, I missed one instance of a hardcoded `pylit` path in #73 . This fixes it.