### PR TITLE
steppers go into appctx

### DIFF
--- a/irksome/base_time_stepper.py
+++ b/irksome/base_time_stepper.py
@@ -26,7 +26,8 @@ class BaseTimeStepper:
             "dt": dt,
             "u0": u0,
             "bcs": bcs,
-            "nullspace": nullspace}
+            "nullspace": nullspace,
+            "stepper": self}
 
         if appctx is None:
             self.appctx = appctx_base
@@ -155,7 +156,7 @@ class StageCoupledTimeStepper(BaseTimeStepper):
     # allow butcher tableau as input for preconditioners to create
     # an alternate operator
     @abstractmethod
-    def get_form_and_bcs(self, stages, butcher_tableau=None):
+    def get_form_and_bcs(self, stages, tableau=None, F=None):
         pass
 
     def solver_stats(self):

--- a/irksome/base_time_stepper.py
+++ b/irksome/base_time_stepper.py
@@ -20,14 +20,7 @@ class BaseTimeStepper:
         self.nullspace = nullspace
         self.V = u0.function_space()
 
-        appctx_base = {
-            "F": F,
-            "t": t,
-            "dt": dt,
-            "u0": u0,
-            "bcs": bcs,
-            "nullspace": nullspace,
-            "stepper": self}
+        appctx_base = {"stepper": self}
 
         if appctx is None:
             self.appctx = appctx_base
@@ -99,13 +92,10 @@ class StageCoupledTimeStepper(BaseTimeStepper):
         self.num_stages = num_stages
         if butcher_tableau:
             assert num_stages == butcher_tableau.num_stages
-            self.appctx["butcher_tableau"] = butcher_tableau
         if splitting is None:
             splitting = AI
         self.splitting = splitting
-        self.appctx["splitting"] = splitting
         self.bc_type = bc_type
-        self.appctx["bc_type"] = bc_type
 
         self.num_steps = 0
         self.num_nonlinear_iterations = 0

--- a/irksome/dirk_stepper.py
+++ b/irksome/dirk_stepper.py
@@ -120,15 +120,7 @@ class DIRKTimeStepper:
 
         self.bcnew = bcnew
 
-        appctx_irksome = {"F": F,
-                          "stage_type": "dirk",
-                          "butcher_tableau": butcher_tableau,
-                          "t": t,
-                          "dt": dt,
-                          "u0": u0,
-                          "bcs": bcs,
-                          "bc_type": "DAE",
-                          "nullspace": nullspace}
+        appctx_irksome = {"stepper": self}
         if appctx is None:
             appctx = appctx_irksome
         else:
@@ -199,3 +191,10 @@ class DIRKTimeStepper:
 
     def solver_stats(self):
         return self.num_steps, self.num_nonlinear_iterations, self.num_linear_iterations
+
+    def get_form_and_bcs(self, stages, tableau=None, F=None):
+        return getFormDIRK(F or self.F,
+                           stages,
+                           tableau or self.butcher_tableau,
+                           self.t, self.dt,
+                           self.u0, bcs=self.orig_bcs)

--- a/irksome/explicit_stepper.py
+++ b/irksome/explicit_stepper.py
@@ -20,4 +20,3 @@ class ExplicitTimeStepper(DIRKTimeStepper):
             F, butcher_tableau, t, dt, u0, bcs=bcs,
             solver_parameters=solver_parameters, appctx=appctx,
             nullspace=None)
-        self.appctx["stage_type"] = "explicit"

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -212,17 +212,8 @@ class RadauIIAIMEXMethod:
         self.orig_bcs = bcs
         self.splitting = splitting
 
-        appctx_irksome = {"F": F,
-                          "Fexp": Fexp,
-                          "butcher_tableau": butcher_tableau,
-                          "t": t,
-                          "dt": dt,
-                          "u0": u0,
-                          "bcs": bcs,
-                          "stage_type": "value",
-                          "stepper": self,
-                          "splitting": splitting,
-                          "nullspace": nullspace}
+        appctx_irksome = {"stepper": self}
+
         if appctx is None:
             appctx = appctx_irksome
         else:

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -208,6 +208,10 @@ class RadauIIAIMEXMethod:
         self.propprob = NonlinearVariationalProblem(
             Fbig + Fprop, UU, bcs=bigBCs)
 
+        self.F = F
+        self.orig_bcs = bcs
+        self.splitting = splitting
+
         appctx_irksome = {"F": F,
                           "Fexp": Fexp,
                           "butcher_tableau": butcher_tableau,
@@ -216,6 +220,7 @@ class RadauIIAIMEXMethod:
                           "u0": u0,
                           "bcs": bcs,
                           "stage_type": "value",
+                          "stepper": self,
                           "splitting": splitting,
                           "nullspace": nullspace}
         if appctx is None:
@@ -281,6 +286,13 @@ class RadauIIAIMEXMethod:
                 self.num_linear_iterations_prop,
                 self.num_nonlinear_iterations_it,
                 self.num_linear_iterations_it)
+
+    def get_form_and_bcs(self, stages, tableau=None, F=None):
+        return getFormStage(F or self.F,
+                            tableau or self.butcher_tableau,
+                            self.t, self.dt, self.u0,
+                            stages, bcs=self.orig_bcs,
+                            splitting=self.splitting)
 
 
 def getFormsDIRKIMEX(F, Fexp, ks, khats, butch, t, dt, u0, bcs=None):

--- a/irksome/nystrom_stepper.py
+++ b/irksome/nystrom_stepper.py
@@ -206,10 +206,9 @@ class StageDerivativeNystromTimeStepper(StageCoupledTimeStepper):
                             for s in range(ns)))
             ut0bit += sum(kp[nf * s + i] * (b[s] * dt) for s in range(ns))
 
-    def get_form_and_bcs(self, stages, tableau=None):
-        if tableau is None:
-            tableau = self.tableau
-        return getFormNystrom(self.F, tableau, self.t,
+    def get_form_and_bcs(self, stages, tableau=None, F=None):
+        return getFormNystrom(F or self.F,
+                              tableau or self.tableau, self.t,
                               self.dt, self.u0, self.ut0,
                               stages,
                               bcs=self.orig_bcs,

--- a/irksome/nystrom_stepper.py
+++ b/irksome/nystrom_stepper.py
@@ -185,9 +185,6 @@ class StageDerivativeNystromTimeStepper(StageCoupledTimeStepper):
                          tableau.num_stages, bcs=bcs,
                          bc_type=bc_type, **kwargs)
 
-        self.appctx["ut0"] = ut0
-        self.appctx["nystrom_tableau"] = tableau
-
         self.updateb = vecconst(tableau.b)
         self.updatebbar = vecconst(tableau.bbar)
         self.num_fields = len(u0.function_space())

--- a/irksome/stage_derivative.py
+++ b/irksome/stage_derivative.py
@@ -212,10 +212,10 @@ class StageDerivativeTimeStepper(StageCoupledTimeStepper):
         for i, u0bit in enumerate(self.u0.subfunctions):
             u0bit += sum(self.stages.subfunctions[nf * s + i] * (b[s] * dt) for s in range(ns))
 
-    def get_form_and_bcs(self, stages, butcher_tableau=None):
-        if butcher_tableau is None:
-            butcher_tableau = self.butcher_tableau
-        return getForm(self.F, butcher_tableau, self.t, self.dt,
+    def get_form_and_bcs(self, stages, tableau=None, F=None):
+        return getForm(F or self.F,
+                       tableau or self.butcher_tableau,
+                       self.t, self.dt,
                        self.u0, stages, self.orig_bcs, self.bc_type,
                        self.splitting)
 

--- a/irksome/stage_derivative.py
+++ b/irksome/stage_derivative.py
@@ -196,7 +196,6 @@ class StageDerivativeTimeStepper(StageCoupledTimeStepper):
                          appctx=appctx,
                          splitting=splitting, bc_type=bc_type,
                          butcher_tableau=butcher_tableau, **kwargs)
-        self.appctx["stage_type"] = "deriv"
 
     def _update(self):
         """Assuming the algebraic problem for the RK stages has been

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -189,8 +189,6 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
                          appctx=appctx,
                          splitting=splitting, butcher_tableau=butcher_tableau, bounds=bounds,
                          **kwargs)
-        self.appctx["stage_type"] = "value"
-        self.appctx["vandermonde"] = vandermonde
 
         if use_collocation_update:
             # Use the terminal value of the collocation polynomial to update the solution. Note: collocation update is only implemented for constant-in-time boundary conditions.

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -262,10 +262,9 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
         for i, u0bit in enumerate(self.u0.subfunctions):
             u0bit.assign(stage_vals[i::self.num_fields] @ self.collocation_vander)
 
-    def get_form_and_bcs(self, stages, butcher_tableau=None):
-        if butcher_tableau is None:
-            butcher_tableau = self.butcher_tableau
-        return getFormStage(self.F, butcher_tableau,
+    def get_form_and_bcs(self, stages, tableau=None, F=None):
+        return getFormStage(F or self.F,
+                            tableau or self.butcher_tableau,
                             self.t, self.dt, self.u0,
                             stages, bcs=self.orig_bcs,
                             splitting=self.splitting,

--- a/tests/test_nystrom_pc.py
+++ b/tests/test_nystrom_pc.py
@@ -23,7 +23,7 @@ def Fubc(V, t, uexact):
 class myPC(NystromAuxiliaryOperatorPC):
     def getNewForm(self, pc, u0, ut0, test):
         appctx = self.get_appctx(pc)
-        bcs = appctx["bcs"]
+        bcs = appctx["stepper"].orig_bcs
         F = inner(Dt(u0, 2), test) * dx + inner(grad(u0), grad(test)) * dx
         return F, bcs
 

--- a/tests/test_pc.py
+++ b/tests/test_pc.py
@@ -25,7 +25,7 @@ def Fubc(V, t, uexact):
 class myPC(IRKAuxiliaryOperatorPC):
     def getNewForm(self, pc, u0, test):
         appctx = self.get_appctx(pc)
-        bcs = appctx["bcs"]
+        bcs = appctx["stepper"].orig_bcs
         F = inner(Dt(u0), test) * dx + inner(grad(u0), grad(test)) * dx
         return F, bcs
 


### PR DESCRIPTION
This lets us streamline a lot of business in preconditioners that re-discretize in time.

As a further simplification, we could remove everything that's in the appctx that is also a member of the class.  Not sure that wouldn't upset anybody?