### PR TITLE
get rid of all the diff's w.r.t. time and let Irksome internally expand  in all MMS

### DIFF
--- a/demos/bounded_heat/demo_bounded_heat.py.rst
+++ b/demos/bounded_heat/demo_bounded_heat.py.rst
@@ -42,10 +42,6 @@ First, we must import firedrake and certain items from Irksome: ::
     from firedrake import *
     from irksome import Dt, MeshConstant, RadauIIA, TimeStepper, BoundsConstrainedDirichletBC
 
-We also need some UFL tools in order to manufacture a solution: ::
-
-    from ufl.algorithms import expand_derivatives
-
 Finally, numpy provides us with the upper bound of infinity: ::
 
     import numpy as np
@@ -98,7 +94,7 @@ We now define the right-hand side using the method of manufactured solutions: ::
 
     uexact = 0.5 * exp(-t) * (1 + (tanh((0.1 - sqrt((x - 0.5) ** 2 + (y - 0.5) ** 2)) / 0.015)))
 
-    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+    rhs = Dt(uexact) - div(grad(uexact))
 
 Note that the exact solution is uniformly positive in space and time. Using a manufactured 
 solution, one usually interpolates or projects the exact solution at time :math:`t = 0` onto the 

--- a/demos/heat/demo_heat.py.rst
+++ b/demos/heat/demo_heat.py.rst
@@ -34,11 +34,6 @@ We will also need to import certain items from irksome::
 
   from irksome import GaussLegendre, Dt, MeshConstant, TimeStepper
 
-And we will need a little bit of UFL to support using the method of
-manufactured solutions::
-
-  from ufl.algorithms.ad import expand_derivatives
-
 We will create the Butcher tableau for the lowest-order Gauss-Legendre
 Runge-Kutta method, which is more commonly known as the implicit
 midpoint rule::
@@ -72,7 +67,7 @@ This defines the right-hand side using the method of manufactured solutions::
   B = (x-Constant(x0))*(x-Constant(x1))*(y-Constant(y0))*(y-Constant(y1))/C
   R = (x * x + y * y) ** 0.5
   uexact = B * atan(t)*(pi / 2.0 - atan(S * (R - t)))
-  rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+  rhs = Dt(uexact) - div(grad(uexact))
 
 We define the initial condition for the fully discrete problem, which
 will get overwritten at each time step::

--- a/demos/heat/demo_heat_adapt.py.rst
+++ b/demos/heat/demo_heat_adapt.py.rst
@@ -34,11 +34,6 @@ We will also need to import certain items from irksome::
 
   from irksome import RadauIIA, Dt, MeshConstant, TimeStepper
 
-And we will need a little bit of UFL to support using the method of
-manufactured solutions::
-
-  from ufl.algorithms.ad import expand_derivatives
-
 We will create the Butcher tableau for the 3-stage RadauIIA
 Runge-Kutta method, which has an embedded scheme we can use
 for adaptivity::
@@ -73,7 +68,7 @@ This defines the right-hand side using the method of manufactured solutions::
   B = (x-Constant(x0))*(x-Constant(x1))*(y-Constant(y0))*(y-Constant(y1))/C
   R = (x * x + y * y) ** 0.5
   uexact = B * atan(t)*(pi / 2.0 - atan(S * (R - t)))
-  rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+  rhs = Dt(uexact) - div(grad(uexact))
 
 We define the initial condition for the fully discrete problem, which
 will get overwritten at each time step::

--- a/demos/heat/demo_heat_dirk.py.rst
+++ b/demos/heat/demo_heat_dirk.py.rst
@@ -34,11 +34,6 @@ We will also need to import certain items from irksome::
 
   from irksome import Alexander, Dt, MeshConstant, TimeStepper
 
-And we will need a little bit of UFL to support using the method of
-manufactured solutions::
-
-  from ufl.algorithms.ad import expand_derivatives
-
 We will create the Butcher tableau for a three-stage L-stable DIRK
 due to Alexander (SINUM 14(6): 1006-1021, 1977).::
 
@@ -71,7 +66,7 @@ This defines the right-hand side using the method of manufactured solutions::
   B = (x-Constant(x0))*(x-Constant(x1))*(y-Constant(y0))*(y-Constant(y1))/C
   R = (x * x + y * y) ** 0.5
   uexact = B * atan(t)*(pi / 2.0 - atan(S * (R - t)))
-  rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+  rhs = Dt(uexact) - div(grad(uexact))
 
 We define the initial condition for the fully discrete problem, which
 will get overwritten at each time step::

--- a/demos/heat/demo_mixed_heat.py.rst
+++ b/demos/heat/demo_mixed_heat.py.rst
@@ -30,7 +30,6 @@ Standard imports, although we're using a different RK scheme this time::
 
   from firedrake import *
   from irksome import LobattoIIIC, Dt, MeshConstant, TimeStepper
-  from ufl.algorithms.ad import expand_derivatives
 
   butcher_tableau = LobattoIIIC(2)
 
@@ -67,7 +66,7 @@ manufactured solutions::
   uexact = B * atan(t)*(pi / 2.0 - atan(S * (R - t)))
   sigexact = -grad(uexact)
 
-  rhs = expand_derivatives(diff(uexact, t) + div(sigexact))
+  rhs = Dt(uexact) + div(sigexact)
 
 
 Set up the initial condition::

--- a/demos/lowlevel/demo_lowlevel_homogbc.py.rst
+++ b/demos/lowlevel/demo_lowlevel_homogbc.py.rst
@@ -12,7 +12,6 @@ We're solving the same problem that is done in the heat equation demos.
 Imports::
 
   from firedrake import *
-  from ufl.algorithms.ad import expand_derivatives
 
   from irksome import GaussLegendre, getForm, Dt, MeshConstant
   from irksome.tools import get_stage_space
@@ -45,7 +44,7 @@ Continuing::
   R = (x * x + y * y) ** 0.5
   uexact = B * atan(t)*(pi / 2.0 - atan(S * (R - t)))
 
-  rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+  rhs = Dt(uexact) - div(grad(uexact))
 
   u = Function(V)
   u.interpolate(uexact)

--- a/demos/lowlevel/demo_lowlevel_inhomogbc.py.rst
+++ b/demos/lowlevel/demo_lowlevel_inhomogbc.py.rst
@@ -9,7 +9,6 @@ reading through the code.
 Imports::
 
   from firedrake import *
-  from ufl.algorithms.ad import expand_derivatives
 
   from irksome import GaussLegendre, getForm, Dt, MeshConstant
   from irksome.tools import get_stage_space
@@ -27,7 +26,7 @@ Imports::
   x, y = SpatialCoordinate(msh)
 
   uexact = exp(-t) * cos(pi * x) * sin(pi * y)
-  rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+  rhs = Dt(uexact) - div(grad(uexact))
 
   u = Function(V)
   u.interpolate(uexact)

--- a/demos/lowlevel/demo_lowlevel_mixed_heat.py.rst
+++ b/demos/lowlevel/demo_lowlevel_mixed_heat.py.rst
@@ -9,7 +9,6 @@ Imports::
   from irksome.tools import get_stage_space
   from firedrake import *
   from irksome import LobattoIIIC, Dt, getForm, MeshConstant
-  from ufl.algorithms.ad import expand_derivatives
 
   butcher_tableau = LobattoIIIC(2)
 
@@ -41,7 +40,7 @@ Build the mesh and approximating spaces::
   uexact = B * atan(t)*(pi / 2.0 - atan(S * (R - t)))
   sigexact = -grad(uexact)
 
-  rhs = expand_derivatives(diff(uexact, t) + div(sigexact))
+  rhs = Dt(uexact) + div(sigexact)
 
   sigu = project(as_vector([0, 0, uexact]), Z)
   sigma, u = split(sigu)

--- a/demos/preconditioning/demo_heat_mg.py.rst
+++ b/demos/preconditioning/demo_heat_mg.py.rst
@@ -18,7 +18,6 @@ We perform similar imports and setup as before::
 
   from firedrake import *
   from irksome import GaussLegendre, Dt, MeshConstant, TimeStepper
-  from ufl.algorithms.ad import expand_derivatives
   butcher_tableau = GaussLegendre(2)
 
 
@@ -55,7 +54,7 @@ are just as for the regular heat equation demo::
   B = (x-Constant(x0))*(x-Constant(x1))*(y-Constant(y0))*(y-Constant(y1))/C
   R = (x * x + y * y) ** 0.5
   uexact = B * atan(t)*(pi / 2.0 - atan(S * (R - t)))
-  rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+  rhs = Dt(uexact) - div(grad(uexact))
 
   u = Function(V)
   u.interpolate(uexact)

--- a/demos/preconditioning/demo_heat_mg_dg.py.rst
+++ b/demos/preconditioning/demo_heat_mg_dg.py.rst
@@ -19,8 +19,6 @@ We perform similar imports and setup as before::
 
   from firedrake import *
   from irksome import DiscontinuousGalerkinTimeStepper, Dt, MeshConstant
-  from ufl.algorithms.ad import expand_derivatives
-
 
 However, we need to set up a mesh hierarchy to enable geometric multigrid
 within Firedrake::
@@ -55,7 +53,7 @@ are just as for the regular heat equation demo::
   B = (x-Constant(x0))*(x-Constant(x1))*(y-Constant(y0))*(y-Constant(y1))/C
   R = (x * x + y * y) ** 0.5
   uexact = B * atan(t)*(pi / 2.0 - atan(S * (R - t)))
-  rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+  rhs = Dt(uexact) - div(grad(uexact))
 
   u = Function(V)
   u.interpolate(uexact)

--- a/demos/preconditioning/demo_heat_pc.py.rst
+++ b/demos/preconditioning/demo_heat_pc.py.rst
@@ -41,7 +41,6 @@ certainly use geometric multigrid or some other technique.
 Common set-up for the problem::
 
   from firedrake import *  # noqa: F403
-  from ufl.algorithms.ad import expand_derivatives
   from irksome import LobattoIIIC, TimeStepper, Dt, MeshConstant
 
   butcher_tableau = LobattoIIIC(3)
@@ -68,7 +67,7 @@ Common set-up for the problem::
   R = (x * x + y * y) ** 0.5
 
   uexact = B * atan(t)*(pi / 2.0 - atan(S * (R - t)))
-  rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+  rhs = Dt(uexact) - div(grad(uexact))
   u = Function(V)
   u.interpolate(uexact)
   v = TestFunction(V)

--- a/demos/preconditioning/demo_heat_rana.py.rst
+++ b/demos/preconditioning/demo_heat_rana.py.rst
@@ -40,7 +40,6 @@ suggest that this method is strongly stage-independent.
 Common set-up for the problem::
 
   from firedrake import *  # noqa: F403
-  from ufl.algorithms.ad import expand_derivatives
   from irksome import LobattoIIIC, TimeStepper, Dt, MeshConstant
 
   butcher_tableau = LobattoIIIC(3)
@@ -67,7 +66,7 @@ Common set-up for the problem::
   R = (x * x + y * y) ** 0.5
 
   uexact = B * atan(t)*(pi / 2.0 - atan(S * (R - t)))
-  rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+  rhs = Dt(uexact) - div(grad(uexact))
   u = Function(V)
   u.interpolate(uexact)
 

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -77,8 +77,6 @@ def getFormStage(F, butch, t, dt, u0, stages, bcs=None, splitting=None, vandermo
        - `bcnew`, a list of :class:`firedrake.DirichletBC` objects to be posed
          on the stages,
     """
-    # preprocess time derivatives
-    F = expand_time_derivatives(F, t=t, timedep_coeffs=(u0,))
     v = F.arguments()[0]
     V = v.function_space()
     assert V == u0.function_space()
@@ -107,7 +105,6 @@ def getFormStage(F, butch, t, dt, u0, stages, bcs=None, splitting=None, vandermo
     # assuming we have something of the form inner(Dt(g(u0)), v)*dx
     # For each stage i, this gets replaced with
     # inner((g(stages[i]) - g(u0))/dt, v)*dx
-    F = expand_time_derivatives(F, t=t, timedep_coeffs=(u0,))
     split_form = extract_terms(F)
     F_dtless = strip_dt_form(split_form.time)
     F_remainder = split_form.remainder
@@ -161,6 +158,7 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
                  use_collocation_update=False,
                  **kwargs):
 
+        F = expand_time_derivatives(F, t=t, timedep_coeffs=(u0,))
         # we can only do DAE-type problems correctly if one assumes a stiffly-accurate method.
         assert is_ode(F, u0) or butcher_tableau.is_stiffly_accurate
 

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -1,6 +1,5 @@
 import pytest
 from firedrake import *
-from ufl.algorithms.ad import expand_derivatives
 from irksome import Dt, MeshConstant, TimeStepper, RadauIIA, LobattoIIIC
 
 
@@ -16,7 +15,7 @@ def adapt_scalar_heat(N, butcher_tableau):
     n = FacetNormal(msh)
 
     uexact = t*(x+y)
-    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+    rhs = Dt(uexact) - div(grad(uexact))
 
     u = Function(V)
     u.interpolate(uexact)
@@ -54,7 +53,7 @@ def compare_scalar_heat(N, butcher_tableau):
     x, y = SpatialCoordinate(msh)
 
     uexact = sin(pi*x)*sin(pi*y)*(1-exp(-5*t))
-    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+    rhs = Dt(uexact) - div(grad(uexact))
 
     u = Function(V)
     u.interpolate(uexact)
@@ -116,7 +115,7 @@ def adapt_vector_heat(N, butcher_tableau):
     uexact_1 = t*(x+y)
     uexact_2 = 2*t*(x-y)
     uexact = as_vector([uexact_1, uexact_2])
-    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+    rhs = Dt(uexact) - div(grad(uexact))
 
     u = Function(V)
     u.interpolate(uexact)
@@ -159,9 +158,9 @@ def adapt_mixed_heat(N, butcher_tableau):
     n = FacetNormal(msh)
 
     uexact_1 = t*(x+y)
-    rhs_1 = expand_derivatives(diff(uexact_1, t)) - div(grad(uexact_1))
+    rhs_1 = Dt(uexact_1) - div(grad(uexact_1))
     uexact_2 = as_vector([2*t*(x-y), t*t*(x*y-2)])
-    rhs_2 = expand_derivatives(diff(uexact_2, t)) - div(grad(uexact_2))
+    rhs_2 = Dt(uexact_2) - div(grad(uexact_2))
 
     w = Function(W)
     (u1, u2) = split(w)

--- a/tests/test_bern.py
+++ b/tests/test_bern.py
@@ -3,12 +3,11 @@ import pytest
 from firedrake import (BrokenElement, DirichletBC, FacetNormal, FiniteElement,
                        Function, FunctionSpace, SpatialCoordinate,
                        TestFunction, TestFunctions, UnitIntervalMesh,
-                       UnitSquareMesh, cos, diff, div, dot, ds, dx, errornorm,
+                       UnitSquareMesh, cos, div, dot, ds, dx, errornorm,
                        exp, grad, inner, norm, pi, project, sin, split,
                        triangle)
 from firedrake.petsc import PETSc
 from irksome import Dt, GaussLegendre, MeshConstant, RadauIIA, TimeStepper
-from ufl.algorithms import expand_derivatives
 
 lu_params = {
     "snes_type": "ksponly",
@@ -106,7 +105,7 @@ def mixed_heat(n, deg, butcher_tableau, solver_parameters, bounds_type, **kwargs
 
     n = FacetNormal(msh)
 
-    rhs = expand_derivatives(diff(pexact, t) + div(uexact))
+    rhs = Dt(pexact) + div(uexact)
 
     F = (inner(Dt(p), w) * dx
          + inner(div(u), w) * dx

--- a/tests/test_bounds.py
+++ b/tests/test_bounds.py
@@ -1,11 +1,11 @@
 import numpy as np
 import pytest
 from firedrake import (assemble, ds, cos, DirichletBC, Function, FunctionSpace, SpatialCoordinate, TestFunction,
-                       TestFunctions, UnitSquareMesh, diff, div, dx, exp, grad, inner,
+                       TestFunctions, UnitSquareMesh, div, dx, exp, grad, inner,
                        norm, pi, sin, split, tanh, sqrt, NonlinearVariationalProblem,
                        NonlinearVariationalSolver)
 from irksome import (Dt, GaussLegendre, MeshConstant, RadauIIA, TimeStepper, BoundsConstrainedDirichletBC)
-from ufl.algorithms import expand_derivatives, replace
+from ufl.algorithms import replace
 
 lu_params = {
     "snes_type": "ksponly",
@@ -36,7 +36,7 @@ def heat(butcher_tableau, basis_type, bounds_type, **kwargs):
 
     uexact = 0.5 * exp(-t) * (1 + (tanh((0.1 - sqrt((x - 0.5) ** 2 + (y - 0.5) ** 2)) / 0.015)))
 
-    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+    rhs = Dt(uexact) - div(grad(uexact))
 
     v = TestFunction(V)
     u_init = Function(V)
@@ -109,7 +109,7 @@ def heat_BC(N, butcher_tableau):
     x, y = SpatialCoordinate(msh)
 
     uexact = exp(-t) * cos(2 * pi * x) ** 2 * sin(2 * pi * y) ** 2
-    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+    rhs = Dt(uexact) - div(grad(uexact))
 
     lb = Function(V).assign(0)
     ub = Function(V).assign(np.inf)

--- a/tests/test_dirichletbc.py
+++ b/tests/test_dirichletbc.py
@@ -2,7 +2,6 @@ import pytest
 from firedrake import *
 from math import isclose
 from irksome import LobattoIIIA, GaussLegendre, Dt, MeshConstant, TimeStepper
-from ufl.algorithms.ad import expand_derivatives
 
 
 @pytest.mark.parametrize("stage_type", ["deriv", "value"])
@@ -34,7 +33,7 @@ def test_1d_heat_dirichletbc(butcher_tableau, stage_type):
         + u_0
         + ((x - x0) / x1) * (u_1 - u_0)
     )
-    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+    rhs = Dt(uexact) - div(grad(uexact))
     u = Function(V)
     u.interpolate(uexact)
 

--- a/tests/test_explicit.py
+++ b/tests/test_explicit.py
@@ -3,7 +3,6 @@ from math import isclose
 import pytest
 from firedrake import *
 from irksome import PEPRK, Dt, MeshConstant, TimeStepper, SSPButcherTableau
-from ufl.algorithms.ad import expand_derivatives
 
 peprks = [PEPRK(*x) for x in ((4, 2, 5), (5, 2, 6))]
 ssprks = [SSPButcherTableau(2, 2), SSPButcherTableau(2, 3), SSPButcherTableau(3, 3)]
@@ -44,7 +43,7 @@ def test_1d_heat_dirichletbc(butcher_tableau):
         + u_0
         + ((x - x0) / x1) * (u_1 - u_0)
     )
-    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+    rhs = Dt(uexact) - div(grad(uexact))
     u = Function(V)
     u.interpolate(uexact)
     v = TestFunction(V)

--- a/tests/test_imex.py
+++ b/tests/test_imex.py
@@ -4,7 +4,6 @@ import pytest
 from firedrake import *
 from irksome import Dt, MeshConstant, TimeStepper, ARS_DIRK_IMEX, SSPK_DIRK_IMEX
 from irksome.labeling import explicit
-from ufl.algorithms.ad import expand_derivatives
 
 
 def convdiff_neumannbc(butcher_tableau, order, N, labeled=False):
@@ -98,7 +97,7 @@ def heat_dirichletbc(butcher_tableau):
         + u_0
         + ((x - x0) / x1) * (u_1 - u_0)
     )
-    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+    rhs = Dt(uexact) - div(grad(uexact))
     u = Function(V)
     u.interpolate(uexact)
     v = TestFunction(V)
@@ -154,7 +153,7 @@ def vecconvdiff_neumannbc(butcher_tableau, order, N):
 
     # Choose uexact so rhs is nonzero
     uexact = as_vector([cos(pi*x)*exp(-t), cos(2*pi*x)*exp(-2*t)])
-    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact)) + uexact.dx(0)
+    rhs = Dt(uexact) - div(grad(uexact)) + uexact.dx(0)
     u = Function(V)
     u.interpolate(uexact)
 
@@ -216,7 +215,7 @@ def mixed_convdiff(butcher_tableau, order, N):
     pexact = exp(-t)*cos(2*pi*x)
     uexact = -pexact.dx(0)
     c = Constant(1.0)
-    rhs = expand_derivatives(diff(pexact, t)) - div(grad(pexact)) - c*pexact.dx(0)
+    rhs = Dt(pexact) - div(grad(pexact)) - c*pexact.dx(0)
 
     bc = DirichletBC(Z.sub(0), 0, "on_boundary")
     F = inner(Dt(p), w) * dx + inner(u.dx(0), w) * dx + inner(u, v) * dx - inner(p, v.dx(0)) * dx - inner(rhs, w) * dx

--- a/tests/test_inhomogbc.py
+++ b/tests/test_inhomogbc.py
@@ -1,6 +1,5 @@
 import pytest
 from firedrake import *
-from ufl.algorithms.ad import expand_derivatives
 from irksome import Dt, MeshConstant, TimeStepper, RadauIIA, GaussLegendre
 from irksome.tools import AI, IA
 
@@ -16,7 +15,7 @@ def heat_inhomog(N, deg, butcher_tableau, stage_type, splitting):
     x, y = SpatialCoordinate(msh)
 
     uexact = t*(x+y)
-    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+    rhs = Dt(uexact) - div(grad(uexact))
 
     u = Function(V)
     u.interpolate(uexact)

--- a/tests/test_pc.py
+++ b/tests/test_pc.py
@@ -1,11 +1,10 @@
 import numpy
 import pytest
 from firedrake import (DirichletBC, Function, FunctionSpace, SpatialCoordinate,
-                       TestFunction, UnitSquareMesh, diff, div, dx, errornorm,
+                       TestFunction, UnitSquareMesh, div, dx, errornorm,
                        grad, inner)
 from irksome import (Dt, IRKAuxiliaryOperatorPC, LobattoIIIC, MeshConstant,
                      RadauIIA, TimeStepper)
-from ufl.algorithms.ad import expand_derivatives
 
 # Tests that various PCs are actually getting the right answer.
 
@@ -14,7 +13,7 @@ def Fubc(V, t, uexact):
     u = Function(V)
     u.interpolate(uexact)
     v = TestFunction(V)
-    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact)) - uexact * (1-uexact)
+    rhs = Dt(uexact) - div(grad(uexact)) - uexact * (1-uexact)
     F = inner(Dt(u), v)*dx + inner(grad(u), grad(v))*dx - inner(u*(1-u), v)*dx - inner(rhs, v)*dx
 
     bc = DirichletBC(V, uexact, "on_boundary")

--- a/tests/test_rtcf.py
+++ b/tests/test_rtcf.py
@@ -2,7 +2,6 @@ import pytest
 from firedrake import *
 from irksome import GaussLegendre, Dt, MeshConstant, TimeStepper
 from irksome.tools import AI, IA
-from ufl.algorithms.ad import expand_derivatives
 
 
 def curlcross(a, b):
@@ -24,7 +23,7 @@ def RTCFtest(N, deg, butcher_tableau, splitting=AI):
     x, y = SpatialCoordinate(msh)
 
     uexact = as_vector([t + 2*t*x + 4*t*y, 7*t + 5*t*x + 6*t*y])
-    rhs = expand_derivatives(diff(uexact, t)) + grad(div(uexact))
+    rhs = Dt(uexact) + grad(div(uexact))
 
     u = project(uexact, V)
 

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -2,7 +2,6 @@ import pytest
 from firedrake import *
 from irksome import Dt, LobattoIIIC, MeshConstant, RadauIIA, TimeStepper
 from irksome.tools import AI, IA
-from ufl.algorithms import expand_derivatives
 
 # test the accuracy of the 2d Stokes heat equation using CG elements
 # and LobattoIIIC time integration.  Particular issue being tested is
@@ -30,7 +29,7 @@ def StokesTest(N, butcher_tableau, stage_type="deriv", splitting=AI):
     uexact = as_vector([x*t + y**2, -y*t+t*(x**2)])
     pexact = x + y * t
 
-    u_rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact)) + grad(pexact)
+    u_rhs = Dt(uexact) - div(grad(uexact)) + grad(pexact)
     p_rhs = -div(uexact)
 
     z = Function(Z)

--- a/tests/test_subdomainbc.py
+++ b/tests/test_subdomainbc.py
@@ -2,7 +2,6 @@ import pytest
 from firedrake import *
 from irksome import GaussLegendre, Dt, MeshConstant, TimeStepper
 from irksome.tools import AI, IA
-from ufl.algorithms.ad import expand_derivatives
 
 
 def heat_subdomainbc(N, deg, butcher_tableau, splitting=AI):
@@ -16,7 +15,7 @@ def heat_subdomainbc(N, deg, butcher_tableau, splitting=AI):
     x, y = SpatialCoordinate(msh)
 
     uexact = t*(x+y)
-    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+    rhs = Dt(uexact) - div(grad(uexact))
 
     u = Function(V)
     u.interpolate(uexact)
@@ -55,7 +54,7 @@ def heat_componentbc(N, deg, butcher_tableau, splitting=AI):
     (x,) = SpatialCoordinate(msh)
 
     uexact = as_vector([(x**2-2*x)*t, (1-x**2)*t])
-    rhs = expand_derivatives(diff(uexact, t)) - div(grad(uexact))
+    rhs = Dt(uexact) - div(grad(uexact))
 
     u = Function(V)
     u.interpolate(uexact)


### PR DESCRIPTION
This clean-up is long overdue -- it's been a long time since we needed to explicitly expand out derivatives.  This cleans up all the tests and demos to allow Irksome internally to expand `Dt` acting on things.

It, however, identified a small logic error in the stage value time stepper that needed fixing -- we need to internally expand the time derivatives early on before we try to do any massaging or other logic.