### PR TITLE
Ensure DOFs are ordered by coordinate

### DIFF
--- a/tests/test_time_form_splitting.py
+++ b/tests/test_time_form_splitting.py
@@ -1,8 +1,9 @@
 import pytest
 from irksome import Dt
 from irksome.manipulation import check_integrals, extract_terms
-from ufl import (Coefficient, FiniteElement, FunctionSpace, Mesh, MixedElement,
-                 TestFunction, VectorElement, dx, grad, inner, sin, triangle)
+from ufl import (Coefficient, FunctionSpace, Mesh,
+                 TestFunction, dx, grad, inner, sin, triangle)
+from finat.ufl import FiniteElement, MixedElement, VectorElement
 from ufl.algorithms.domain_analysis import group_form_integrals
 
 


### PR DESCRIPTION
After https://github.com/firedrakeproject/fiat/pull/49 GLL DOFs inherit the same ordering as Lagrange, which is no longer by coordinate, but now vertex DOFs are ordered first, followed by the interior DOFs. This PR should fix the failing tests.

fixes #76