### PR TITLE
Pass **kwargs through AdaptiveTimeStepper to support options_prefix

### DIFF
--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -223,31 +223,3 @@ def test_adapt_vector_heat(N, butcher_tableau):
 def test_adapt_mixed_heat(N, butcher_tableau):
     error = adapt_mixed_heat(N, butcher_tableau(3))
     assert abs(error) < 1e-10
-
-
-def test_adaptive_base_kwargs():
-    """Test that valid_base_kwargs are passed through AdaptiveTimeStepper."""
-    msh = UnitSquareMesh(4, 4)
-    MC = MeshConstant(msh)
-    dt = MC.Constant(0.1)
-    t = MC.Constant(0.0)
-
-    V = FunctionSpace(msh, "CG", 1)
-    u = Function(V)
-    v = TestFunction(V)
-    F = inner(Dt(u), v)*dx + inner(grad(u), grad(v))*dx
-
-    luparams = {"mat_type": "aij",
-                "snes_type": "ksponly",
-                "ksp_type": "preonly",
-                "pc_type": "lu"}
-
-    stepper = TimeStepper(
-        F, RadauIIA(2), t, dt, u,
-        solver_parameters=luparams,
-        adaptive_parameters={"tol": 1e-2},
-        options_prefix="test_adaptive_",
-        form_compiler_parameters={"quadrature_degree": 4},
-    )
-
-    assert stepper.solver.snes.getOptionsPrefix() == "test_adaptive_"

--- a/tests/test_base_kwargs.py
+++ b/tests/test_base_kwargs.py
@@ -1,0 +1,45 @@
+import pytest
+from firedrake import *
+from irksome import Dt, GaussLegendre, SSPButcherTableau, MeshConstant, TimeStepper
+
+
+@pytest.fixture
+def heat_problem():
+    """Simple heat equation setup."""
+    msh = UnitSquareMesh(4, 4)
+    MC = MeshConstant(msh)
+    V = FunctionSpace(msh, "CG", 1)
+    u = Function(V)
+    v = TestFunction(V)
+    F = inner(Dt(u), v)*dx + inner(grad(u), grad(v))*dx
+    return F, MC.Constant(0), MC.Constant(0.1), u
+
+
+@pytest.mark.parametrize("stage_type,tableau", [
+    ("deriv", GaussLegendre(1)),
+    ("value", GaussLegendre(1)),
+    ("dirk", GaussLegendre(1)),
+    ("explicit", SSPButcherTableau(2, 2)),
+])
+def test_base_kwargs(heat_problem, stage_type, tableau):
+    """Test that valid_base_kwargs are passed through for all stage types."""
+    F, t, dt, u = heat_problem
+    stepper = TimeStepper(
+        F, tableau, t, dt, u,
+        stage_type=stage_type,
+        options_prefix="test_prefix_",
+        form_compiler_parameters={"quadrature_degree": 4},
+    )
+    assert stepper.solver.snes.getOptionsPrefix() == "test_prefix_"
+
+
+def test_base_kwargs_adaptive(heat_problem):
+    """Test that valid_base_kwargs are passed through for adaptive stepper."""
+    F, t, dt, u = heat_problem
+    stepper = TimeStepper(
+        F, GaussLegendre(2), t, dt, u,
+        adaptive_parameters={"tol": 1e-2},
+        options_prefix="test_adaptive_",
+        form_compiler_parameters={"quadrature_degree": 4},
+    )
+    assert stepper.solver.snes.getOptionsPrefix() == "test_adaptive_"


### PR DESCRIPTION
## Summary

- Add `**kwargs` to `AdaptiveTimeStepper.__init__` and pass it to the parent class

## Problem

`AdaptiveTimeStepper` did not accept `**kwargs`, which meant that valid base kwargs like `options_prefix` could not be passed through to the `NonlinearVariationalSolver`. This caused a `TypeError` when users tried to use adaptive timestepping with a custom solver prefix:

```python
TypeError: AdaptiveTimeStepper.__init__() got an unexpected keyword argument 'options_prefix'
```

## Fix

This PR adds `**kwargs` to `AdaptiveTimeStepper.__init__` and passes it to the parent class `StageDerivativeTimeStepper`, which already accepts and passes through `**kwargs`. This makes `AdaptiveTimeStepper` consistent with the non-adaptive timesteppers.

Fixes #188

## Test

- [x] Verified that `options_prefix` is now correctly passed through to the solver for adaptive timestepping
- [x] Verified that non-adaptive timestepping still works correctly