### PR TITLE
Useful error message

### DIFF
--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -104,7 +104,8 @@ def TimeStepper(F, butcher_tableau, t, dt, u0, **kwargs):
     bcs = kwargs.pop("bcs", None)
 
     for cur_kwarg in kwargs.keys():
-        assert cur_kwarg in valid_kwargs_per_stage_type[stage_type], f"kwarg {cur_kwarg} is not allowable for stage_type {stage_type}"
+        if cur_kwarg not in valid_kwargs_per_stage_type[stage_type]:
+            raise ValueError(f"kwarg {cur_kwarg} is not allowable for stage_type {stage_type})"
 
     if stage_type == "deriv":
         bc_type = kwargs.get("bc_type", "DAE")

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -104,7 +104,7 @@ def TimeStepper(F, butcher_tableau, t, dt, u0, **kwargs):
     bcs = kwargs.pop("bcs", None)
 
     for cur_kwarg in kwargs.keys():
-        assert cur_kwarg in valid_kwargs_per_stage_type[stage_type]
+        assert cur_kwarg in valid_kwargs_per_stage_type[stage_type], f"kwarg {cur_kwarg} is not allowable for stage_type {stage_type}"
 
     if stage_type == "deriv":
         bc_type = kwargs.get("bc_type", "DAE")

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -105,7 +105,7 @@ def TimeStepper(F, butcher_tableau, t, dt, u0, **kwargs):
 
     for cur_kwarg in kwargs.keys():
         if cur_kwarg not in valid_kwargs_per_stage_type[stage_type]:
-            raise ValueError(f"kwarg {cur_kwarg} is not allowable for stage_type {stage_type})"
+            raise ValueError(f"kwarg {cur_kwarg} is not allowable for stage_type {stage_type}")
 
     if stage_type == "deriv":
         bc_type = kwargs.get("bc_type", "DAE")


### PR DESCRIPTION
When an invalid kwarg is passed to `TimeStepper`, we catch it and error out, but don't provide a useful message about which kwarg is invalid.  This fixes that oversight.