### PR TITLE
Add DIRK-IMEX schemes

### DIFF
--- a/demos/monodomain/demo_monodomain_FHN.py.rst
+++ b/demos/monodomain/demo_monodomain_FHN.py.rst
@@ -8,7 +8,7 @@ The basic form of the equation is:
 
    \chi \left( C_m u_t + I_{ion}(u) \right) = \nabla \cdot \sigma \nabla u
 
-where :math:`u` is the membrane potential, :math:`\sigma` is the conductivity tensor, :math:`C_m` is the specific capacitance of the cell membrane, and :math:`\chi` is the surface area to volume ration.  The term :math:`I_{ion}` is current due to ionic flows through channels in the cell membranes, and may couple to a complicated reaction network.  In our case, we take the relatively simple model due to Fitzhugh and Nagumo.  Here, we have a separate concentration variable :math:`c` satisfying the reaction equation:
+where :math:`u` is the membrane potential, :math:`\sigma` is the conductivity tensor, :math:`C_m` is the specific capacitance of the cell membrane, and :math:`\chi` is the surface area to volume ratio.  The term :math:`I_{ion}` is current due to ionic flows through channels in the cell membranes, and may couple to a complicated reaction network.  In our case, we take the relatively simple model due to Fitzhugh and Nagumo.  Here, we have a separate concentration variable :math:`c` satisfying the reaction equation:
 
 .. math::
 
@@ -58,15 +58,15 @@ Specify the physical constants and initial conditions::
   sigma = as_matrix([[sigma1, 0.0], [0.0, sigma2]])
 
   
-  InitialPotential = conditional(x < 3.5, Constant(2.0), Constant(-1.28791))
-  InitialCell = conditional(And(And(31 <= x, x < 39), And(0 <= y, y < 35)),
+  initial_potential = conditional(x < 3.5, Constant(2.0), Constant(-1.28791))
+  initial_cell = conditional(And(And(31 <= x, x < 39), And(0 <= y, y < 35)),
                             Constant(2.0), Constant(-0.5758))
 
 
   uu = Function(Z)
   vu, vc = TestFunctions(Z)
-  uu.sub(0).interpolate(InitialPotential)
-  uu.sub(1).interpolate(InitialCell)
+  uu.sub(0).interpolate(initial_potential)
+  uu.sub(1).interpolate(initial_cell)
 
   (u, c) = split(uu)
   

--- a/demos/monodomain/demo_monodomain_FHN_dirkimex.py.rst
+++ b/demos/monodomain/demo_monodomain_FHN_dirkimex.py.rst
@@ -145,10 +145,13 @@ Now, we access the IMEX method via the `TimeStepper` as with other methods.  Not
           outfile1.write(uFinal, time=j * float(dt))
           outfile2.write(cFinal, time=j * float(dt))
 
+
+We can print out some solver statistics here.  We expect one implicit solve per stage per timestep, and that's what we see with the four-stage method.  For this Butcher Tableau, we can avoid computing the final explicit stage (since it's coefficient in the next stage reconstruction is zero), so we see the same number of mass solves.::
+
   nsteps, n_nonlin, n_lin, n_nonlin_mass, n_lin_mass = stepper.solver_stats()
   print(f"Time steps taken: {nsteps}")
   print(f"  {n_nonlin} nonlinear steps in implicit stage solves (should be {nsteps*ns})")
   print(f"  {n_lin} linear steps in implicit stage solves")
-  print(f"  {n_nonlin_mass} nonlinear steps in mass solves (should be {nsteps*(ns+1)})")
+  print(f"  {n_nonlin_mass} nonlinear steps in mass solves (should be {nsteps*ns})")
   print(f"  {n_lin_mass} linear steps in mass solves")
 

--- a/demos/monodomain/demo_monodomain_FHN_dirkimex.py.rst
+++ b/demos/monodomain/demo_monodomain_FHN_dirkimex.py.rst
@@ -1,5 +1,5 @@
-Solving monodomain equations with Fitzhugh-Nagumo reaction and a DIRK- IMEX method
-==================================================================================
+Solving monodomain equations with Fitzhugh-Nagumo reaction and a DIRK-IMEX method
+=================================================================================
 
 We're solving monodomain (reaction-diffusion) with a particular reaction term.
 The basic form of the equation is:
@@ -112,7 +112,7 @@ specify only parameters for each stage.  We use an additive Schwarz (fieldsplit)
 	    }}
 
 
-The DIRK-IMEX schemes also require a mass-matrix solver.  Here, we just use AMG on the coupled system, which works fine.::
+The DIRK-IMEX schemes also require a mass-matrix solver.  Here, we just use an incomplete Cholesky preconditioner for CG on the coupled system, which works fine.::
 
   mass_params = {"snes_type": "ksponly",
                  "ksp_rtol": 1.e-8,

--- a/demos/monodomain/demo_monodomain_FHN_dirkimex.py.rst
+++ b/demos/monodomain/demo_monodomain_FHN_dirkimex.py.rst
@@ -1,0 +1,153 @@
+Solving monodomain equations with Fitzhugh-Nagumo reaction and a DIRK- IMEX method
+==================================================================================
+
+We're solving monodomain (reaction-diffusion) with a particular reaction term.
+The basic form of the equation is:
+
+.. math::
+
+   \chi \left( C_m u_t + I_{ion}(u) \right) = \nabla \cdot \sigma \nabla u
+
+where :math:`u` is the membrane potential, :math:`\sigma` is the conductivity tensor, :math:`C_m` is the specific capacitance of the cell membrane, and :math:`\chi` is the surface area to volume ration.  The term :math:`I_{ion}` is current due to ionic flows through channels in the cell membranes, and may couple to a complicated reaction network.  In our case, we take the relatively simple model due to Fitzhugh and Nagumo.  Here, we have a separate concentration variable :math:`c` satisfying the reaction equation:
+
+.. math::
+
+   c_t = \epsilon( u + \beta - \gamma c)
+
+for certain positive parameters :math:`\beta` and :math:`\gamma`, and the current takes the form of:
+
+.. math::
+
+   I_{ion}(u, c) = \tfrac{1}{\epsilon} \left( u - \tfrac{u^3}{3} - c \right)
+
+so that we have an overall system of two equations.  One of them is linear but stiff/diffusive, and the other is nonstiff but nonlinear.  This combination makes the system a good candidate for IMEX-type methods.
+
+
+We start with standard Firedrake/Irksome imports::
+
+  import copy
+
+  from firedrake import (And, Constant, File, Function, FunctionSpace,
+                         RectangleMesh, SpatialCoordinate, TestFunctions,
+                         as_matrix, conditional, dx, grad, inner, split)
+  from irksome import Dt, MeshConstant, IMEX4, TimeStepper
+
+And we set up the mesh and function space.::
+  
+  mesh = RectangleMesh(20, 20, 70, 70, quadrilateral=True)
+  polyOrder = 2
+  
+  V = FunctionSpace(mesh, "CG", 2)
+  Z = V * V
+
+  x, y = SpatialCoordinate(mesh)
+  MC = MeshConstant(mesh)
+  dt = MC.Constant(0.05)
+  t = MC.Constant(0.0)
+
+Specify the physical constants and initial conditions::
+
+  eps = Constant(0.1)
+  beta = Constant(1.0)
+  gamma = Constant(0.5)
+
+  chi = Constant(1.0)
+  capacitance = Constant(1.0)
+
+  sigma1 = sigma2 = 1.0
+  sigma = as_matrix([[sigma1, 0.0], [0.0, sigma2]])
+
+  
+  InitialPotential = conditional(x < 3.5, Constant(2.0), Constant(-1.28791))
+  InitialCell = conditional(And(And(31 <= x, x < 39), And(0 <= y, y < 35)),
+                            Constant(2.0), Constant(-0.5758))
+
+
+  uu = Function(Z)
+  vu, vc = TestFunctions(Z)
+  uu.sub(0).interpolate(InitialPotential)
+  uu.sub(1).interpolate(InitialCell)
+
+  (u, c) = split(uu)
+  
+
+This sets up the Butcher tableau.  All of our IMEX-type methods are
+based on a RadauIIA method for the implicit part.  We use a three-stage method.::
+  
+  butcher_tableau = IMEX4()
+  ns = butcher_tableau.num_stages
+
+To access an IMEX method, we need to separately specify the implicit and explicit parts of the operator.
+The part to be handled implicitly is taken to contain the time derivatives as well::
+  
+  F1 = (inner(chi * capacitance * Dt(u), vu)*dx
+        + inner(grad(u), sigma * grad(vu))*dx
+        + inner(Dt(c), vc)*dx - inner(eps * u, vc)*dx
+        - inner(beta * eps, vc)*dx + inner(gamma * eps * c, vc)*dx)
+
+This is the part to be handled explicitly.::
+	  
+  F2 = - inner((chi/eps) * (-u + (u**3 / 3) + c), vu)*dx
+
+If we wanted to use a fully implicit method, we would just take
+F = F1 - F2.   Note the minus sign, since DIRK-IMEX takes forms as F1 = F2.
+
+Now, set up solver parameters.  Since we're using a DIRK-IMEX scheme, we can
+specify only parameters for each stage::
+  
+  params = {"snes_type": "ksponly",
+            "ksp_monitor": None,
+            "mat_type": "aij",
+            "ksp_type": "fgmres",
+	    "pc_type": "fieldsplit",
+	    "pc_fieldsplit_type": "additive",
+	    "fieldsplit_0": {
+                "ksp_type": "preonly",
+                "pc_type": "gamg",
+	    },
+	    "fieldsplit_1": {
+                "ksp_type": "preonly",
+                "pc_type": "icc",
+	    }}
+
+
+The DIRK-IMEX schemes also require a mass-matrix solver.  Here, we just use AMG on the coupled system, which works fine.::
+
+  mass_params = {"snes_type": "ksponly",
+                 "ksp_rtol": 1.e-8,
+		 "ksp_monitor": None,
+		 "mat_type": "aij",
+		 "ksp_type": "fgmres",
+		 "pc_type": "gamg",
+		}
+
+Now, we access the IMEX method via the `TimeStepper` as with other methods.  Note that we specify somewhat different kwargs, needing to specify the implicit and explicit parts separately as well as separate solver options for the implicit and mass solvers.::
+  
+  stepper = TimeStepper(F1, butcher_tableau, t, dt, uu,
+                        stage_type="dirkimex",
+                        solver_parameters=params,
+                        mass_parameters=mass_params,
+		        Fexp=F2)
+
+  uFinal, cFinal = uu.split()
+  outfile1 = File("FHN_results/FHN_2d_u.pvd")
+  outfile2 = File("FHN_results/FHN_2d_c.pvd")
+  outfile1.write(uFinal, time=0)
+  outfile2.write(cFinal, time=0)
+
+  for j in range(12):
+      print(f"{float(t)}")
+      stepper.advance()
+      t.assign(float(t) + float(dt))
+
+      if (j % 5 == 0):
+          outfile1.write(uFinal, time=j * float(dt))
+          outfile2.write(cFinal, time=j * float(dt))
+
+  nsteps, n_nonlin, n_lin, n_nonlin_mass, n_lin_mass = stepper.solver_stats()
+  print(f"Time steps taken: {nsteps}")
+  print(f"  {n_nonlin} nonlinear steps in implicit stage solves (should be {nsteps*ns})")
+  print(f"  {n_lin} linear steps in implicit stage solves")
+  print(f"  {n_nonlin_mass} nonlinear steps in mass solves (should be {nsteps*(ns+1)})")
+  print(f"  {n_lin_mass} linear steps in mass solves")
+

--- a/demos/monodomain/demo_monodomain_FHN_dirkimex.py.rst
+++ b/demos/monodomain/demo_monodomain_FHN_dirkimex.py.rst
@@ -118,8 +118,8 @@ The DIRK-IMEX schemes also require a mass-matrix solver.  Here, we just use AMG 
                  "ksp_rtol": 1.e-8,
 		 "ksp_monitor": None,
 		 "mat_type": "aij",
-		 "ksp_type": "fgmres",
-		 "pc_type": "gamg",
+		 "ksp_type": "cg",
+		 "pc_type": "icc",
 		}
 
 Now, we access the IMEX method via the `TimeStepper` as with other methods.  Note that we specify somewhat different kwargs, needing to specify the implicit and explicit parts separately as well as separate solver options for the implicit and mass solvers.::

--- a/demos/monodomain/demo_monodomain_FHN_dirkimex.py.rst
+++ b/demos/monodomain/demo_monodomain_FHN_dirkimex.py.rst
@@ -30,7 +30,7 @@ We start with standard Firedrake/Irksome imports::
   from firedrake import (And, Constant, File, Function, FunctionSpace,
                          RectangleMesh, SpatialCoordinate, TestFunctions,
                          as_matrix, conditional, dx, grad, inner, split)
-  from irksome import Dt, MeshConstant, IMEX4, TimeStepper
+  from irksome import Dt, MeshConstant, DIRK_IMEX, TimeStepper
 
 And we set up the mesh and function space.::
   
@@ -75,7 +75,7 @@ This sets up the Butcher tableau.  Here, we use the DIRK-IMEX methods proposed
 by Ascher, Ruuth, and Spiteri in their 1997 Applied Numerical Mathematics paper.
 For this case, We use a four-stage method.::
   
-  butcher_tableau = IMEX4()
+  butcher_tableau = DIRK_IMEX(4, 4, 3)
   ns = butcher_tableau.num_stages
 
 To access an IMEX method, we need to separately specify the implicit and explicit parts of the operator.

--- a/demos/monodomain/demo_monodomain_FHN_dirkimex.py.rst
+++ b/demos/monodomain/demo_monodomain_FHN_dirkimex.py.rst
@@ -88,10 +88,10 @@ The part to be handled implicitly is taken to contain the time derivatives as we
 
 This is the part to be handled explicitly.::
 	  
-  F2 = - inner((chi/eps) * (-u + (u**3 / 3) + c), vu)*dx
+  F2 = inner((chi/eps) * (-u + (u**3 / 3) + c), vu)*dx
 
 If we wanted to use a fully implicit method, we would just take
-F = F1 - F2.   Note the minus sign, since DIRK-IMEX takes forms as F1 = F2.
+F = F1 + F2.
 
 Now, set up solver parameters.  Since we're using a DIRK-IMEX scheme, we can
 specify only parameters for each stage.  We use an additive Schwarz (fieldsplit) method that applies AMG to the potential block and incomplete Cholesky to the cell block independently for each stage::

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -98,12 +98,13 @@ and for adaptive IRK methods:
    demos/demo_heat_adapt.py
 
 
-Or check out an IMEX-type method for the monodomain equations:
+Or check out two IMEX-type methods for the monodomain equations:
 
 .. toctree::
    :maxdepth: 1
 
    demos/demo_monodomain_FHN.py
+   demos/demo_monodomain_FHN_dirkimex.py
 
 Advanced demos
 --------------

--- a/irksome/__init__.py
+++ b/irksome/__init__.py
@@ -8,10 +8,7 @@ from .ButcherTableaux import QinZhang       # noqa: F401
 from .ButcherTableaux import RadauIIA       # noqa: F401
 from .pep_explicit_rk import PEPRK          # noqa: F401
 from .deriv import Dt                       # noqa: F401
-from .dirk_imex_tableaux import IMEXEuler   # noqa: F401
-from .dirk_imex_tableaux import IMEX2       # noqa: F401
-from .dirk_imex_tableaux import IMEX3       # noqa: F401
-from .dirk_imex_tableaux import IMEX4       # noqa: F401
+from .dirk_imex_tableaux import DIRK_IMEX   # noqa: F401
 from .dirk_stepper import DIRKTimeStepper   # noqa: F401
 from .getForm import getForm                # noqa: F401
 from .imex import RadauIIAIMEXMethod        # noqa: F401

--- a/irksome/__init__.py
+++ b/irksome/__init__.py
@@ -8,9 +8,14 @@ from .ButcherTableaux import QinZhang       # noqa: F401
 from .ButcherTableaux import RadauIIA       # noqa: F401
 from .pep_explicit_rk import PEPRK          # noqa: F401
 from .deriv import Dt                       # noqa: F401
+from .dirk_imex_tableaux import IMEXEuler   # noqa: F401
+from .dirk_imex_tableaux import IMEX2       # noqa: F401
+from .dirk_imex_tableaux import IMEX3       # noqa: F401
+from .dirk_imex_tableaux import IMEX4       # noqa: F401
 from .dirk_stepper import DIRKTimeStepper   # noqa: F401
 from .getForm import getForm                # noqa: F401
 from .imex import RadauIIAIMEXMethod        # noqa: F401
+from .imex import DIRKIMEXMethod            # noqa: F401
 from .pc import RanaBase, RanaDU, RanaLD    # noqa: F401
 from .pc import IRKAuxiliaryOperatorPC      # noqa: F401
 from .stage import StageValueTimeStepper    # noqa: F401

--- a/irksome/dirk_imex_tableaux.py
+++ b/irksome/dirk_imex_tableaux.py
@@ -18,7 +18,7 @@ class IMEXEuler(ButcherTableau):
         self.A_hat = A_hat
         self.b_hat = b_hat
         self.c_hat = c_hat
-        self.is_explicit_implicit = True  # Mark this as an IMEX scheme
+        self.is_imex = True  # Mark this as an IMEX scheme
 
 
 # IMEX Butcher tableau for s = 2
@@ -46,7 +46,7 @@ class IMEX2(ButcherTableau):
         self.A_hat = A_hat
         self.b_hat = b_hat
         self.c_hat = c_hat
-        self.is_explicit_implicit = True  # Mark this as an IMEX scheme
+        self.is_imex = True  # Mark this as an IMEX scheme
 
 
 # IMEX Butcher tableau for s = 3
@@ -69,7 +69,7 @@ class IMEX3(ButcherTableau):
         self.A_hat = A_hat
         self.b_hat = b_hat
         self.c_hat = c_hat
-        self.is_explicit_implicit = True  # Mark this as an IMEX scheme
+        self.is_imex = True  # Mark this as an IMEX scheme
 
 
 # IMEX Butcher tableau for s = 4
@@ -97,4 +97,4 @@ class IMEX4(ButcherTableau):
         self.A_hat = A_hat
         self.b_hat = b_hat
         self.c_hat = c_hat
-        self.is_explicit_implicit = True  # Mark this as an IMEX scheme
+        self.is_imex = True  # Mark this as an IMEX scheme

--- a/irksome/dirk_imex_tableaux.py
+++ b/irksome/dirk_imex_tableaux.py
@@ -6,11 +6,11 @@ import numpy as np
 class IMEXEuler(ButcherTableau):
     def __init__(self):
         A = np.array([[1.0]])    # Implicit matrix (for implicit part)
-        A_hat = np.array([[0.0]])  # Explicit matrix (for explicit part)
+        A_hat = np.array([[1.0]])  # Explicit matrix (for explicit part)
         b = np.array([1.0])      # Implicit weights
-        b_hat = np.array([1.0])  # Explicit weights
+        b_hat = np.array([1.0, 0.0])  # Explicit weights
         c = np.array([1.0])      # Time steps for implicit part
-        c_hat = np.array([0.0])  # Time steps for explicit part
+        c_hat = np.array([0.0, 1.0])  # Time steps for explicit part
         order = 1                  # First-order method (Euler)
         embedded_order = None      # set to None
         gamma0 = None              # set to None

--- a/irksome/dirk_imex_tableaux.py
+++ b/irksome/dirk_imex_tableaux.py
@@ -1,99 +1,70 @@
 from .ButcherTableaux import ButcherTableau
 import numpy as np
 
+# For the implicit scheme, the full Butcher Table is given as A, b, c.
 
-# IMEX Butcher tableau using numpy arrays
-class IMEXEuler(ButcherTableau):
-    def __init__(self):
-        A = np.array([[1.0]])    # Implicit matrix (for implicit part)
-        A_hat = np.array([[1.0]])  # Explicit matrix (for explicit part)
-        b = np.array([1.0])      # Implicit weights
-        b_hat = np.array([1.0, 0.0])  # Explicit weights
-        c = np.array([1.0])      # Time steps for implicit part
-        c_hat = np.array([0.0, 1.0])  # Time steps for explicit part
-        order = 1                  # First-order method (Euler)
-        embedded_order = None      # set to None
-        gamma0 = None              # set to None
-        super().__init__(A, b, b_hat, c, order, embedded_order, gamma0)
-        self.A_hat = A_hat
-        self.b_hat = b_hat
-        self.c_hat = c_hat
-        self.is_dirk_imex = True  # Mark this as a DIRK-IMEX scheme
+# For the explicit scheme, the full b_hat and c_hat are given, but (to
+# avoid a lot of offset-by-ones in the code we store only the
+# lower-left ns x ns block of A_hat
+
+# IMEX Butcher tableau for 1 stage
+imex111A = np.array([[1.0]])
+imex111A_hat = np.array([[1.0]])
+imex111b = np.array([1.0])
+imex111b_hat = np.array([1.0, 0.0])
+imex111c = np.array([1.0])
+imex111c_hat = np.array([0.0, 1.0])
 
 
 # IMEX Butcher tableau for s = 2
-class IMEX2(ButcherTableau):
-    def __init__(self):
-        # Parameters for the s = 2 method
-        gamma = (2 - np.sqrt(2)) / 2
-        delta = -2 * np.sqrt(2) / 3
+gamma = (2 - np.sqrt(2)) / 2
+delta = -2 * np.sqrt(2) / 3
+imex232A = np.array([[gamma, 0], [1 - gamma, gamma]])
+imex232A_hat = np.array([[gamma, 0], [delta, 1 - delta]])
+imex232b = np.array([1 - gamma, gamma])
+imex232b_hat = np.array([0, 1 - gamma, gamma])
+imex232c = np.array([gamma, 1.0])
+imex232c_hat = np.array([0, gamma, 1.0])
 
-        # Implicit and explicit coefficients
-        A = np.array([[gamma, 0], [1 - gamma, gamma]])   # Implicit matrix (A)
-        A_hat = np.array([[gamma, 0], [delta, 1 - delta]])  # Explicit matrix (A_hat)
-        b = np.array([1 - gamma, gamma])     # Implicit weights
-        b_hat = np.array([0, 1 - gamma, gamma])     # Explicit weights (b_hat)
-        c = np.array([gamma, 1.0])     # Time steps for implicit part (c)
-        c_hat = np.array([0, gamma, 1.0])    # Time steps for explicit part (c_hat)
-
-        # The method order is 2
-        order = 2
-        embedded_order = None  # set to None
-        gamma0 = None  # set to None
-        btilde = None
-
-        super().__init__(A, b, btilde, c, order, embedded_order, gamma0)
-        self.A_hat = A_hat
-        self.b_hat = b_hat
-        self.c_hat = c_hat
-        self.is_dirk_imex = True  # Mark this as a DIRK-IMEX scheme
+# IMEX Butcher tableau for 3 stages
+imex343A = np.array([[0.4358665215, 0, 0], [0.2820667392, 0.4358665215, 0], [1.208496649, -0.644363171, 0.4358665215]])
+imex343A_hat = np.array([[0.4358665215, 0, 0], [0.3212788860, 0.3966543747, 0], [-0.105858296, 0.5529291479, 0.5529291479]])
+imex343b = np.array([1.208496649, -0.644363171, 0.4358665215])
+imex343b_hat = np.array([0, 1.208496649, -0.644363171, 0.4358665215])
+imex343c = np.array([0.4358665215, 0.7179332608, 1])
+imex343c_hat = np.array([0, 0.4358665215, 0.7179332608, 1.0])
 
 
-# IMEX Butcher tableau for s = 3
-class IMEX3(ButcherTableau):
-    def __init__(self):
-        A = np.array([[0.4358665215, 0, 0], [0.2820667392, 0.4358665215, 0], [1.208496649, -0.644363171, 0.4358665215]])   # Implicit matrix (A)
-        A_hat = np.array([[0.4358665215, 0, 0], [0.3212788860, 0.3966543747, 0], [-0.105858296, 0.5529291479, 0.5529291479]])  # Explicit matrix (A_hat)
-        b = np.array([1.208496649, -0.644363171, 0.4358665215])     # Implicit weights
-        b_hat = np.array([0, 1.208496649, -0.644363171, 0.4358665215])     # Explicit weights (b_hat)
-        c = np.array([0.4358665215, 0.7179332608, 1])     # Time steps for implicit part (c)
-        c_hat = np.array([0, 0.4358665215, 0.7179332608, 1.0])    # Time steps for explicit part (c_hat)
+# IMEX Butcher tableau for 4 stages
+imex443A = np.array([[1/2, 0, 0, 0],
+                     [1/6, 1/2, 0, 0],
+                     [-1/2, 1/2, 1/2, 0],
+                     [3/2, -3/2, 1/2, 1/2]])
+imex443A_hat = np.array([[1/2, 0, 0, 0],
+                         [11/18, 1/18, 0, 0],
+                         [5/6, -5/6, 1/2, 0],
+                         [1/4, 7/4, 3/4, -7/4]])
+imex443b = np.array([3/2, -3/2, 1/2, 1/2])
+imex443b_hat = np.array([1/4, 7/4, 3/4, -7/4, 0])
+imex443c = np.array([1/2, 2/3, 1/2, 1])
+imex443c_hat = np.array([0, 1/2, 2/3, 1/2, 1])
 
-        # The method order is 3
-        order = 3
-        embedded_order = None  # set to None
-        gamma0 = None  # set to None
-        btilde = None
-
-        super().__init__(A, b, btilde, c, order, embedded_order, gamma0)
-        self.A_hat = A_hat
-        self.b_hat = b_hat
-        self.c_hat = c_hat
-        self.is_dirk_imex = True  # Mark this as a DIRK-IMEX scheme
+dirk_imex_dict = {
+    (1, 1, 1): (imex111A, imex111b, imex111c, imex111A_hat, imex111b_hat, imex111c_hat),
+    (2, 3, 2): (imex232A, imex232b, imex232c, imex232A_hat, imex232b_hat, imex232c_hat),
+    (3, 4, 3): (imex343A, imex343b, imex343c, imex343A_hat, imex343b_hat, imex343c_hat),
+    (4, 4, 3): (imex443A, imex443b, imex443c, imex443A_hat, imex443b_hat, imex443c_hat)
+}
 
 
-# IMEX Butcher tableau for s = 4
-class IMEX4(ButcherTableau):
-    def __init__(self):
-        A = np.array([[1/2, 0, 0, 0],
-                      [1/6, 1/2, 0, 0],
-                      [-1/2, 1/2, 1/2, 0],
-                      [3/2, -3/2, 1/2, 1/2]])  # Corrected A matrix definition
-        A_hat = np.array([[1/2, 0, 0, 0],
-                          [11/18, 1/18, 0, 0],
-                          [5/6, -5/6, 1/2, 0],
-                          [1/4, 7/4, 3/4, -7/4]])  # Explicit matrix (A_hat)
-        b = np.array([3/2, -3/2, 1/2, 1/2])  # Implicit weights
-        b_hat = np.array([1/4, 7/4, 3/4, -7/4, 0])  # Explicit weights (b_hat)
-        c = np.array([1/2, 2/3, 1/2, 1])  # Time steps for implicit part (c)
-        c_hat = np.array([0, 1/2, 2/3, 1/2, 1])  # Time steps for explicit part (c_hat)
-
-        order = 3
-        embedded_order = None
-        gamma0 = None
-        btilde = None
-
-        super().__init__(A, b, btilde, c, order, embedded_order, gamma0)
+class DIRK_IMEX(ButcherTableau):
+    def __init__(self, ns_imp, ns_exp, order):
+        try:
+            A, b, c, A_hat, b_hat, c_hat = dirk_imex_dict[ns_imp, ns_exp, order]
+        except KeyError:
+            raise NotImplementedError("No DIRK-IMEX method for that combination of implicit and explicit stages and order")
+        self.order = order
+        super(DIRK_IMEX, self).__init__(A, b, None, c, order, None, None)
         self.A_hat = A_hat
         self.b_hat = b_hat
         self.c_hat = c_hat

--- a/irksome/dirk_imex_tableaux.py
+++ b/irksome/dirk_imex_tableaux.py
@@ -18,7 +18,7 @@ class IMEXEuler(ButcherTableau):
         self.A_hat = A_hat
         self.b_hat = b_hat
         self.c_hat = c_hat
-        self.is_imex = True  # Mark this as an IMEX scheme
+        self.is_dirk_imex = True  # Mark this as a DIRK-IMEX scheme
 
 
 # IMEX Butcher tableau for s = 2
@@ -46,7 +46,7 @@ class IMEX2(ButcherTableau):
         self.A_hat = A_hat
         self.b_hat = b_hat
         self.c_hat = c_hat
-        self.is_imex = True  # Mark this as an IMEX scheme
+        self.is_dirk_imex = True  # Mark this as a DIRK-IMEX scheme
 
 
 # IMEX Butcher tableau for s = 3
@@ -69,7 +69,7 @@ class IMEX3(ButcherTableau):
         self.A_hat = A_hat
         self.b_hat = b_hat
         self.c_hat = c_hat
-        self.is_imex = True  # Mark this as an IMEX scheme
+        self.is_dirk_imex = True  # Mark this as a DIRK-IMEX scheme
 
 
 # IMEX Butcher tableau for s = 4
@@ -97,4 +97,4 @@ class IMEX4(ButcherTableau):
         self.A_hat = A_hat
         self.b_hat = b_hat
         self.c_hat = c_hat
-        self.is_imex = True  # Mark this as an IMEX scheme
+        self.is_dirk_imex = True  # Mark this as a DIRK-IMEX scheme

--- a/irksome/dirk_imex_tableaux.py
+++ b/irksome/dirk_imex_tableaux.py
@@ -1,0 +1,100 @@
+from .ButcherTableaux import ButcherTableau
+import numpy as np
+
+
+# IMEX Butcher tableau using numpy arrays
+class IMEXEuler(ButcherTableau):
+    def __init__(self):
+        A = np.array([[1.0]])    # Implicit matrix (for implicit part)
+        A_hat = np.array([[0.0]])  # Explicit matrix (for explicit part)
+        b = np.array([1.0])      # Implicit weights
+        b_hat = np.array([1.0])  # Explicit weights
+        c = np.array([1.0])      # Time steps for implicit part
+        c_hat = np.array([0.0])  # Time steps for explicit part
+        order = 1                  # First-order method (Euler)
+        embedded_order = None      # set to None
+        gamma0 = None              # set to None
+        super().__init__(A, b, b_hat, c, order, embedded_order, gamma0)
+        self.A_hat = A_hat
+        self.b_hat = b_hat
+        self.c_hat = c_hat
+        self.is_explicit_implicit = True  # Mark this as an IMEX scheme
+
+
+# IMEX Butcher tableau for s = 2
+class IMEX2(ButcherTableau):
+    def __init__(self):
+        # Parameters for the s = 2 method
+        gamma = (2 - np.sqrt(2)) / 2
+        delta = -2 * np.sqrt(2) / 3
+
+        # Implicit and explicit coefficients
+        A = np.array([[gamma, 0], [1 - gamma, gamma]])   # Implicit matrix (A)
+        A_hat = np.array([[gamma, 0], [delta, 1 - delta]])  # Explicit matrix (A_hat)
+        b = np.array([1 - gamma, gamma])     # Implicit weights
+        b_hat = np.array([0, 1 - gamma, gamma])     # Explicit weights (b_hat)
+        c = np.array([gamma, 1.0])     # Time steps for implicit part (c)
+        c_hat = np.array([0, gamma, 1.0])    # Time steps for explicit part (c_hat)
+
+        # The method order is 2
+        order = 2
+        embedded_order = None  # set to None
+        gamma0 = None  # set to None
+        btilde = None
+
+        super().__init__(A, b, btilde, c, order, embedded_order, gamma0)
+        self.A_hat = A_hat
+        self.b_hat = b_hat
+        self.c_hat = c_hat
+        self.is_explicit_implicit = True  # Mark this as an IMEX scheme
+
+
+# IMEX Butcher tableau for s = 3
+class IMEX3(ButcherTableau):
+    def __init__(self):
+        A = np.array([[0.4358665215, 0, 0], [0.2820667392, 0.4358665215, 0], [1.208496649, -0.644363171, 0.4358665215]])   # Implicit matrix (A)
+        A_hat = np.array([[0.4358665215, 0, 0], [0.3212788860, 0.3966543747, 0], [-0.105858296, 0.5529291479, 0.5529291479]])  # Explicit matrix (A_hat)
+        b = np.array([1.208496649, -0.644363171, 0.4358665215])     # Implicit weights
+        b_hat = np.array([0, 1.208496649, -0.644363171, 0.4358665215])     # Explicit weights (b_hat)
+        c = np.array([0.4358665215, 0.7179332608, 1])     # Time steps for implicit part (c)
+        c_hat = np.array([0, 0.4358665215, 0.7179332608, 1.0])    # Time steps for explicit part (c_hat)
+
+        # The method order is 3
+        order = 3
+        embedded_order = None  # set to None
+        gamma0 = None  # set to None
+        btilde = None
+
+        super().__init__(A, b, btilde, c, order, embedded_order, gamma0)
+        self.A_hat = A_hat
+        self.b_hat = b_hat
+        self.c_hat = c_hat
+        self.is_explicit_implicit = True  # Mark this as an IMEX scheme
+
+
+# IMEX Butcher tableau for s = 4
+class IMEX4(ButcherTableau):
+    def __init__(self):
+        A = np.array([[1/2, 0, 0, 0],
+                      [1/6, 1/2, 0, 0],
+                      [-1/2, 1/2, 1/2, 0],
+                      [3/2, -3/2, 1/2, 1/2]])  # Corrected A matrix definition
+        A_hat = np.array([[1/2, 0, 0, 0],
+                          [11/18, 1/18, 0, 0],
+                          [5/6, -5/6, 1/2, 0],
+                          [1/4, 7/4, 3/4, -7/4]])  # Explicit matrix (A_hat)
+        b = np.array([3/2, -3/2, 1/2, 1/2])  # Implicit weights
+        b_hat = np.array([1/4, 7/4, 3/4, -7/4, 0])  # Explicit weights (b_hat)
+        c = np.array([1/2, 2/3, 1/2, 1])  # Time steps for implicit part (c)
+        c_hat = np.array([0, 1/2, 2/3, 1/2, 1])  # Time steps for explicit part (c_hat)
+
+        order = 3
+        embedded_order = None
+        gamma0 = None
+        btilde = None
+
+        super().__init__(A, b, btilde, c, order, embedded_order, gamma0)
+        self.A_hat = A_hat
+        self.b_hat = b_hat
+        self.c_hat = c_hat
+        self.is_explicit_implicit = True  # Mark this as an IMEX scheme

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -397,7 +397,7 @@ class DIRKIMEXMethod:
 
     def __init__(self, F, F_explicit, butcher_tableau, t, dt, u0, bcs=None,
                  solver_parameters=None, mass_parameters=None, appctx=None, nullspace=None):
-        assert butcher_tableau.is_imex
+        assert butcher_tableau.is_dirk_imex
 
         self.num_steps = 0
         self.num_nonlinear_iterations = 0

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -467,13 +467,15 @@ class DIRKIMEXMethod:
 
         # Calculate explicit term for the first stage
         ghat.assign(u0)
-        chat.assign(C_hat[0])
-        self.mass_solver.solve()
-        self.num_mass_nonlinear_iterations += self.mass_solver.snes.getIterationNumber()
-        self.num_mass_linear_iterations += self.mass_solver.snes.getLinearSolveIterations()
-        k_hat_s[0].assign(khat)
 
         for i in range(ns):
+
+            chat.assign(C_hat[i])
+            self.mass_solver.solve()
+            self.num_mass_nonlinear_iterations += self.mass_solver.snes.getIterationNumber()
+            self.num_mass_linear_iterations += self.mass_solver.snes.getLinearSolveIterations()
+            k_hat_s[i].assign(khat)
+
             g.assign(u0)
             # Update g with contributions from previous stages
             for j in range(i):
@@ -510,11 +512,11 @@ class DIRKIMEXMethod:
             for ghatbit, kbit in zip(ghat.subfunctions, ks[i].subfunctions):
                 ghatbit += dtc * AA[i, i] * kbit
 
-            chat.assign(C_hat[i+1])
-            self.mass_solver.solve()
-            self.num_mass_nonlinear_iterations += self.mass_solver.snes.getIterationNumber()
-            self.num_mass_linear_iterations += self.mass_solver.snes.getLinearSolveIterations()
-            k_hat_s[i + 1].assign(khat)
+        chat.assign(C_hat[ns])
+        self.mass_solver.solve()
+        self.num_mass_nonlinear_iterations += self.mass_solver.snes.getIterationNumber()
+        self.num_mass_linear_iterations += self.mass_solver.snes.getLinearSolveIterations()
+        k_hat_s[ns].assign(khat)
 
         # Final solution update
         for i in range(ns):

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -1,9 +1,8 @@
 import FIAT
 import numpy as np
-from firedrake import (DirichletBC, Function, NonlinearVariationalProblem,
+from firedrake import (Function, NonlinearVariationalProblem,
                        NonlinearVariationalSolver, TestFunction,
-                       assemble, as_ufl, dx, inner, interpolate,
-                       project, split)
+                       as_ufl, dx, inner, split)
 from firedrake.dmhooks import pop_parent, push_parent
 from ufl.classes import Zero
 
@@ -11,6 +10,7 @@ from .ButcherTableaux import RadauIIA
 from .deriv import TimeDerivative
 from .stage import getBits, getFormStage
 from .tools import AI, IA, MeshConstant, replace
+from .bcs import bc2space
 
 
 def riia_explicit_coeffs(k):
@@ -360,7 +360,7 @@ def getThingy(V, bc):
             return BCCompOfMixedBitThingy(sub, comp)
 
 
-def getFormsIMEX(F, Fexp, butch, t, dt, u0, bcs=None):
+def getFormsIMEX(F, Fexp, ks, khats, butch, t, dt, u0, bcs=None):
     if bcs is None:
         bcs = []
 
@@ -370,14 +370,16 @@ def getFormsIMEX(F, Fexp, butch, t, dt, u0, bcs=None):
     assert V == u0.function_space()
 
     num_fields = len(V)
-
+    num_stages = butch.num_stages
     k = Function(V)
     g = Function(V)
 
     khat = Function(V)
-    vhat = TestFunction(V)
     ghat = Function(V)
+    vhat = TestFunction(V)
 
+    # If we're on a mixed problem, we need to replace pieces of the
+    # solution.  Stores array of the splittings of the functions for each stage.
     if num_fields == 1:
         k_bits = [k]
         u0bits = [u0]
@@ -389,44 +391,59 @@ def getFormsIMEX(F, Fexp, butch, t, dt, u0, bcs=None):
         gbits = split(g)
         ghat_bits = split(g)
 
+    # Note: the Constant c is used for substitution in both the
+    # implicit variational form and BC's, and we update it for each stage in
+    # the loop over stages in the advance method.  The Constants a and chat are
+    # used similarly in the variational forms
     MC = MeshConstant(msh)
     c = MC.Constant(1.0)
     chat = MC.Constant(1.0)
     a = MC.Constant(1.0)
 
+    # Implicit replacement, solve at time t + c * dt, for k
     repl = {t: t + c * dt}
     for u0bit, kbit, gbit in zip(u0bits, k_bits, gbits):
         repl[u0bit] = gbit + dt * a * kbit
         repl[TimeDerivative(u0bit)] = kbit
     stage_F = replace(F, repl)
 
+    # Explicit replacement, solve at time t + chat * dt, for khat
     replhat = {t: t + chat * dt}
     for u0bit, ghatbit in zip(u0bits, ghat_bits):
         replhat[u0bit] = ghatbit
     Fhat = inner(khat, vhat)*dx - replace(Fexp, replhat)
 
     bcnew = []
-    gblah = []
+
+    # For the DIRK-IMEX case, we need one new BC for each old one
+    # (rather than one per stage), but we need a `Function` inside of
+    # each BC and a rule for computing that function at each time for
+    # each stage.
+
+    a_vals = np.array([MC.Constant(0) for i in range(num_stages)],
+                      dtype=object)
+    ahat_vals = np.array([MC.Constant(0) for i in range(num_stages+1)],
+                         dtype=object)
+    d_val = MC.Constant(1.0)
 
     for bc in bcs:
-        Vbc = bc.function_space()
         bcarg = as_ufl(bc._original_arg)
-        bcarg_stage = replace(bcarg, {t: t + c * dt})
-        try:
-            gdat = assemble(interpolate(bcarg, Vbc))
-            gmethod = lambda gd, gc: gd.interpolate(gc)
-        except:  # noqa: E722
-            gdat = assemble(project(bcarg, Vbc))
-            gmethod = lambda gd, gc: gd.project(gc)
+        bcarg_stage = replace(bcarg, {t: t+c*dt})
+        if bcarg_stage == 0:
+            # Homogeneous BC, just zero out stage dofs
+            bcnew.append(bc.reconstruct(g=0))
+            continue
 
-        new_bc = DirichletBC(Vbc, gdat, bc.sub_domain)
-        bcnew.append(new_bc)
+        gdat = bcarg_stage - bc2space(bc, u0)
+        for i in range(num_stages):
+            gdat -= dt*a_vals[i]*bc2space(bc, ks[i])
+        for i in range(num_stages+1):
+            gdat -= dt*ahat_vals[i]*bc2space(bc, khats[i])
 
-        dat4bc = getThingy(V, bc)
-        gdat2 = Function(gdat.function_space())
-        gblah.append((gdat, gdat2, bcarg_stage, gmethod, dat4bc))
+        gdat /= dt*d_val
+        bcnew.append(bc.reconstruct(g=gdat))
 
-    return stage_F, (k, g, a, c), bcnew, gblah, Fhat, (khat, ghat, chat)
+        return stage_F, (k, g, a, c), bcnew, Fhat, (khat, ghat, chat), (a_vals, ahat_vals, d_val)
 
 
 class DIRKIMEXMethod:
@@ -435,29 +452,32 @@ class DIRKIMEXMethod:
 
     def __init__(self, F, F_explicit, butcher_tableau, t, dt, u0, bcs=None,
                  solver_parameters=None, mass_parameters=None, appctx=None, nullspace=None):
-        assert butcher_tableau.is_explicit_implicit
+        assert butcher_tableau.is_imex
 
         self.num_steps = 0
         self.num_nonlinear_iterations = 0
         self.num_linear_iterations = 0
+        self.num_mass_nonlinear_iterations = 0
+        self.num_mass_linear_iterations = 0
 
         self.butcher_tableau = butcher_tableau
+        self.num_stages = butcher_tableau.num_stages
+
         self.V = V = u0.function_space()
         self.u0 = u0
         self.t = t
         self.dt = dt
         self.num_fields = len(u0.function_space())
-        self.num_stages = butcher_tableau.num_stages
         self.ks = [Function(V) for _ in range(self.num_stages)]
         self.k_hat_s = [Function(V) for _ in range(self.num_stages+1)]
 
-        stage_F, (k, g, a, c), bcnew, gblah, Fhat, (khat, ghat, chat) = getFormsIMEX(
-            F, F_explicit, butcher_tableau, t, dt, u0, bcs=bcs)
+        stage_F, (k, g, a, c), bcnew, Fhat, (khat, ghat, chat), (a_vals, ahat_vals, d_val) = getFormsIMEX(
+            F, F_explicit, self.ks, self.k_hat_s, butcher_tableau, t, dt, u0, bcs=bcs)
 
         self.bcnew = bcnew
-        self.gblah = gblah
 
         appctx_irksome = {"F": F,
+                          "F_explicit": F_explicit,
                           "butcher_tableau": butcher_tableau,
                           "t": t,
                           "dt": dt,
@@ -481,6 +501,7 @@ class DIRKIMEXMethod:
 
         self.kgac = k, g, a, c
         self.kgchat = khat, ghat, chat
+        self.bc_constants = a_vals, ahat_vals, d_val
 
     def advance(self):
         k, g, a, c = self.kgac
@@ -490,55 +511,52 @@ class DIRKIMEXMethod:
         u0 = self.u0
         dtc = float(self.dt)
         bt = self.butcher_tableau
+        ns = self.num_stages
         AA = bt.A
         A_hat = bt.A_hat
         CC = bt.c
         C_hat = bt.c_hat
         BB = bt.b
         B_hat = bt.b_hat
+        a_vals, ahat_vals, d_val = self.bc_constants
 
         # Calculate explicit term for the first stage
         ghat.assign(u0)
         chat.assign(C_hat[0])
         self.mass_solver.solve()
+        self.num_mass_nonlinear_iterations += self.mass_solver.getIterationNumber()
+        self.num_mass_linear_iterations += self.mass_solver.getLinearSolveIterations()
         k_hat_s[0].assign(khat)
 
-        for i in range(self.num_stages):
-            # Set implicit coefficients
-            a.assign(AA[i, i])
-            c.assign(CC[i])
-
+        for i in range(ns):
             g.assign(u0)
-
             # Update g with contributions from previous stages
             for j in range(i):
                 ksplit = ks[j].subfunctions
                 for gbit, kbit in zip(g.subfunctions, ksplit):
                     gbit += dtc * AA[i, j] * kbit
-
             for j in range(i+1):
                 k_hat_split = k_hat_s[j].subfunctions
                 for gbit, k_hat_bit in zip(g.subfunctions, k_hat_split):
                     gbit += dtc * A_hat[i, j] * k_hat_bit
 
             # Solve for current stage
-            for (bc, (gdat, gdat2, gcur, gmethod, dat4bc)) in zip(self.bcnew, self.gblah):
-                gmethod(gdat, gcur)
-                gmethod(gdat2, dat4bc(u0))
-                gdat -= gdat2
-
-                for j in range(i):
-                    gmethod(gdat2, dat4bc(ks[j]))
-                    gdat -= dtc * AA[i, j] * gdat2
-
-                for j in range(i+1):
-                    gmethod(gdat2, dat4bc(k_hat_s[j]))
-                    gdat -= dtc * A_hat[i, j] * gdat2
-
-                gdat /= dtc * AA[i, i]
+            for j in range(i):
+                a_vals[j].assign(AA[i, j])
+            for j in range(i, ns):
+                a_vals[j].assign(0)
+            for j in range(i+1):
+                ahat_vals[j].assign(A_hat[i, j])
+            for j in range(i+1, ns+1):
+                ahat_vals[j].assign(0)
+            d_val.assign(AA[i, i])
 
             # Solve the nonlinear problem at stage i
+            a.assign(AA[i, i])
+            c.assign(CC[i])
             self.solver.solve()
+            self.num_nonlinear_iterations += self.solver.getIterationNumber()
+            self.num_linear_iterations += self.solver.getLinearSolveIterations()
             ks[i].assign(k)
 
             # Update the solution for next stage
@@ -546,21 +564,23 @@ class DIRKIMEXMethod:
                 ghatbit.assign(gbit)
             for ghatbit, kbit in zip(ghat.subfunctions, ks[i].subfunctions):
                 ghatbit += dtc * AA[i, i] * kbit
-            chat.assign(C_hat[i+1])
 
+            chat.assign(C_hat[i+1])
             self.mass_solver.solve()
+            self.num_mass_nonlinear_iterations += self.mass_solver.getIterationNumber()
+            self.num_mass_linear_iterations += self.mass_solver.getLinearSolveIterations()
             k_hat_s[i + 1].assign(khat)
 
         # Final solution update
-        for i in range(self.num_stages):
+        for i in range(ns):
             for u0bit, kbit in zip(u0.subfunctions, ks[i].subfunctions):
                 u0bit += dtc * BB[i] * kbit
 
-        for i in range(self.num_stages+1):
+        for i in range(ns+1):
             for u0bit, k_hat_bit in zip(u0.subfunctions, k_hat_s[i].subfunctions):
                 u0bit += dtc * B_hat[i] * k_hat_bit
 
         self.num_steps += 1
 
     def solver_stats(self):
-        return self.num_steps, self.num_nonlinear_iterations, self.num_linear_iterations
+        return self.num_steps, self.num_nonlinear_iterations, self.num_linear_iterations, self.num_mass_nonlinear_iterations, self.num_mass_linear_iterations

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -389,7 +389,7 @@ def getFormsDIRKIMEX(F, Fexp, ks, khats, butch, t, dt, u0, bcs=None):
 
 class DIRKIMEXMethod:
     """Front-end class for advancing a time-dependent PDE via a diagonally-implicit
-    Runge-Kutta method formulated in terms of stage derivatives."""
+    Runge-Kutta IMEX method formulated in terms of stage derivatives."""
 
     def __init__(self, F, F_explicit, butcher_tableau, t, dt, u0, bcs=None,
                  solver_parameters=None, mass_parameters=None, appctx=None, nullspace=None):

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -461,8 +461,6 @@ class DIRKIMEXMethod:
         A_hat = bt.A_hat
         CC = bt.c
         C_hat = bt.c_hat
-        BB = bt.b
-        B_hat = bt.b_hat
         a_vals, ahat_vals, d_val = self.bc_constants
 
         # Calculate explicit term for the first stage
@@ -512,6 +510,22 @@ class DIRKIMEXMethod:
             for ghatbit, kbit in zip(ghat.subfunctions, ks[i].subfunctions):
                 ghatbit += dtc * AA[i, i] * kbit
 
+        self._finalize_general()
+        self.num_steps += 1
+
+    # Last part of advance for the general case, where last explicit stage is calculated and used
+    def _finalize_general(self):
+        khat, ghat, chat = self.kgchat
+        ks = self.ks
+        k_hat_s = self.k_hat_s
+        u0 = self.u0
+        dtc = float(self.dt)
+        bt = self.butcher_tableau
+        ns = self.num_stages
+        C_hat = bt.c_hat
+        BB = bt.b
+        B_hat = bt.b_hat
+
         chat.assign(C_hat[ns])
         self.mass_solver.solve()
         self.num_mass_nonlinear_iterations += self.mass_solver.snes.getIterationNumber()
@@ -526,8 +540,6 @@ class DIRKIMEXMethod:
         for i in range(ns+1):
             for u0bit, k_hat_bit in zip(u0.subfunctions, k_hat_s[i].subfunctions):
                 u0bit += dtc * B_hat[i] * k_hat_bit
-
-        self.num_steps += 1
 
     def solver_stats(self):
         return self.num_steps, self.num_nonlinear_iterations, self.num_linear_iterations, self.num_mass_nonlinear_iterations, self.num_mass_linear_iterations

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -356,7 +356,7 @@ def getFormsDIRKIMEX(F, Fexp, ks, khats, butch, t, dt, u0, bcs=None):
     replhat = {t: t + chat * dt}
     for u0bit, ghatbit in zip(u0bits, ghat_bits):
         replhat[u0bit] = ghatbit
-    Fhat = inner(khat, vhat)*dx - replace(Fexp, replhat)
+    Fhat = inner(khat, vhat)*dx + replace(Fexp, replhat)
 
     bcnew = []
 
@@ -388,8 +388,13 @@ def getFormsDIRKIMEX(F, Fexp, ks, khats, butch, t, dt, u0, bcs=None):
 
 
 class DIRKIMEXMethod:
-    """Front-end class for advancing a time-dependent PDE via a diagonally-implicit
-    Runge-Kutta IMEX method formulated in terms of stage derivatives."""
+    """Front-end class for advancing a time-dependent PDE via a
+    diagonally-implicit Runge-Kutta IMEX method formulated in terms of
+    stage derivatives.  This implementation assumes a weak form
+    written as F + F_explicit = 0, where both F and F_explicit are UFL
+    Forms, with terms in F to be handled implicitly and those in
+    F_explicit to be handled explicitly
+    """
 
     def __init__(self, F, F_explicit, butcher_tableau, t, dt, u0, bcs=None,
                  solver_parameters=None, mass_parameters=None, appctx=None, nullspace=None):

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -473,8 +473,8 @@ class DIRKIMEXMethod:
         ghat.assign(u0)
         chat.assign(C_hat[0])
         self.mass_solver.solve()
-        self.num_mass_nonlinear_iterations += self.mass_solver.getIterationNumber()
-        self.num_mass_linear_iterations += self.mass_solver.getLinearSolveIterations()
+        self.num_mass_nonlinear_iterations += self.mass_solver.snes.getIterationNumber()
+        self.num_mass_linear_iterations += self.mass_solver.snes.getLinearSolveIterations()
         k_hat_s[0].assign(khat)
 
         for i in range(ns):
@@ -504,8 +504,8 @@ class DIRKIMEXMethod:
             a.assign(AA[i, i])
             c.assign(CC[i])
             self.solver.solve()
-            self.num_nonlinear_iterations += self.solver.getIterationNumber()
-            self.num_linear_iterations += self.solver.getLinearSolveIterations()
+            self.num_nonlinear_iterations += self.solver.snes.getIterationNumber()
+            self.num_linear_iterations += self.solver.snes.getLinearSolveIterations()
             ks[i].assign(k)
 
             # Update the solution for next stage
@@ -516,8 +516,8 @@ class DIRKIMEXMethod:
 
             chat.assign(C_hat[i+1])
             self.mass_solver.solve()
-            self.num_mass_nonlinear_iterations += self.mass_solver.getIterationNumber()
-            self.num_mass_linear_iterations += self.mass_solver.getLinearSolveIterations()
+            self.num_mass_nonlinear_iterations += self.mass_solver.snes.getIterationNumber()
+            self.num_mass_linear_iterations += self.mass_solver.snes.getLinearSolveIterations()
             k_hat_s[i + 1].assign(khat)
 
         # Final solution update

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -378,10 +378,6 @@ def getFormsIMEX(F, Fexp, ks, khats, butch, t, dt, u0, bcs=None):
     for bc in bcs:
         bcarg = as_ufl(bc._original_arg)
         bcarg_stage = replace(bcarg, {t: t+c*dt})
-        if bcarg_stage == 0:
-            # Homogeneous BC, just zero out stage dofs
-            bcnew.append(bc.reconstruct(g=0))
-            continue
 
         gdat = bcarg_stage - bc2space(bc, u0)
         for i in range(num_stages):
@@ -392,7 +388,7 @@ def getFormsIMEX(F, Fexp, ks, khats, butch, t, dt, u0, bcs=None):
         gdat /= dt*d_val
         bcnew.append(bc.reconstruct(g=gdat))
 
-        return stage_F, (k, g, a, c), bcnew, Fhat, (khat, ghat, chat), (a_vals, ahat_vals, d_val)
+    return stage_F, (k, g, a, c), bcnew, Fhat, (khat, ghat, chat), (a_vals, ahat_vals, d_val)
 
 
 class DIRKIMEXMethod:

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -309,57 +309,6 @@ class RadauIIAIMEXMethod:
                 self.num_linear_iterations_it)
 
 
-class BCThingy:
-    def __init__(self):
-        pass
-
-    def __call__(self, u):
-        return u
-
-
-class BCCompOfNotMixedThingy:
-    def __init__(self, comp):
-        self.comp = comp
-
-    def __call__(self, u):
-        return u[self.comp]
-
-
-class BCMixedBitThingy:
-    def __init__(self, sub):
-        self.sub = sub
-
-    def __call__(self, u):
-        return u.sub(self.sub)
-
-
-class BCCompOfMixedBitThingy:
-    def __init__(self, sub, comp):
-        self.sub = sub
-        self.comp = comp
-
-    def __call__(self, u):
-        return u.sub(self.sub)[self.comp]
-
-
-def getThingy(V, bc):
-    num_fields = len(V)
-    Vbc = bc.function_space()
-    if num_fields == 1:
-        comp = Vbc.component
-        if comp is None:
-            return BCThingy()
-        else:
-            return BCCompOfNotMixedThingy(comp)
-    else:
-        sub = bc.function_space_index()
-        comp = Vbc.component
-        if comp is None:
-            return BCMixedBitThingy(sub)
-        else:
-            return BCCompOfMixedBitThingy(sub, comp)
-
-
 def getFormsIMEX(F, Fexp, ks, khats, butch, t, dt, u0, bcs=None):
     if bcs is None:
         bcs = []

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -309,7 +309,7 @@ class RadauIIAIMEXMethod:
                 self.num_linear_iterations_it)
 
 
-def getFormsIMEX(F, Fexp, ks, khats, butch, t, dt, u0, bcs=None):
+def getFormsDIRKIMEX(F, Fexp, ks, khats, butch, t, dt, u0, bcs=None):
     if bcs is None:
         bcs = []
 
@@ -416,7 +416,7 @@ class DIRKIMEXMethod:
         self.ks = [Function(V) for _ in range(self.num_stages)]
         self.k_hat_s = [Function(V) for _ in range(self.num_stages+1)]
 
-        stage_F, (k, g, a, c), bcnew, Fhat, (khat, ghat, chat), (a_vals, ahat_vals, d_val) = getFormsIMEX(
+        stage_F, (k, g, a, c), bcnew, Fhat, (khat, ghat, chat), (a_vals, ahat_vals, d_val) = getFormsDIRKIMEX(
             F, F_explicit, self.ks, self.k_hat_s, butcher_tableau, t, dt, u0, bcs=bcs)
 
         self.bcnew = bcnew

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -9,7 +9,7 @@ from .bcs import EmbeddedBCData, bc2space
 from .dirk_stepper import DIRKTimeStepper
 from .explicit_stepper import ExplicitTimeStepper
 from .getForm import AI, getForm
-from .imex import RadauIIAIMEXMethod
+from .imex import RadauIIAIMEXMethod, DIRKIMEXMethod
 from .manipulation import extract_terms
 from .stage import StageValueTimeStepper
 
@@ -67,7 +67,8 @@ def TimeStepper(F, butcher_tableau, t, dt, u0, **kwargs):
         "imex": ["Fexp", "stage_type", "bcs", "nullspace",
                  "it_solver_parameters", "prop_solver_parameters",
                  "splitting", "appctx",
-                 "num_its_initial", "num_its_per_step"]}
+                 "num_its_initial", "num_its_per_step"],
+        "dirkimex": ["stage_type", "bcs", "nullspace", "solver_parameters", "mass_parameters", "appctx"]}
 
     valid_adapt_parameters = ["tol", "dtmin", "dtmax", "KI", "KP",
                               "max_reject", "onscale_factor",
@@ -161,6 +162,15 @@ def TimeStepper(F, butcher_tableau, t, dt, u0, **kwargs):
             it_solver_parameters, prop_solver_parameters,
             splitting, appctx, nullspace,
             num_its_initial, num_its_per_step)
+    elif stage_type == "dirkimex":
+        bcs = kwargs.get("bcs")
+        appctx = kwargs.get("appctx")
+        solver_parameters = kwargs.get("solver_parameters")
+        mass_parameters = kwargs.get("mass_parameters")
+        nullspace = kwargs.get("nullspace")
+        return DIRKIMEXMethod(
+            F, butcher_tableau, t, dt, u0, bcs,
+            solver_parameters, mass_parameters, appctx, nullspace)
 
 
 class StageDerivativeTimeStepper:

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -68,7 +68,7 @@ def TimeStepper(F, butcher_tableau, t, dt, u0, **kwargs):
                  "it_solver_parameters", "prop_solver_parameters",
                  "splitting", "appctx",
                  "num_its_initial", "num_its_per_step"],
-        "dirkimex": ["stage_type", "bcs", "nullspace", "solver_parameters", "mass_parameters", "appctx"]}
+        "dirkimex": ["Fexp", "stage_type", "bcs", "nullspace", "solver_parameters", "mass_parameters", "appctx"]}
 
     valid_adapt_parameters = ["tol", "dtmin", "dtmax", "KI", "KP",
                               "max_reject", "onscale_factor",
@@ -163,13 +163,15 @@ def TimeStepper(F, butcher_tableau, t, dt, u0, **kwargs):
             splitting, appctx, nullspace,
             num_its_initial, num_its_per_step)
     elif stage_type == "dirkimex":
+        Fexp = kwargs.get("Fexp")
+        assert Fexp is not None
         bcs = kwargs.get("bcs")
         appctx = kwargs.get("appctx")
         solver_parameters = kwargs.get("solver_parameters")
         mass_parameters = kwargs.get("mass_parameters")
         nullspace = kwargs.get("nullspace")
         return DIRKIMEXMethod(
-            F, butcher_tableau, t, dt, u0, bcs,
+            F, Fexp, butcher_tableau, t, dt, u0, bcs,
             solver_parameters, mass_parameters, appctx, nullspace)
 
 

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -147,7 +147,7 @@ def TimeStepper(F, butcher_tableau, t, dt, u0, **kwargs):
             solver_parameters, appctx)
     elif stage_type == "imex":
         Fexp = kwargs.get("Fexp")
-        assert Fexp is not None
+        assert Fexp is not None, "Calling an IMEX scheme with no explicit form.  Did you really mean to do this?"
         bcs = kwargs.get("bcs")
         appctx = kwargs.get("appctx")
         splitting = kwargs.get("splitting", AI)
@@ -164,7 +164,7 @@ def TimeStepper(F, butcher_tableau, t, dt, u0, **kwargs):
             num_its_initial, num_its_per_step)
     elif stage_type == "dirkimex":
         Fexp = kwargs.get("Fexp")
-        assert Fexp is not None
+        assert Fexp is not None, "Calling an IMEX scheme with no explicit form.  Did you really mean to do this?"
         bcs = kwargs.get("bcs")
         appctx = kwargs.get("appctx")
         solver_parameters = kwargs.get("solver_parameters")

--- a/tests/test_imex.py
+++ b/tests/test_imex.py
@@ -6,17 +6,17 @@ from irksome import Dt, MeshConstant, TimeStepper, IMEXEuler, IMEX2, IMEX3, IMEX
 from ufl.algorithms.ad import expand_derivatives
 
 
-def heat_neumannbc(butcher_tableau, order, N):
+def convdiff_neumannbc(butcher_tableau, order, N):
     msh = UnitIntervalMesh(N)
     V = FunctionSpace(msh, "CG", order)
     MC = MeshConstant(msh)
-    dt = MC.Constant(1.0 / N)
+    dt = MC.Constant(0.1 / N)
     t = MC.Constant(0.0)
     (x,) = SpatialCoordinate(msh)
 
     # Choose uexact so rhs is nonzero
     uexact = cos(pi*x)*exp(-t)
-    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact)) - uexact.dx(0)
     u = Function(V)
     u.interpolate(uexact)
 
@@ -24,8 +24,9 @@ def heat_neumannbc(butcher_tableau, order, N):
     F = (
         inner(Dt(u), v) * dx
         + inner(grad(u), grad(v)) * dx
+        - inner(rhs, v) * dx
     )
-    Fexp = inner(rhs, v) * dx
+    Fexp = inner(u.dx(0), v)*dx
 
     luparams = {"mat_type": "aij", "ksp_type": "preonly", "pc_type": "lu"}
 
@@ -35,7 +36,7 @@ def heat_neumannbc(butcher_tableau, order, N):
         stage_type="dirkimex"
     )
 
-    t_end = 1.0
+    t_end = 0.1
     while float(t) < t_end:
         if float(t) + float(dt) > t_end:
             dt.assign(t_end - float(t))
@@ -48,12 +49,12 @@ def heat_neumannbc(butcher_tableau, order, N):
 @pytest.mark.parametrize("butcher_tableau, order",
                          [(IMEXEuler(), 1), (IMEX2(), 2),
                           (IMEX3(), 3), (IMEX4(), 3)])
-def test_1d_heat_neumannbc(butcher_tableau, order):
-    errs = np.array([heat_neumannbc(butcher_tableau, order, 10*2**p) for p in [3, 4]])
+def test_1d_convdiff_neumannbc(butcher_tableau, order):
+    errs = np.array([convdiff_neumannbc(butcher_tableau, order, 10*2**p) for p in [3, 4]])
     print(errs)
     conv = np.log2(errs[0]/errs[1])
     print(conv)
-    assert conv > order-0.2
+    assert conv > order-0.4
 
 
 # Note IMEX4 is stiffly accurate, so satisfies BC checks.  IMEX2 and IMEX3 do not

--- a/tests/test_imex.py
+++ b/tests/test_imex.py
@@ -2,12 +2,12 @@ from math import isclose
 
 import pytest
 from firedrake import *
-from irksome import Dt, MeshConstant, TimeStepper, IMEX4
+from irksome import Dt, MeshConstant, TimeStepper, IMEXEuler, IMEX4
 from ufl.algorithms.ad import expand_derivatives
 
 
 # Note IMEX4 is stiffly accurate, so satisfies BC checks.  IMEX2 and IMEX3 do not
-@pytest.mark.parametrize("butcher_tableau", [IMEX4()])
+@pytest.mark.parametrize("butcher_tableau", [IMEXEuler(), IMEX4()])
 def test_1d_heat_dirichletbc(butcher_tableau):
     # Boundary values
     u_0 = Constant(2.0)

--- a/tests/test_imex.py
+++ b/tests/test_imex.py
@@ -2,7 +2,7 @@ from math import isclose
 
 import pytest
 from firedrake import *
-from irksome import Dt, MeshConstant, TimeStepper, IMEXEuler, IMEX2, IMEX3, IMEX4
+from irksome import Dt, MeshConstant, TimeStepper, DIRK_IMEX
 from ufl.algorithms.ad import expand_derivatives
 
 
@@ -46,22 +46,25 @@ def convdiff_neumannbc(butcher_tableau, order, N):
     return (errornorm(uexact, u) / norm(uexact))
 
 
-@pytest.mark.parametrize("butcher_tableau, order",
-                         [(IMEXEuler(), 1), (IMEX2(), 2),
-                          (IMEX3(), 3), (IMEX4(), 3)])
-def test_1d_convdiff_neumannbc(butcher_tableau, order):
-    errs = np.array([convdiff_neumannbc(butcher_tableau, order, 10*2**p) for p in [3, 4]])
+@pytest.mark.parametrize("imp_stages, exp_stages, order",
+                         [(1, 1, 1), (2, 3, 2),
+                          (3, 4, 3), (4, 4, 3)])
+def test_1d_convdiff_neumannbc(imp_stages, exp_stages, order):
+    bt = DIRK_IMEX(imp_stages, exp_stages, order)
+    errs = np.array([convdiff_neumannbc(bt, order, 10*2**p) for p in [3, 4]])
     print(errs)
     conv = np.log2(errs[0]/errs[1])
     print(conv)
     assert conv > order-0.4
 
 
-# Note IMEX4 is stiffly accurate, so the DAE-style BC imposition leads
-# to satisfying the BCs exactly at each timestep, which we check here.
-# IMEX2 and IMEX3 do not have this property
-@pytest.mark.parametrize("butcher_tableau", [IMEXEuler(), IMEX4()])
-def test_1d_heat_dirichletbc(butcher_tableau):
+# Note that DIRK_IMEX(1,1,1) and DIRK_IMEX(4,4,2) are stiffly
+# accurate, so the DAE-style BC imposition leads to satisfying the BCs
+# exactly at each timestep, which we check here.  The 2- and 3-stage
+# methods are not.
+@pytest.mark.parametrize("imp_stages, exp_stages, order",
+                         [(1, 1, 1), (4, 4, 3)])
+def test_1d_heat_dirichletbc(imp_stages, exp_stages, order):
     # Boundary values
     u_0 = Constant(2.0)
     u_1 = Constant(3.0)
@@ -104,6 +107,7 @@ def test_1d_heat_dirichletbc(butcher_tableau):
 
     luparams = {"mat_type": "aij", "ksp_type": "preonly", "pc_type": "lu"}
 
+    butcher_tableau = DIRK_IMEX(imp_stages, exp_stages, order)
     stepper = TimeStepper(
         F, butcher_tableau, t, dt, u, Fexp=Fexp, bcs=bc,
         solver_parameters=luparams, mass_parameters=luparams,

--- a/tests/test_imex.py
+++ b/tests/test_imex.py
@@ -57,7 +57,9 @@ def test_1d_convdiff_neumannbc(butcher_tableau, order):
     assert conv > order-0.4
 
 
-# Note IMEX4 is stiffly accurate, so satisfies BC checks.  IMEX2 and IMEX3 do not
+# Note IMEX4 is stiffly accurate, so the DAE-style BC imposition leads
+# to satisfying the BCs exactly at each timestep, which we check here.
+# IMEX2 and IMEX3 do not have this property
 @pytest.mark.parametrize("butcher_tableau", [IMEXEuler(), IMEX4()])
 def test_1d_heat_dirichletbc(butcher_tableau):
     # Boundary values

--- a/tests/test_imex.py
+++ b/tests/test_imex.py
@@ -16,7 +16,7 @@ def convdiff_neumannbc(butcher_tableau, order, N):
 
     # Choose uexact so rhs is nonzero
     uexact = cos(pi*x)*exp(-t)
-    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact)) - uexact.dx(0)
+    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact)) + uexact.dx(0)
     u = Function(V)
     u.interpolate(uexact)
 
@@ -98,7 +98,7 @@ def test_1d_heat_dirichletbc(imp_stages, exp_stages, order):
         inner(Dt(u), v) * dx
         + inner(grad(u), grad(v)) * dx
     )
-    Fexp = inner(rhs, v) * dx
+    Fexp = -inner(rhs, v) * dx
 
     bc = [
         DirichletBC(V, u_1, 2),

--- a/tests/test_imex.py
+++ b/tests/test_imex.py
@@ -1,0 +1,69 @@
+from math import isclose
+
+import pytest
+from firedrake import *
+from irksome import Dt, MeshConstant, TimeStepper, IMEX4
+from ufl.algorithms.ad import expand_derivatives
+
+
+# Note IMEX4 is stiffly accurate, so satisfies BC checks.  IMEX2 and IMEX3 do not
+@pytest.mark.parametrize("butcher_tableau", [IMEX4()])
+def test_1d_heat_dirichletbc(butcher_tableau):
+    # Boundary values
+    u_0 = Constant(2.0)
+    u_1 = Constant(3.0)
+
+    N = 10
+    x0 = 0.0
+    x1 = 10.0
+    msh = IntervalMesh(N, x1)
+    V = FunctionSpace(msh, "CG", 1)
+    MC = MeshConstant(msh)
+    dt = MC.Constant(1.0 / N)
+    t = MC.Constant(0.0)
+    (x,) = SpatialCoordinate(msh)
+
+    # Method of manufactured solutions copied from Heat equation demo.
+    S = Constant(2.0)
+    C = Constant(1000.0)
+    B = (x - Constant(x0)) * (x - Constant(x1)) / C
+    R = (x * x) ** 0.5
+    # Note end linear contribution
+    uexact = (
+        B * atan(t) * (pi / 2.0 - atan(S * (R - t)))
+        + u_0
+        + ((x - x0) / x1) * (u_1 - u_0)
+    )
+    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+    u = Function(V)
+    u.interpolate(uexact)
+    v = TestFunction(V)
+    F = (
+        inner(Dt(u), v) * dx
+        + inner(grad(u), grad(v)) * dx
+    )
+    Fexp = inner(rhs, v) * dx
+
+    bc = [
+        DirichletBC(V, u_1, 2),
+        DirichletBC(V, u_0, 1),
+    ]
+
+    luparams = {"mat_type": "aij", "ksp_type": "preonly", "pc_type": "lu"}
+
+    stepper = TimeStepper(
+        F, butcher_tableau, t, dt, u, Fexp=Fexp, bcs=bc,
+        solver_parameters=luparams, mass_parameters=luparams,
+        stage_type="dirkimex"
+    )
+
+    t_end = 2.0
+    while float(t) < t_end:
+        if float(t) + float(dt) > t_end:
+            dt.assign(t_end - float(t))
+        stepper.advance()
+        t.assign(float(t) + float(dt))
+        # Check solution and boundary values
+        assert errornorm(uexact, u) / norm(uexact) < 10.0 ** -3
+        assert isclose(u.at(x0), u_0)
+        assert isclose(u.at(x1), u_1)


### PR DESCRIPTION
This adds an implementation of the DIRK-IMEX method from the Ascher-Ruuth-Spiteri 1997 Applied Numerical Mathematics paper.  Mostly this layers the IMEX part on top of the existing DIRK code (but is different enough that reuse is not feasible).