### PR TITLE
Specify that build runners run Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   test:
-    runs-on: self-hosted
+    runs-on: [self-hosted, Linux]
     container:
       image: docker://firedrakeproject/firedrake-vanilla:latest
 


### PR DESCRIPTION
This is in preparation for the rollout of Mac build runners.