### PR TITLE
fix solver options for explicit solver

### DIFF
--- a/irksome/explicit_stepper.py
+++ b/irksome/explicit_stepper.py
@@ -11,6 +11,7 @@ class ExplicitTimeStepper(DIRKTimeStepper):
         assert butcher_tableau.is_explicit
         # we just have one mass matrix we're reusing for each time step and
         # each stage, so we can nudge this along
+        solver_parameters = {} if solver_parameters is None else solver_parameters
         solver_parameters["snes_lag_jacobian_persists"] = "true"
         solver_parameters["snes_lag_jacobian"] = -2
         solver_parameters["snes_lag_preconditioner_persists"] = "true"


### PR DESCRIPTION
If one passed `solver_parameters=None` into an explicit stepper, it's rewriting the Jacobian/PC options should fail.  This converts the `None` into an empty dictionary.