### PR TITLE
Fix Tableau typo

### DIFF
--- a/irksome/nystrom_stepper.py
+++ b/irksome/nystrom_stepper.py
@@ -60,7 +60,7 @@ class ClassicNystrom4Tableau(NystromTableau):
 
         Abar[1, 0] = 1./8
         Abar[2, 0] = 1./8
-        Abar[3, 2] = 1.0
+        Abar[3, 2] = 1./2
 
         b = numpy.array([1, 2, 2, 1]) / 6.
         bbar = numpy.array([1, 1, 1, 0]) / 6.


### PR DESCRIPTION
There's a typo in our Classic Nystrom Tableau, in comparison to that given in Hairer-Norsett-Wanner (see attached screenshot).  Let's maybe fix that...

<img width="720" height="353" alt="screenshot_2025-07-25_at_8 13 28___pm_720" src="https://github.com/user-attachments/assets/291da638-05df-455d-9168-a700cbdbb7ec" />
