### PR TITLE
Fixing what we put in appctx for Rana

### DIFF
--- a/irksome/dirk_stepper.py
+++ b/irksome/dirk_stepper.py
@@ -119,6 +119,7 @@ class DIRKTimeStepper:
         self.bcnew = bcnew
 
         appctx_irksome = {"F": F,
+                          "stage_type": "dirk",
                           "butcher_tableau": butcher_tableau,
                           "t": t,
                           "dt": dt,
@@ -130,6 +131,7 @@ class DIRKTimeStepper:
             appctx = appctx_irksome
         else:
             appctx = {**appctx, **appctx_irksome}
+        self.appctx = appctx
 
         self.problem = NLVP(stage_F, k, bcnew)
         self.solver = NLVS(

--- a/irksome/explicit_stepper.py
+++ b/irksome/explicit_stepper.py
@@ -20,3 +20,4 @@ class ExplicitTimeStepper(DIRKTimeStepper):
             F, butcher_tableau, t, dt, u0, bcs=bcs,
             solver_parameters=solver_parameters, appctx=appctx,
             nullspace=None)
+        self.appctx["stage_type"] = "explicit"

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -411,6 +411,7 @@ class DIRKIMEXMethod:
                           "u0": u0,
                           "bcs": bcs,
                           "bc_type": "DAE",
+                          "stage_type": "dirkimex",
                           "nullspace": nullspace}
         if appctx is None:
             appctx = appctx_irksome

--- a/irksome/pc.py
+++ b/irksome/pc.py
@@ -62,6 +62,7 @@ class IRKAuxiliaryOperatorPC(AuxiliaryOperatorPC):
         stage_type = appctx.get("stage_type", None)
         bc_type = appctx.get("bc_type", None)
         splitting = appctx.get("splitting", None)
+        vandermonde = appctx.get("vandermonde", None)
         v0, = F.arguments()
 
         try:
@@ -86,7 +87,9 @@ class IRKAuxiliaryOperatorPC(AuxiliaryOperatorPC):
         if stage_type in ("deriv", None):
             Fnew, bcnew = getForm(F, butcher, t, dt, u0, w, bcs, bc_type, splitting)
         elif stage_type == "value":
-            Fnew, bcnew = getFormStage(F, butcher, t, dt, u0, w, bcs, splitting)
+            Fnew, bcnew = getFormStage(F, butcher, t, dt, u0, w, bcs, splitting, vandermonde)
+        else:
+            raise NotImplementedError(f"Rana PC is not implemented (and probably doesn't make sense) for stage_type of {stage_type}")
 
         # Now we get the Jacobian for the modified system,
         # which becomes the auxiliary operator!

--- a/irksome/stage_derivative.py
+++ b/irksome/stage_derivative.py
@@ -183,6 +183,7 @@ class StageDerivativeTimeStepper(StageCoupledTimeStepper):
                          appctx=appctx, nullspace=nullspace,
                          splitting=splitting, bc_type=bc_type,
                          butcher_tableau=butcher_tableau)
+        self.appctx["stage_type"] = "deriv"
 
     def _update(self):
         """Assuming the algebraic problem for the RK stages has been

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -183,6 +183,8 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
                          solver_parameters=solver_parameters,
                          appctx=appctx, nullspace=nullspace,
                          splitting=splitting, butcher_tableau=butcher_tableau, bounds=bounds)
+        self.appctx["stage_type"] = "value"
+        self.appctx["vandermonde"] = vandermonde
 
         if (not butcher_tableau.is_stiffly_accurate) and (basis_type != "Bernstein"):
             self.unew, self.update_solver = self.get_update_solver(update_solver_parameters)


### PR DESCRIPTION
We need to be able to call `getForm` and its variants from within `IRKAuxiliaryOperatorPC`, which requires us to stash all of the options needed to do that in our `appctx`.  This tries to make sure that we do that consistently.