### PR TITLE
fix interpolate import to be up-to-date with Firedrake.

### DIFF
--- a/tests/test_curl.py
+++ b/tests/test_curl.py
@@ -1,6 +1,5 @@
 import pytest
 from firedrake import *
-from firedrake.__future__ import interpolate
 from irksome import GaussLegendre, Dt, MeshConstant, TimeStepper
 from irksome.tools import AI, IA
 


### PR DESCRIPTION
We were getting warnings because one of our tests still used the future interpolate.