### PR TITLE
stage value initial guess

### DIFF
--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -184,6 +184,8 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
                          splitting=splitting, butcher_tableau=butcher_tableau, bounds=bounds,
                          **kwargs)
 
+        self.set_initial_guess()
+
         if use_collocation_update:
             # Use the terminal value of the collocation polynomial to update the solution. Note: collocation update is only implemented for constant-in-time boundary conditions.
             # TODO: create an assertion to check for constant-in-time boundary conditions.
@@ -264,3 +266,10 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
                             stages, bcs=bcs,
                             splitting=self.splitting,
                             vandermonde=self.vandermonde)
+
+    def set_initial_guess(self):
+        """Set a constant-in-time initial guess"""
+        for k in range(self.num_stages):
+            for i, u0bit in enumerate(self.u0.subfunctions):
+                sbit = self.stages.subfunctions[self.num_fields * k + i]
+                sbit.assign(u0bit)

--- a/tests/test_stage_value_init.py
+++ b/tests/test_stage_value_init.py
@@ -1,8 +1,11 @@
 from firedrake import *
-from irksome import Dt, TimeStepper, BackwardEuler
+from irksome import Dt, TimeStepper, BackwardEuler, RadauIIA
+import pytest
 
 
-def test_stage_value_init():
+@pytest.mark.parametrize("basis_type", ["Lagrange", "Bernstein"])
+@pytest.mark.parametrize("degree", [1, 2])
+def test_stage_value_init(basis_type, degree):
     nx = 16
     lx = 1.0
     mesh = IntervalMesh(nx, lx)
@@ -31,13 +34,13 @@ def test_stage_value_init():
     F_outflow = p * max_value(0, inner(u, n)) * q * ds
     F = F_cells + F_facets + F_inflow + F_outflow
 
-    method = BackwardEuler()
+    method = BackwardEuler() if degree == 1 else RadauIIA(2)
     t = Constant(0.0)
     timestep = 0.5 / nx
     dt = Constant(timestep)
     params = {
         "stage_type": "value",
-        "basis_type": "Bernstein",
+        "basis_type": basis_type,
         "solver_parameters": {"snes_monitor": None},
     }
     stepper = TimeStepper(F, method, t, dt, p, **params)

--- a/tests/test_stage_value_init.py
+++ b/tests/test_stage_value_init.py
@@ -20,9 +20,9 @@ def test_stage_value_init(basis_type, degree):
     q = TestFunction(Q)
 
     u_0 = Constant(1.0)
-    δu = Constant(1.0)
+    du = Constant(1.0)
     Lx = Constant(lx)
-    u = as_vector((u_0 + δu * x / Lx,))
+    u = as_vector((u_0 + du * x / Lx,))
 
     p_max = Constant(2.0)
     s = p_max / p - 1
@@ -34,7 +34,7 @@ def test_stage_value_init(basis_type, degree):
     F_outflow = p * max_value(0, inner(u, n)) * q * ds
     F = F_cells + F_facets + F_inflow + F_outflow
 
-    method = BackwardEuler() if degree == 1 else RadauIIA(2)
+    method = BackwardEuler() if degree == 1 else RadauIIA(degree)
     t = Constant(0.0)
     timestep = 0.5 / nx
     dt = Constant(timestep)

--- a/tests/test_stage_value_init.py
+++ b/tests/test_stage_value_init.py
@@ -1,0 +1,50 @@
+from firedrake import *
+from irksome import Dt, TimeStepper, BackwardEuler
+
+
+def test_stage_value_init():
+    nx = 16
+    lx = 1.0
+    mesh = IntervalMesh(nx, lx)
+
+    Q = FunctionSpace(mesh, "DG", 0)
+    x, = SpatialCoordinate(mesh)
+
+    p = Function(Q)
+    p_in = Constant(0.5)
+    p.assign(p_in)
+
+    q = TestFunction(Q)
+
+    u_0 = Constant(1.0)
+    δu = Constant(1.0)
+    Lx = Constant(lx)
+    u = as_vector((u_0 + δu * x / Lx,))
+
+    p_max = Constant(2.0)
+    s = p_max / p - 1
+    F_cells = (Dt(p) * q - inner(p * u, grad(q)) - s * q) * dx
+    n = FacetNormal(mesh)
+    f_n = p * max_value(0, inner(u, n))
+    F_facets = (f_n("+") - f_n("-")) * (q("+") - q("-")) * dS
+    F_inflow = p_in * min_value(0, inner(u, n)) * q * ds
+    F_outflow = p * max_value(0, inner(u, n)) * q * ds
+    F = F_cells + F_facets + F_inflow + F_outflow
+
+    method = BackwardEuler()
+    t = Constant(0.0)
+    timestep = 0.5 / nx
+    dt = Constant(timestep)
+    params = {
+        "stage_type": "value",
+        "basis_type": "Bernstein",
+        "solver_parameters": {"snes_monitor": None},
+    }
+    stepper = TimeStepper(F, method, t, dt, p, **params)
+
+    final_time = 2.0
+    num_steps = int(final_time / timestep)
+    for step in range(num_steps):
+        stepper.advance()
+
+    assert norm(p) > 0.0


### PR DESCRIPTION
Resolves #193. I added a test based on a simple conservation law with a source term. The test fails with FNORM_NAN without properly initializing the timestepper, and passes as soon as the timestepper uses a constant initial guess. I put it in its own file but let me know if it should go elsewhere.