### PR TITLE
Removing Constant domains everywhere I can find them

### DIFF
--- a/demos/demo_nitsche_heat.py
+++ b/demos/demo_nitsche_heat.py
@@ -12,7 +12,7 @@ msh = UnitSquareMesh(N, N)
 V = FunctionSpace(msh, "CG", 1)
 x, y = SpatialCoordinate(msh)
 
-MC = MeshConstnt(msh)
+MC = MeshConstant(msh)
 dt = MC.Constant(10.0 / N)
 t = MC.Constant(0.0)
 
@@ -28,7 +28,7 @@ u = interpolate(uexact, V)
 # define the variational form once outside the loop
 h = CellSize(msh)
 n = FacetNormal(msh)
-beta = Constant(100.0, domain=msh)
+beta = Constant(100.0)
 v = TestFunction(V)
 F = (inner(Dt(u), v)*dx + inner(grad(u), grad(v))*dx - inner(rhs, v) * dx
      - inner(dot(grad(u), n), v) * ds

--- a/irksome/dirk_stepper.py
+++ b/irksome/dirk_stepper.py
@@ -1,12 +1,12 @@
 import numpy
-from firedrake import Constant, DirichletBC, Function
+from firedrake import DirichletBC, Function
 from firedrake import NonlinearVariationalProblem as NLVP
 from firedrake import NonlinearVariationalSolver as NLVS
 from firedrake import interpolate, split
 from ufl.constantvalue import as_ufl
 
 from .deriv import TimeDerivative
-from .tools import replace
+from .tools import replace, MeshConstant
 
 
 class BCThingy:
@@ -89,8 +89,9 @@ def getFormDIRK(F, butch, t, dt, u0, bcs=None):
     # variational form and BC's, and we update it for each stage in
     # the loop over stages in the advance method.  The Constant a is
     # used similarly in the variational form
-    c = Constant(1.0, domain=msh)
-    a = Constant(1.0, domain=msh)
+    MC = MeshConstant(msh)
+    c = MC.Constant(1.0)
+    a = MC.Constant(1.0)
 
     repl = {t: t+c*dt}
     for u0bit, kbit, gbit in zip(u0bits, k_bits, gbits):

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -1,13 +1,13 @@
 import FIAT
 import numpy as np
-from firedrake import (Constant, Function, NonlinearVariationalProblem,
+from firedrake import (Function, NonlinearVariationalProblem,
                        NonlinearVariationalSolver, TestFunction)
 from firedrake.dmhooks import pop_parent, push_parent
 from ufl.classes import Zero
 
 from .ButcherTableaux import RadauIIA
 from .stage import getBits, getFormStage
-from .tools import AI, IA, replace
+from .tools import AI, IA, MeshConstant, replace
 
 
 def riia_explicit_coeffs(k):
@@ -45,7 +45,8 @@ def getFormExplicit(Fexp, butch, u0, UU, t, dt, splitting=None):
 
     num_stages = butch.num_stages
     num_fields = len(V)
-    vc = np.vectorize(lambda c: Constant(c, domain=msh))
+    MC = MeshConstant(msh)
+    vc = np.vectorize(lambda c: MC.Constant(c))
     Aexp = riia_explicit_coeffs(num_stages)
     Aprop = vc(Aexp)
     Ait = vc(butch.A)

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 from firedrake import (diff, div, dx, errornorm, exp, grad,
                        inner, norm, pi, project, sin,
-                       Constant, DirichletBC, FunctionSpace,
+                       DirichletBC, FunctionSpace,
                        SpatialCoordinate, TestFunction, UnitIntervalMesh)
 
 from irksome import Dt, MeshConstant, TimeStepper, GaussLegendre
@@ -40,7 +40,7 @@ def heat(n, deg, time_stages, stage_type="deriv", splitting=IA):
     F = (inner(Dt(u), v) * dx + inner(grad(u), grad(v)) * dx
          - inner(rhs, v) * dx)
 
-    bc = DirichletBC(V, Constant(0, domain=msh), "on_boundary")
+    bc = DirichletBC(V, MC.Constant(0), "on_boundary")
 
     stepper = TimeStepper(F, butcher_tableau, t, dt, u,
                           bcs=bc, solver_parameters=params,


### PR DESCRIPTION
In #73 , we removed `Constant` for all of our `time` and `dt` objects, by introducing `MeshConstant` in `irksome/tools.py`.  This finishes(?) that job, by removing other places where we assigning constants with domains, and using `MeshConstant` for all of these