### PR TITLE
Refactor replacements

### DIFF
--- a/irksome/deriv.py
+++ b/irksome/deriv.py
@@ -3,6 +3,7 @@ from ufl.core.ufl_type import ufl_type
 from ufl.corealg.multifunction import MultiFunction
 from ufl.algorithms.map_integrands import map_integrand_dags, map_expr_dag
 from ufl.algorithms.apply_derivatives import GenericDerivativeRuleset
+from ufl.tensors import ListTensor
 
 
 @ufl_type(num_ops=1,
@@ -16,6 +17,8 @@ class TimeDerivative(Derivative):
     __slots__ = ()
 
     def __new__(cls, f):
+        if isinstance(f, ListTensor):
+            return ListTensor(*map(TimeDerivative, f.ufl_operands))
         return Derivative.__new__(cls)
 
     def __init__(self, f):

--- a/irksome/dirk_stepper.py
+++ b/irksome/dirk_stepper.py
@@ -2,7 +2,6 @@ import numpy
 from firedrake import Function
 from firedrake import NonlinearVariationalProblem as NLVP
 from firedrake import NonlinearVariationalSolver as NLVS
-from firedrake import split
 from ufl.constantvalue import as_ufl
 
 from .deriv import TimeDerivative
@@ -19,21 +18,9 @@ def getFormDIRK(F, ks, butch, t, dt, u0, bcs=None):
     msh = V.mesh()
     assert V == u0.function_space()
 
-    num_fields = len(V)
     num_stages = butch.num_stages
     k = Function(V)
     g = Function(V)
-
-    # If we're on a mixed problem, we need to replace pieces of the
-    # solution.  Stores an array of the splittings of the k for each stage.
-    if num_fields == 1:
-        k_bits = [k]
-        u0bits = [u0]
-        gbits = [g]
-    else:
-        k_bits = numpy.array(split(k), dtype=object)
-        u0bits = split(u0)
-        gbits = split(g)
 
     # Note: the Constant c is used for substitution in both the
     # variational form and BC's, and we update it for each stage in
@@ -44,9 +31,11 @@ def getFormDIRK(F, ks, butch, t, dt, u0, bcs=None):
     a = MC.Constant(1.0)
 
     repl = {t: t+c*dt}
-    for u0bit, kbit, gbit in zip(u0bits, k_bits, gbits):
-        repl[u0bit] = gbit + dt * a * kbit
-        repl[TimeDerivative(u0bit)] = kbit
+    repl[u0] = g + dt * a * k
+    repl[TimeDerivative(u0)] = k
+    for i in numpy.ndindex(u0.ufl_shape):
+        repl[u0[i]] = repl[u0][i]
+        repl[TimeDerivative(u0[i])] = k[i]
     stage_F = replace(F, repl)
 
     bcnew = []

--- a/irksome/dirk_stepper.py
+++ b/irksome/dirk_stepper.py
@@ -5,7 +5,7 @@ from firedrake import NonlinearVariationalSolver as NLVS
 from ufl.constantvalue import as_ufl
 
 from .deriv import TimeDerivative
-from .tools import replace, MeshConstant
+from .tools import component_replace, replace, MeshConstant
 from .bcs import bc2space
 
 
@@ -30,13 +30,10 @@ def getFormDIRK(F, ks, butch, t, dt, u0, bcs=None):
     c = MC.Constant(1.0)
     a = MC.Constant(1.0)
 
-    repl = {t: t+c*dt}
-    repl[u0] = g + dt * a * k
-    repl[TimeDerivative(u0)] = k
-    for i in numpy.ndindex(u0.ufl_shape):
-        repl[u0[i]] = repl[u0][i]
-        repl[TimeDerivative(u0[i])] = k[i]
-    stage_F = replace(F, repl)
+    repl = {t: t+c*dt,
+            u0: g + dt * a * k,
+            TimeDerivative(u0): k}
+    stage_F = component_replace(F, repl)
 
     bcnew = []
 

--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -4,12 +4,11 @@ from FIAT import (Bernstein, DiscontinuousElement,
                   IntegratedLegendre, Lagrange,
                   make_quadrature, ufc_simplex)
 from operator import mul
-from ufl.classes import Zero
+from ufl import as_tensor, zero
 from ufl.constantvalue import as_ufl
 from .bcs import stage2spaces4bc
 from .manipulation import extract_terms, strip_dt_form
-from .stage import getBits
-from .tools import getNullspace, replace
+from .tools import getNullspace, component_replace, replace
 import numpy as np
 from firedrake import as_vector, Constant, dot, TestFunction, Function, NonlinearVariationalProblem as NLVP, NonlinearVariationalSolver as NLVS
 from firedrake.dmhooks import pop_parent, push_parent
@@ -57,7 +56,6 @@ def getFormDiscGalerkin(F, L, Q, t, dt, u0, bcs=None, nullspace=None):
 
     vecconst = Constant
 
-    num_fields = len(V)
     num_stages = L.space_dimension()
 
     Vbig = reduce(mul, (V for _ in range(num_stages)))
@@ -87,13 +85,13 @@ def getFormDiscGalerkin(F, L, Q, t, dt, u0, bcs=None, nullspace=None):
     # L2 projector
     proj = Constant(np.linalg.solve(mmat, np.multiply(basis_vals, qwts)))
 
-    u0bits, vbits, VVbits, UUbits = getBits(num_stages, num_fields,
-                                            u0, UU, v, VV)
+    u_np = np.reshape(UU, (num_stages, *u0.ufl_shape))
+    v_np = np.reshape(VV, (num_stages, *u0.ufl_shape))
 
     split_form = extract_terms(F)
     dtless = strip_dt_form(split_form.time)
 
-    Fnew = Zero()
+    Fnew = zero()
 
     basis_vals = vecconst(basis_vals)
     basis_dvals = vecconst(basis_dvals)
@@ -103,57 +101,38 @@ def getFormDiscGalerkin(F, L, Q, t, dt, u0, bcs=None, nullspace=None):
 
     # Terms with time derivatives
     for i in range(num_stages):
-        repl = {}
-        for j in range(num_fields):
-            repl[vbits[j]] = VVbits[i][j]
-            for ii in np.ndindex(vbits[j].ufl_shape):
-                repl[vbits[j][ii]] = VVbits[i][j][ii]
-        F_i = replace(dtless, repl)
+        repl = {v: v_np[i]}
+        F_i = component_replace(dtless, repl)
 
         # now loop over quadrature points
         for q in range(len(qpts)):
             repl = {t: t + dt * qpts[q]}
-            for k in range(num_fields):
-                d_tosub = sum(basis_dvals[ell, q] * UUbits[ell][k] for ell in range(num_stages)) / dt
-                repl[u0bits[k]] = d_tosub
 
-                for ii in np.ndindex(u0bits[k].ufl_shape):
-                    d_tosub = sum(basis_dvals[ell, q] * UUbits[ell][k][ii]
-                                  for ell in range(num_stages)) / dt
-                    repl[u0bits[k][ii]] = d_tosub
+            d_tosub = sum(basis_dvals[ell, q] * u_np[ell] for ell in range(num_stages)) / dt
+            repl[u0] = d_tosub
+
             Fnew += dt * qwts[q] * basis_vals[i, q] * replace(F_i, repl)
 
     # jump terms
-    repl = {}
-    for k in range(num_fields):
-        repl[u0bits[k]] = UUbits[0][k] - u0bits[k]
-        repl[vbits[k]] = VVbits[0][k]
-        for ii in np.ndindex(u0bits[k].ufl_shape):
-            repl[u0bits[k][ii]] = UUbits[0][k][ii] - u0bits[k][ii]
-            repl[vbits[k][ii]] = VVbits[0][k][ii]
-    Fnew += replace(dtless, repl)
+    repl = {u0: as_tensor(u_np[0]) - u0,
+            v: v_np[0]}
+
+    Fnew += component_replace(dtless, repl)
 
     # handle the rest of the terms
     for i in range(num_stages):
-        repl = {}
-        for j in range(num_fields):
-            repl[vbits[j]] = VVbits[i][j]
-            for ii in np.ndindex(vbits[j].ufl_shape):
-                repl[vbits[j][ii]] = VVbits[i][j][ii]
-        F_i = replace(split_form.remainder, repl)
+        repl = {v: v_np[i]}
+
+        F_i = component_replace(split_form.remainder, repl)
 
         # now loop over quadrature points
         for q in range(len(qpts)):
             repl = {t: t + dt * qpts[q]}
-            for k in range(num_fields):
-                tosub = sum(basis_vals[ell, q] * UUbits[ell][k] for ell in range(num_stages))
-                repl[u0bits[k]] = tosub
 
-                for ii in np.ndindex(u0bits[k].ufl_shape):
-                    tosub = sum(basis_vals[ell, q] * UUbits[ell][k][ii]
-                                for ell in range(num_stages))
-                    repl[u0bits[k][ii]] = tosub
-            Fnew += dt * qwts[q] * basis_vals[i, q] * replace(F_i, repl)
+            tosub = sum(basis_vals[ell, q] * u_np[ell] for ell in range(num_stages))
+            repl[u0] = tosub
+
+            Fnew += dt * qwts[q] * basis_vals[i, q] * component_replace(F_i, repl)
 
     # Oh, honey, is it the boundary conditions?
     if bcs is None:

--- a/irksome/galerkin_stepper.py
+++ b/irksome/galerkin_stepper.py
@@ -7,8 +7,7 @@ from ufl.classes import Zero
 from ufl.constantvalue import as_ufl
 from .bcs import bc2space, stage2spaces4bc
 from .deriv import TimeDerivative
-from .stage import getBits
-from .tools import getNullspace, replace
+from .tools import getNullspace, component_replace, replace
 import numpy as np
 from firedrake import as_vector, dot, Constant, TestFunction, Function, NonlinearVariationalProblem as NLVP, NonlinearVariationalSolver as NLVS
 from firedrake.dmhooks import pop_parent, push_parent
@@ -57,12 +56,14 @@ def getFormGalerkin(F, L_trial, L_test, Q, t, dt, u0, bcs=None, nullspace=None):
     V = v.function_space()
     assert V == u0.function_space()
 
-    num_fields = len(V)
     num_stages = L_test.space_dimension()
 
     Vbig = reduce(mul, (V for _ in range(num_stages)))
     VV = TestFunction(Vbig)
     UU = Function(Vbig)  # u0 + this are coefficients of the Galerkin polynomial
+
+    u_np = np.reshape(UU, (num_stages, *u0.ufl_shape))
+    v_np = np.reshape(VV, (num_stages, *u0.ufl_shape))
 
     qpts = Q.get_points()
     qwts = Q.get_weights()
@@ -84,9 +85,6 @@ def getFormGalerkin(F, L_trial, L_test, Q, t, dt, u0, bcs=None, nullspace=None):
     # L2 projector
     proj = Constant(np.linalg.solve(mmat, np.multiply(test_vals, qwts)))
 
-    u0bits, vbits, VVbits, UUbits = getBits(num_stages, num_fields,
-                                            u0, UU, v, VV)
-
     Fnew = Zero()
 
     trial_vals = Constant(trial_vals)
@@ -96,35 +94,24 @@ def getFormGalerkin(F, L_trial, L_test, Q, t, dt, u0, bcs=None, nullspace=None):
     qwts = Constant(qwts)
 
     for i in range(num_stages):
-        repl = {}
-        for j in range(num_fields):
-            repl[vbits[j]] = VVbits[i][j]
-            for ii in np.ndindex(vbits[j].ufl_shape):
-                repl[vbits[j][ii]] = VVbits[i][j][ii]
-        F_i = replace(F, repl)
+        repl = {v: v_np[i]}
+        F_i = component_replace(F, repl)
 
         # now loop over quadrature points
         for q in range(len(qpts)):
             repl = {t: t + dt * qpts[q]}
-            for k in range(num_fields):
-                tosub = u0bits[k] * trial_vals[0, q]
-                d_tosub = u0bits[k] * trial_dvals[0, q]
-                for ell in range(num_stages):
-                    tosub += UUbits[ell][k] * trial_vals[1 + ell, q]
-                    d_tosub += UUbits[ell][k] * trial_dvals[1 + ell, q]
 
-                repl[u0bits[k]] = tosub
-                repl[TimeDerivative(u0bits[k])] = d_tosub / dt
+            tosub = u0 * trial_vals[0, q]
+            d_tosub = u0 * trial_dvals[0, q]
 
-                for ii in np.ndindex(u0bits[k].ufl_shape):
-                    tosub = u0bits[k][ii] * trial_vals[0, q]
-                    d_tosub = u0bits[k][ii] * trial_dvals[0, q]
-                    for ell in range(num_stages):
-                        tosub += UUbits[ell][k][ii] * trial_vals[1 + ell, q]
-                        d_tosub += UUbits[ell][k][ii] * trial_dvals[1 + ell, q]
-                    repl[u0bits[k][ii]] = tosub
-                    repl[TimeDerivative(u0bits[k][ii])] = d_tosub / dt
-            Fnew += dt * qwts[q] * test_vals[i, q] * replace(F_i, repl)
+            for ell in range(num_stages):
+                tosub += u_np[ell] * trial_vals[1 + ell, q]
+                d_tosub += u_np[ell] * trial_dvals[1 + ell, q]
+
+            repl[u0] = tosub
+            repl[TimeDerivative(u0)] = d_tosub / dt
+
+            Fnew += dt * qwts[q] * test_vals[i, q] * component_replace(F_i, repl)
 
     # Oh, honey, is it the boundary conditions?
     if bcs is None:

--- a/irksome/getForm.py
+++ b/irksome/getForm.py
@@ -3,9 +3,8 @@ from operator import mul
 
 import numpy
 from firedrake import Constant, Function, TestFunction
-from ufl import as_tensor, diff, dot
+from ufl import as_tensor, diff, dot, zero
 from ufl.algorithms import expand_derivatives
-from ufl.classes import Zero
 from ufl.constantvalue import as_ufl
 from .tools import component_replace, replace, getNullspace, AI, ConstantOrZero
 from .deriv import TimeDerivative  # , apply_time_derivatives
@@ -98,13 +97,13 @@ def getForm(F, butch, t, dt, u0, bcs=None, bc_type=None, splitting=AI,
     A1w = A1 @ w_np
     A2invw = A2inv @ w_np
 
-    Fnew = Zero()
+    Fnew = zero()
     dtu = TimeDerivative(u0)
 
     for i in range(num_stages):
         repl = {t: t + c[i] * dt,
                 v: v_np[i],
-                u0: u0 + dt * as_tensor(A1w[i]),
+                u0: u0 + dt * A1w[i],
                 dtu: A2invw[i]}
 
         Fnew += component_replace(F, repl)
@@ -115,7 +114,7 @@ def getForm(F, butch, t, dt, u0, bcs=None, bc_type=None, splitting=AI,
         bcs = []
     if bc_type == "ODE":
         assert splitting == AI, "ODE-type BC aren't implemented for this splitting strategy"
-        u0_mult = Zero(butch.c.shape)
+        u0_mult = zero(butch.c.shape)
 
         def bc2gcur(bc, i):
             gorig = as_ufl(bc._original_arg)

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -4,7 +4,7 @@ from firedrake import (Function, NonlinearVariationalProblem,
                        NonlinearVariationalSolver, TestFunction,
                        as_ufl, dx, inner)
 from firedrake.dmhooks import pop_parent, push_parent
-from ufl.classes import Zero
+from ufl import zero
 
 from .ButcherTableaux import RadauIIA
 from .deriv import TimeDerivative
@@ -56,8 +56,8 @@ def getFormExplicit(Fexp, butch, u0, UU, t, dt, splitting=None):
     v_np = np.reshape(VV, (num_stages, *u0.ufl_shape))
     u_np = np.reshape(UU, (num_stages, *u0.ufl_shape))
 
-    Fit = Zero()
-    Fprop = Zero()
+    Fit = zero()
+    Fprop = zero()
 
     if splitting == AI:
         for i in range(num_stages):

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -65,17 +65,19 @@ def getFormExplicit(Fexp, butch, u0, UU, t, dt, splitting=None):
             # replace test function
             repl = {}
 
+            repl[v] = as_tensor(v_np[i])
             for k in np.ndindex(u0.ufl_shape):
-                repl[v[k]] = v_np[i][k]
+                repl[v[k]] = repl[v][k]
 
             Ftmp = replace(Fexp, repl)
 
             # replace the solution with stage values
             for j in range(num_stages):
-                repl = {t: t + C[j] * dt}
+                repl = {t: t + C[j] * dt,
+                        u0: as_tensor(u_np[j])}
 
                 for k in np.ndindex(u0.ufl_shape):
-                    repl[u0[k]] = u_np[j][k]
+                    repl[u0[k]] = repl[u0][k]
 
                 # and sum the contribution
                 replF = replace(Ftmp, repl)

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -4,7 +4,7 @@ from firedrake import (Function, NonlinearVariationalProblem,
                        NonlinearVariationalSolver, TestFunction,
                        as_ufl, dx, inner)
 from firedrake.dmhooks import pop_parent, push_parent
-from ufl import as_tensor, Zero
+from ufl.classes import Zero
 
 from .ButcherTableaux import RadauIIA
 from .deriv import TimeDerivative
@@ -68,7 +68,7 @@ def getFormExplicit(Fexp, butch, u0, UU, t, dt, splitting=None):
             # replace the solution with stage values
             for j in range(num_stages):
                 repl = {t: t + C[j] * dt,
-                        u0: as_tensor(u_np[j])}
+                        u0: u_np[j]}
 
                 # and sum the contribution
                 replF = component_replace(Ftmp, repl)
@@ -226,6 +226,7 @@ class RadauIIAIMEXMethod:
 
         num_fields = len(self.u0.function_space())
         u0split = u0.subfunctions
+
         for i, u0bit in enumerate(u0split):
             for s in range(self.num_stages):
                 ii = s * num_fields + i

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -1,15 +1,15 @@
 import FIAT
 import numpy as np
-from firedrake import (Constant, Function, NonlinearVariationalProblem,
+from firedrake import (Function, NonlinearVariationalProblem,
                        NonlinearVariationalSolver, TestFunction,
-                       as_ufl, dx, inner, split)
+                       as_ufl, dx, inner)
 from firedrake.dmhooks import pop_parent, push_parent
-from ufl.classes import Zero
+from ufl import as_tensor, Zero
 
 from .ButcherTableaux import RadauIIA
 from .deriv import TimeDerivative
 from .stage import getFormStage
-from .tools import AI, ConstantOrZero, IA, MeshConstant, component_replace
+from .tools import AI, ConstantOrZero, IA, MeshConstant, replace, component_replace
 from .bcs import bc2space
 
 
@@ -40,7 +40,6 @@ def getFormExplicit(Fexp, butch, u0, UU, t, dt, splitting=None):
     method.  Returns the forms for both the iterator and propagator,
     which really just differ by which constants are in them."""
     v = Fexp.arguments()[0]
-    V = v.function_space()
     Vbig = UU.function_space()
     VV = TestFunction(Vbig)
 
@@ -290,7 +289,6 @@ def getFormsDIRKIMEX(F, Fexp, ks, khats, butch, t, dt, u0, bcs=None):
     msh = V.mesh()
     assert V == u0.function_space()
 
-    num_fields = len(V)
     num_stages = butch.num_stages
     k = Function(V)
     g = Function(V)

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -226,7 +226,6 @@ class RadauIIAIMEXMethod:
 
         num_fields = len(self.u0.function_space())
         u0split = u0.subfunctions
-
         for i, u0bit in enumerate(u0split):
             for s in range(self.num_stages):
                 ii = s * num_fields + i

--- a/irksome/stage.py
+++ b/irksome/stage.py
@@ -171,14 +171,14 @@ def getFormStage(F, butch, u0, t, dt, bcs=None, splitting=None, vandermonde=None
             repl = {v: as_tensor(v_np[i])}
 
             for k in np.ndindex(u0.ufl_shape):
-                repl[v[k]] = repl[v][k]#v_np[i][k]
+                repl[v[k]] = repl[v][k]
 
             Ftmp = replace(split_form.remainder, repl)
 
             # replace the solution with stage values
             for j in range(num_stages):
                 repl = {t: t + C[j] * dt,
-                        u0: as_tensor(U_np[j]) }
+                        u0: as_tensor(U_np[j])}
                 for k in np.ndindex(u0.ufl_shape):
                     repl[u0[k]] = repl[u0][k]
 

--- a/irksome/stage.py
+++ b/irksome/stage.py
@@ -1,5 +1,4 @@
 # formulate RK methods to solve for stage values rather than the stage derivatives.
-from collections.abc import Iterable
 from functools import reduce
 from operator import mul
 
@@ -7,7 +6,7 @@ import numpy as np
 from FIAT import Bernstein, ufc_simplex
 from firedrake import (Function, NonlinearVariationalProblem,
                        NonlinearVariationalSolver, TestFunction, dx,
-                       inner, split)
+                       inner)
 from firedrake.petsc import PETSc
 from ufl import as_tensor
 from ufl.classes import Zero

--- a/irksome/stage.py
+++ b/irksome/stage.py
@@ -19,29 +19,6 @@ from .manipulation import extract_terms, strip_dt_form
 from .tools import (AI, IA, ConstantOrZero, getNullspace, is_ode, replace)
 
 
-def isiterable(x):
-    return hasattr(x, "__iter__") or isinstance(x, Iterable)
-
-
-def split_field(num_fields, u):
-    ubits = np.array(split(u), dtype="O")
-    return ubits
-
-
-def split_stage_field(num_stages, num_fields, UU):
-    UUbits = np.reshape(np.asarray(split(UU), dtype="O"),
-                        (num_stages, num_fields))
-    return UUbits
-
-
-def getBits(num_stages, num_fields, u0, UU, v, VV):
-    u0bits, vbits = (split_field(num_fields, x) for x in (u0, v))
-    UUbits, VVbits = (split_stage_field(num_stages, num_fields, x)
-                      for x in (UU, VV))
-
-    return u0bits, vbits, VVbits, UUbits
-
-
 def getFormStage(F, butch, u0, t, dt, bcs=None, splitting=None, vandermonde=None,
                  bc_constraints=None, nullspace=None):
     """Given a time-dependent variational form and a

--- a/irksome/stage.py
+++ b/irksome/stage.py
@@ -92,9 +92,6 @@ def getFormStage(F, butch, u0, t, dt, bcs=None, splitting=None, vandermonde=None
     ZZ = Function(Vbig)
 
     # set up the pieces we need to work with to do our substitutions
-    # u0bits, vbits, VVbits, ZZbits = getBits(num_stages, num_fields,
-    #                                         u0, ZZ, v, VV)
-
     v_np = np.reshape(VV, (num_stages, *u0.ufl_shape))
     z_np = np.reshape(ZZ, (num_stages, *u0.ufl_shape))
 

--- a/irksome/stage.py
+++ b/irksome/stage.py
@@ -8,8 +8,7 @@ from firedrake import (Function, NonlinearVariationalProblem,
                        NonlinearVariationalSolver, TestFunction, dx,
                        inner)
 from firedrake.petsc import PETSc
-from ufl import as_tensor
-from ufl.classes import Zero
+from ufl import zero
 from ufl.constantvalue import as_ufl
 
 from .bcs import stage2spaces4bc
@@ -116,7 +115,7 @@ def getFormStage(F, butch, u0, t, dt, bcs=None, splitting=None, vandermonde=None
 
     split_form = extract_terms(F)
 
-    Fnew = Zero()
+    Fnew = zero()
 
     # first, process terms with a time derivative.  I'm
     # assuming we have something of the form inner(Dt(g(u0)), v)*dx
@@ -130,7 +129,7 @@ def getFormStage(F, butch, u0, t, dt, bcs=None, splitting=None, vandermonde=None
         # time derivative part
         for i in range(num_stages):
             repl = {t: t+C[i]*dt,
-                    u0: as_tensor(u_np[i]) - u0,
+                    u0: u_np[i] - u0,
                     v: v_np[i]}
 
             Fnew += component_replace(dtless, repl)
@@ -138,8 +137,7 @@ def getFormStage(F, butch, u0, t, dt, bcs=None, splitting=None, vandermonde=None
         # Now for the non-time derivative parts
         for i in range(num_stages):
             # replace test function
-            repl = {v: as_tensor(v_np[i])}
-
+            repl = {v: v_np[i]}
             Ftmp = component_replace(split_form.remainder, repl)
 
             # replace the solution with stage values
@@ -160,7 +158,7 @@ def getFormStage(F, butch, u0, t, dt, bcs=None, splitting=None, vandermonde=None
 
             for j in range(num_stages):
                 repl = {t: t + C[j] * dt,
-                        u0: as_tensor(u_np[j]) - u0}
+                        u0: u_np[j] - u0}
 
                 Fnew += Ainv[i, j] * component_replace(Ftmp, repl)
         # rest of the operator: just diagonal!

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -1,5 +1,5 @@
 import numpy
-from firedrake import Function, FunctionSpace, MixedVectorSpaceBasis, split, Constant
+from firedrake import Function, FunctionSpace, MixedVectorSpaceBasis, Constant
 from ufl.algorithms.analysis import extract_type, has_exact_type
 from ufl.algorithms.map_integrands import map_integrand_dags
 from ufl.classes import CoefficientDerivative, Zero
@@ -107,7 +107,7 @@ def is_ode(f, u):
     blah = extract_type(f, TimeDerivative)
 
     Dtbits = set(b.ufl_operands[0] for b in blah)
-    ubits = set(split(u))
+    ubits = set(u[i] for i in numpy.ndindex(u.ufl_shape))
     return Dtbits == ubits
 
 

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -1,5 +1,5 @@
 import numpy
-from firedrake import Function, FunctionSpace, MixedVectorSpaceBasis, split
+from firedrake import Function, FunctionSpace, MixedVectorSpaceBasis, split, Constant
 from ufl.algorithms.analysis import extract_type, has_exact_type
 from ufl.algorithms.map_integrands import map_integrand_dags
 from ufl.classes import CoefficientDerivative, Zero
@@ -119,5 +119,6 @@ class MeshConstant(object):
         return Function(self.V).assign(val)
 
 
-def ConstantOrZero(x, MC):
-    return Zero() if abs(complex(x)) < 1.e-10 else MC.Constant(x)
+def ConstantOrZero(x, MC=None):
+    const = MC.Constant if MC else Constant
+    return Zero() if abs(complex(x)) < 1.e-10 else const(x)

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -3,10 +3,8 @@ from firedrake import Function, FunctionSpace, MixedVectorSpaceBasis, Constant
 from ufl.algorithms.analysis import extract_type, has_exact_type
 from ufl.algorithms.map_integrands import map_integrand_dags
 from ufl.classes import CoefficientDerivative, Zero
-from ufl.constantvalue import as_ufl, Identity
+from ufl.constantvalue import as_ufl
 from ufl.corealg.multifunction import MultiFunction
-from ufl.operators import diag
-from ufl.tensors import as_tensor
 
 from irksome.deriv import TimeDerivative
 
@@ -124,15 +122,3 @@ class MeshConstant(object):
 def ConstantOrZero(x, MC=None):
     const = MC.Constant if MC else Constant
     return Zero() if abs(complex(x)) < 1.e-10 else const(x)
-
-
-def numpy_to_ufl(x):
-    shape = x.shape
-    if len(shape) == 2 and shape[0] == shape[1] and numpy.allclose(x, numpy.eye(*shape)):
-        return Identity(shape[0])
-    elif numpy.allclose(x, numpy.diag(x.diagonal())):
-        return diag(Constant(x.diagonal()))
-    elif numpy.allclose(x, numpy.tril(x)) or numpy.allclose(x, numpy.triu(x)):
-        return as_tensor(numpy.vectorize(ConstantOrZero)(x))
-    else:
-        return Constant(x)

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -103,8 +103,7 @@ def component_replace(e, mapping):
     # Replace, reccurring on components
     cmapping = {}
     for key, value in mapping.items():
-        value = as_tensor(value)
-        cmapping[key] = value
+        cmapping[key] = as_tensor(value)
         if key.ufl_shape:
             for j in numpy.ndindex(key.ufl_shape):
                 cmapping[get_component(key, j)] = value[j]

--- a/tests/test_dirk.py
+++ b/tests/test_dirk.py
@@ -1,5 +1,5 @@
 from math import isclose
-
+import numpy
 import pytest
 from firedrake import *
 from irksome import WSODIRK, Alexander, Dt, MeshConstant, TimeStepper
@@ -257,7 +257,7 @@ def test_stokes_bcs(butcher_tableau, bctype):
          - inner(q, div(u))*dx
          - inner(u_rhs, v)*dx
          - inner(p_rhs, q)*dx)
-    Fdirk = replace(F, {u: u_dirk, p: p_dirk})
+    Fdirk = replace(F, {z[i]: z_dirk[i] for i in numpy.ndindex(z.ufl_shape)})
 
     nsp = [(1, VectorSpaceBasis(constant=True))]
     nsp_dirk = MixedVectorSpaceBasis(Z, [Z.sub(0), VectorSpaceBasis(constant=True)])

--- a/tests/test_dirk.py
+++ b/tests/test_dirk.py
@@ -257,7 +257,7 @@ def test_stokes_bcs(butcher_tableau, bctype):
          - inner(q, div(u))*dx
          - inner(u_rhs, v)*dx
          - inner(p_rhs, q)*dx)
-    Fdirk = replace(F, {z[i]: z_dirk[i] for i in numpy.ndindex(z.ufl_shape)})
+    Fdirk = replace(F, {z: z_dirk})
 
     nsp = [(1, VectorSpaceBasis(constant=True))]
     nsp_dirk = MixedVectorSpaceBasis(Z, [Z.sub(0), VectorSpaceBasis(constant=True)])

--- a/tests/test_dirk.py
+++ b/tests/test_dirk.py
@@ -1,5 +1,4 @@
 from math import isclose
-import numpy
 import pytest
 from firedrake import *
 from irksome import WSODIRK, Alexander, Dt, MeshConstant, TimeStepper


### PR DESCRIPTION
Executive summary:

- `component_replace` takes a dictionary of replacements and programmatically inserts replacements of all sub-components.  This was a commonly used pattern, so tucking it into a function simplifies things.
- it is also easier to iterate over scalar components of a ufl `Function` or `TestFunction` by indexing, so we don't have to use `split` and then worry whether the pieces were scalar or vector-valued.  This is largely hidden inside `component_replace`
- `TimeDerivative` now pushes through tensors during construction, and this greatly simplified some of the replacements.

These key changes required pervasive simplification of all of our the UFL manipulation in our various time steppers.

We explored `Constant` around numpy versus numpy array of `Constant` objects.  The former makes fewer GEM nodes so might help with compilation, but the latter seems needed most of the time to respect sparsity for computation.
