### PR TITLE
Implement TimeDerivativeRuleset as a DAGTraverser

### DIFF
--- a/irksome/deriv.py
+++ b/irksome/deriv.py
@@ -7,19 +7,9 @@ from ufl.algorithms.map_integrands import map_integrands
 from ufl.algorithms.apply_derivatives import GenericDerivativeRuleset
 from ufl.algorithms.apply_algebra_lowering import apply_algebra_lowering
 from ufl.form import BaseForm
-from ufl.classes import (
-    Coefficient,
-    Conj,
-    ConstantValue,
-    Derivative,
-    Expr,
-    Grad,
-    Indexed,
-    ReferenceGrad,
-    ReferenceValue,
-    SpatialCoordinate,
-    Variable,
-)
+from ufl.classes import (Coefficient, Conj, Curl, ConstantValue, Derivative,
+                         Div, Expr, Grad, Indexed, ReferenceGrad,
+                         ReferenceValue, SpatialCoordinate, Variable)
 
 
 @ufl_type(num_ops=1,
@@ -93,7 +83,9 @@ class TimeDerivativeRuleset(GenericDerivativeRuleset):
             return self(f)
 
     @process.register(Conj)
+    @process.register(Curl)
     @process.register(Derivative)
+    @process.register(Div)
     @process.register(Grad)
     @process.register(Indexed)
     @process.register(ReferenceGrad)

--- a/irksome/deriv.py
+++ b/irksome/deriv.py
@@ -1,10 +1,25 @@
+from functools import singledispatchmethod
+
 from ufl.constantvalue import as_ufl
-from ufl.differentiation import Derivative
 from ufl.core.ufl_type import ufl_type
-from ufl.corealg.multifunction import MultiFunction
-from ufl.algorithms.map_integrands import map_integrand_dags, map_expr_dag
+from ufl.corealg.dag_traverser import DAGTraverser
+from ufl.algorithms.map_integrands import map_integrands
 from ufl.algorithms.apply_derivatives import GenericDerivativeRuleset
 from ufl.algorithms.apply_algebra_lowering import apply_algebra_lowering
+from ufl.form import BaseForm
+from ufl.classes import (
+    Coefficient,
+    Conj,
+    ConstantValue,
+    Derivative,
+    Expr,
+    Grad,
+    Indexed,
+    ReferenceGrad,
+    ReferenceValue,
+    SpatialCoordinate,
+    Variable,
+)
 
 
 @ufl_type(num_ops=1,
@@ -39,64 +54,83 @@ class TimeDerivativeRuleset(GenericDerivativeRuleset):
     def __init__(self, t=None, timedep_coeffs=None):
         GenericDerivativeRuleset.__init__(self, ())
         self.t = t
+        self._Id = as_ufl(1.0)
         self.timedep_coeffs = timedep_coeffs
 
-    def constant_value(self, o):
+    # Work around singledispatchmethod inheritance issue;
+    # see https://bugs.python.org/issue36457.
+    @singledispatchmethod
+    def process(self, o):
+        return super().process(o)
+
+    @process.register(ConstantValue)
+    @process.register(Variable)
+    def constant(self, o):
         if self.t is not None and o is self.t:
-            return as_ufl(1.0)
+            return self._Id
         else:
             return self.independent_terminal(o)
 
-    def variable(self, o):
-        if self.t is not None and o is self.t:
-            return as_ufl(1.0)
-        else:
-            return self.independent_terminal(o)
-
+    @process.register(Coefficient)
     def coefficient(self, o):
         if self.t is not None and o is self.t:
-            return as_ufl(1.0)
+            return self._Id
         elif self.timedep_coeffs is None or o in self.timedep_coeffs:
             return TimeDerivative(o)
         else:
             return self.independent_terminal(o)
 
+    @process.register(SpatialCoordinate)
     def spatial_coordinate(self, o):
         return self.independent_terminal(o)
 
+    @process.register(TimeDerivative)
+    @DAGTraverser.postorder
     def time_derivative(self, o, f):
         if isinstance(f, TimeDerivative):
             return TimeDerivative(f)
         else:
-            return map_expr_dag(self, f)
+            return self(f)
 
-    def _linear_op(self, o, *operands):
+    @process.register(Conj)
+    @process.register(Derivative)
+    @process.register(Grad)
+    @process.register(Indexed)
+    @process.register(ReferenceGrad)
+    @process.register(ReferenceValue)
+    @DAGTraverser.postorder
+    def linear_op(self, o, *operands):
         return o._ufl_expr_reconstruct_(*operands)
-
-    indexed = _linear_op
-    derivative = _linear_op
-    grad = _linear_op
-    curl = _linear_op
-    div = _linear_op
 
 
 # mapping rules to splat out time derivatives so that replacement should
 # work on more complex problems.
-class TimeDerivativeRuleDispatcher(MultiFunction):
-    def __init__(self, t=None, timedep_coeffs=None):
-        MultiFunction.__init__(self)
+class TimeDerivativeRuleDispatcher(DAGTraverser):
+    def __init__(self, t=None, timedep_coeffs=None,
+                 compress=True, visited_cache=None, result_cache=None):
+        super().__init__(compress=compress, visited_cache=visited_cache, result_cache=result_cache)
         self.rules = TimeDerivativeRuleset(t=t, timedep_coeffs=timedep_coeffs)
 
+    # Work around singledispatchmethod inheritance issue;
+    # see https://bugs.python.org/issue36457.
+    @singledispatchmethod
+    def process(self, o):
+        return super().process(o)
+
+    @process.register(TimeDerivative)
     def time_derivative(self, o):
         f, = o.ufl_operands
-        return map_expr_dag(self.rules, f)
+        return self.rules(f)
 
-    ufl_type = MultiFunction.reuse_if_untouched
+    @process.register(Expr)
+    @process.register(BaseForm)
+    def ufl_type(self, o):
+        return self.reuse_if_untouched(o)
 
 
 def apply_time_derivatives(expression, t=None, timedep_coeffs=None):
     rules = TimeDerivativeRuleDispatcher(t=t, timedep_coeffs=timedep_coeffs)
-    return map_integrand_dags(rules, expression)
+    return map_integrands(rules, expression)
 
 
 def expand_time_derivatives(expression, t=None, timedep_coeffs=None):


### PR DESCRIPTION
This PR has to be merged as soon as (but not before) `ufl.DAGTraversal` lands in UFL `release`.