### PR TITLE
Example logic for auxiliary variables in DIRK stepper

### DIFF
--- a/irksome/dirk_stepper.py
+++ b/irksome/dirk_stepper.py
@@ -143,7 +143,7 @@ class DIRKTimeStepper:
         # stage values we've computed earlier in the time step...
 
         stage_F, (k, g, a, c), bcnew, (a_vals, d_val), (has_deriv, no_deriv) \
-        = getFormDIRK(F, self.ks, butcher_tableau, t, dt, u0, bcs=bcs)
+            = getFormDIRK(F, self.ks, butcher_tableau, t, dt, u0, bcs=bcs)
 
         self.bcnew = bcnew
 


### PR DESCRIPTION
Previously all variables were treated as if they have explicit time dependence and were updated by summing over stage derivatives. If $u$ was the time-dependent variable and $\zeta$ an auxiliary variable they would both be replaced by

$$\partial_t u \leftarrow k_u\quad,\quad u \leftarrow g_u + ahk_u$$
$$\partial_t \zeta \leftarrow k_\zeta\quad,\quad \zeta\leftarrow g_\zeta + ahk_\zeta$$

Now the lack of a time derivative on $\zeta$ is identified and they are instead replaced by

$$\partial_t u \leftarrow k_u\quad,\quad u \leftarrow g_u + ahk_u$$
$$\zeta\leftarrow k_\zeta$$

The non-linear solve is still done over $k_u$ , $k_\zeta$ but $k_\zeta$ now represents the value of the auxiliary variable $\zeta$ instead of its stage derivative which is not needed. Only the time-dependent $g_u$ is updated by summing over stage derivatives $k_u$.