### PR TITLE
Fix DIRK boundary conditions

### DIFF
--- a/irksome/dirk_stepper.py
+++ b/irksome/dirk_stepper.py
@@ -132,6 +132,12 @@ class DIRKTimeStepper:
         self.bc_constants = a_vals, d_val
 
     def update_bc_constants(self, i, c):
+        """This sets the BCs that are imposed on the solution at stage i.  In
+           the DIRK case, we say that the stage i solution should match the
+           prescribed boundary values at time c[i].  So, we set c to be the i^th
+           stage time, and a_vals and d_vals to correspond to the i^th row of A
+        """
+
         AAb = self.AAb
         CCone = self.CCone
         a_vals, d_val = self.bc_constants

--- a/irksome/explicit_stepper.py
+++ b/irksome/explicit_stepper.py
@@ -26,6 +26,16 @@ class ExplicitTimeStepper(DIRKTimeStepper):
     # stage for all but that last stage, and that they are satisfied
     # for the next timestep for the last stage.
     def update_bc_constants(self, i, c):
+        """This sets the BCs that are imposed on the solution at stage i.  In
+           the explicit case, we say that the stage i solution should
+           match the prescribed boundary values at time c[i+1], and at
+           the next time step for the last stage.  So, we set c to be
+           the (i+1)^st stage time, and a_vals and d_vals to
+           correspond to the (i+1)^st row of A.  For the last stage,
+           we use c = 1 for the next time-step, and use the row b to
+           impose the final solution satisfies the BCs there.
+        """
+
         AAb = self.AAb
         CCone = self.CCone
         a_vals, d_val = self.bc_constants

--- a/irksome/explicit_stepper.py
+++ b/irksome/explicit_stepper.py
@@ -25,7 +25,10 @@ class ExplicitTimeStepper(DIRKTimeStepper):
     # we should impose the BCs so that they are satisfied for the next
     # stage for all but that last stage, and that they are satisfied
     # for the next timestep for the last stage.
-    def update_bc_constants(self, AAb, CCone, i, a_vals, d_val, c):
+    def update_bc_constants(self, i, c):
+        AAb = self.AAb
+        CCone = self.CCone
+        a_vals, d_val = self.bc_constants
         ns = AAb.shape[1]
         for j in range(i):
             a_vals[j].assign(AAb[i+1, j])

--- a/irksome/explicit_stepper.py
+++ b/irksome/explicit_stepper.py
@@ -20,29 +20,3 @@ class ExplicitTimeStepper(DIRKTimeStepper):
             F, butcher_tableau, t, dt, u0, bcs=bcs,
             solver_parameters=solver_parameters, appctx=appctx,
             nullspace=None)
-
-    # DAE treatment of the boundary conditions in this case says that
-    # we should impose the BCs so that they are satisfied for the next
-    # stage for all but that last stage, and that they are satisfied
-    # for the next timestep for the last stage.
-    def update_bc_constants(self, i, c):
-        """This sets the BCs that are imposed on the solution at stage i.  In
-           the explicit case, we say that the stage i solution should
-           match the prescribed boundary values at time c[i+1], and at
-           the next time step for the last stage.  So, we set c to be
-           the (i+1)^st stage time, and a_vals and d_vals to
-           correspond to the (i+1)^st row of A.  For the last stage,
-           we use c = 1 for the next time-step, and use the row b to
-           impose the final solution satisfies the BCs there.
-        """
-
-        AAb = self.AAb
-        CCone = self.CCone
-        a_vals, d_val = self.bc_constants
-        ns = AAb.shape[1]
-        for j in range(i):
-            a_vals[j].assign(AAb[i+1, j])
-        for j in range(i, ns):
-            a_vals[j].assign(0)
-        d_val.assign(AAb[i+1, i])
-        c.assign(CCone[i+1])

--- a/irksome/explicit_stepper.py
+++ b/irksome/explicit_stepper.py
@@ -20,3 +20,16 @@ class ExplicitTimeStepper(DIRKTimeStepper):
             F, butcher_tableau, t, dt, u0, bcs=bcs,
             solver_parameters=solver_parameters, appctx=appctx,
             nullspace=None)
+
+    # DAE treatment of the boundary conditions in this case says that
+    # we should impose the BCs so that they are satisfied for the next
+    # stage for all but that last stage, and that they are satisfied
+    # for the next timestep for the last stage.
+    def update_bc_constants(self, AAb, CCone, i, a_vals, d_val, c):
+        ns = AAb.shape[1]
+        for j in range(i):
+            a_vals[j].assign(AAb[i+1, j])
+        for j in range(i, ns):
+            a_vals[j].assign(0)
+        d_val.assign(AAb[i+1, i])
+        c.assign(CCone[i+1])

--- a/tests/test_explicit.py
+++ b/tests/test_explicit.py
@@ -8,6 +8,11 @@ from ufl.algorithms.ad import expand_derivatives
 peprks = [PEPRK(*x) for x in ((4, 2, 5), (5, 2, 6))]
 
 
+# Note that this test is constructed with dt small enough relative to
+# dx that these explicit methods stay stable -- while Irksome provides
+# support for explicit schemes, we also caution users that there are
+# no checks in the code that the method you are trying to run is
+# actually sensible!
 @pytest.mark.parametrize("butcher_tableau", peprks)
 def test_1d_heat_dirichletbc(butcher_tableau):
     # Boundary values

--- a/tests/test_explicit.py
+++ b/tests/test_explicit.py
@@ -1,0 +1,69 @@
+from math import isclose
+
+import pytest
+from firedrake import *
+from irksome import PEPRK, Dt, MeshConstant, TimeStepper
+from ufl.algorithms.ad import expand_derivatives
+
+peprks = [PEPRK(*x) for x in ((4, 2, 5), (5, 2, 6))]
+
+
+@pytest.mark.parametrize("butcher_tableau", peprks)
+def test_1d_heat_dirichletbc(butcher_tableau):
+    # Boundary values
+    u_0 = Constant(2.0)
+    u_1 = Constant(3.0)
+
+    N = 10
+    x0 = 0.0
+    x1 = 10.0
+    msh = IntervalMesh(N, x1)
+    V = FunctionSpace(msh, "CG", 1)
+    MC = MeshConstant(msh)
+    dt = MC.Constant(1.0 / N)
+    t = MC.Constant(0.0)
+    (x,) = SpatialCoordinate(msh)
+
+    # Method of manufactured solutions copied from Heat equation demo.
+    S = Constant(2.0)
+    C = Constant(1000.0)
+    B = (x - Constant(x0)) * (x - Constant(x1)) / C
+    R = (x * x) ** 0.5
+    # Note end linear contribution
+    uexact = (
+        B * atan(t) * (pi / 2.0 - atan(S * (R - t)))
+        + u_0
+        + ((x - x0) / x1) * (u_1 - u_0)
+    )
+    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+    u = Function(V)
+    u.interpolate(uexact)
+    v = TestFunction(V)
+    F = (
+        inner(Dt(u), v) * dx
+        + inner(grad(u), grad(v)) * dx
+        - inner(rhs, v) * dx
+    )
+    bc = [
+        DirichletBC(V, u_1, 2),
+        DirichletBC(V, u_0, 1),
+    ]
+
+    luparams = {"mat_type": "aij", "ksp_type": "preonly", "pc_type": "lu"}
+
+    stepper = TimeStepper(
+        F, butcher_tableau, t, dt, u, bcs=bc,
+        solver_parameters=luparams,
+        stage_type="explicit"
+    )
+
+    t_end = 2.0
+    while float(t) < t_end:
+        if float(t) + float(dt) > t_end:
+            dt.assign(t_end - float(t))
+        stepper.advance()
+        t.assign(float(t) + float(dt))
+        # Check solution and boundary values
+        assert errornorm(uexact, u) / norm(uexact) < 10.0 ** -3
+        assert isclose(u.at(x0), u_0)
+        assert isclose(u.at(x1), u_1)


### PR DESCRIPTION
When BCs were refactored in #98, the DIRK case was left untouched.

This PR aims to correct that, as well as addressing the root problem in #102, where we don't implement the correct DAE-style BCs for explicit schemes

fixes #102