### PR TITLE
Conservative StageValueStepper

### DIFF
--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -50,10 +50,11 @@ def getTermDiscGalerkin(F, L, Q, t, dt, u0, stages, test):
     basis_vals = tabulate_basis[(0,)]
     basis_dvals = tabulate_basis[(1,)]
     basis_vals_w = np.multiply(basis_vals, qwts)
+    basis_dvals_w = np.multiply(basis_dvals, qwts)
 
     trial_vals = vecconst(basis_vals)
-    trial_dvals = vecconst(basis_dvals)
     test_vals_w = vecconst(basis_vals_w)
+    test_dvals_w = vecconst(basis_dvals_w)
     qpts = vecconst(qpts.reshape((-1,)))
 
     # set up the pieces we need to work with to do our substitutions
@@ -61,7 +62,7 @@ def getTermDiscGalerkin(F, L, Q, t, dt, u0, stages, test):
     u_np = reshape(stages, (-1, *u0.ufl_shape))
     vsub = dot(test_vals_w.T, v_np)
     usub = dot(trial_vals.T, u_np)
-    dtu0sub = dot(trial_dvals.T, u_np)
+    dtvsub = dot(test_dvals_w.T, v_np)
 
     # preprocess time derivatives
     split_form = split_time_derivative_terms(F, t=t, timedep_coeffs=(u0,))
@@ -70,20 +71,23 @@ def getTermDiscGalerkin(F, L, Q, t, dt, u0, stages, test):
     if F_dtless.empty():
         Fnew = F_dtless
     else:
-        # Jump terms
-        L_at_0 = vecconst(L.tabulate(0, (0.0,))[(0,)])
-        u_at_0 = L_at_0 @ u_np
-        v_at_0 = L_at_0 @ v_np
-        repl = {u0: u_at_0 - u0,
-                v: v_at_0}
-        Fnew = replace(F_dtless, repl)
+        # Integrate by parts in time (Dt(g(u)), v)
+        # Jump terms: [(g(u), v)](t+dt) - [(g(u), v)](t)
+        ref_el = L.get_reference_element()
+        L_at_01 = vecconst(L.tabulate(0, ref_el.vertices)[(0,)])
+        u_at_01 = dot(L_at_01.T, u_np)
+        v_at_01 = dot(L_at_01.T, v_np)
 
-        # Terms with time derivatives
+        repl_old = {v: v_at_01[0]}
+        repl_new = {v: v_at_01[1], u0: u_at_01[1], t: t + dt}
+        Fnew = replace(F_dtless, repl_new) - replace(F_dtless, repl_old)
+
+        # Terms with time derivatives: -(g(u), Dt(v))
         for q in range(len(qpts)):
             repl = {t: t + qpts[q] * dt,
-                    v: vsub[q] * dt,
-                    u0: dtu0sub[q] / dt}
-            Fnew += replace(F_dtless, repl)
+                    v: dtvsub[q],
+                    u0: usub[q]}
+            Fnew -= replace(F_dtless, repl)
 
     # Handle the rest of the terms
     for q in range(len(qpts)):

--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -1,7 +1,7 @@
 from FIAT import (Bernstein,
                   DiscontinuousLagrange, Legendre,
                   GaussLobattoLegendre, GaussRadau)
-from ufl import as_ufl, as_tensor, Form
+from ufl import as_ufl, as_tensor
 from .base_time_stepper import StageCoupledTimeStepper
 from .bcs import stage2spaces4bc
 from .labeling import split_quadrature, as_form
@@ -64,12 +64,11 @@ def getTermDiscGalerkin(F, L, Q, t, dt, u0, stages, test):
     dtu0sub = dot(trial_dvals.T, u_np)
 
     split_form = extract_terms(F, timedep_coeffs=(u0,))
-    F_time = split_form.time
-    F_remainder = split_form.remainder
-    if F_time.empty():
-        Fnew = Form([])
+    F_dtless = strip_dt_form(split_form.time)
+    F_remainder = expand_time_derivatives(split_form.remainder, t=t, timedep_coeffs=())
+    if F_dtless.empty():
+        Fnew = F_dtless
     else:
-        F_dtless = strip_dt_form(F_time)
         # Jump terms
         L_at_0 = vecconst(L.tabulate(0, (0.0,))[(0,)])
         u_at_0 = L_at_0 @ u_np
@@ -85,8 +84,6 @@ def getTermDiscGalerkin(F, L, Q, t, dt, u0, stages, test):
                     u0: dtu0sub[q] / dt}
             Fnew += replace(F_dtless, repl)
 
-    # preprocess time derivatives
-    F_remainder = expand_time_derivatives(F_remainder, t=t, timedep_coeffs=(u0,))
     # Handle the rest of the terms
     for q in range(len(qpts)):
         repl = {t: t + qpts[q] * dt,

--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -7,7 +7,7 @@ from .bcs import stage2spaces4bc
 from .labeling import split_quadrature, as_form
 from .ufl.estimate_degrees import TimeDegreeEstimator, get_degree_mapping
 from .ufl.deriv import expand_time_derivatives
-from .ufl.manipulation import extract_terms, strip_dt_form
+from .ufl.manipulation import split_time_derivative_terms, remove_time_derivatives
 from .scheme import create_time_quadrature, ufc_line
 from .tools import dot, reshape, replace
 from .constant import vecconst
@@ -63,8 +63,9 @@ def getTermDiscGalerkin(F, L, Q, t, dt, u0, stages, test):
     usub = dot(trial_vals.T, u_np)
     dtu0sub = dot(trial_dvals.T, u_np)
 
-    split_form = extract_terms(F, timedep_coeffs=(u0,))
-    F_dtless = strip_dt_form(split_form.time)
+    # preprocess time derivatives
+    split_form = split_time_derivative_terms(F, timedep_coeffs=(u0,))
+    F_dtless = remove_time_derivatives(split_form.time)
     F_remainder = expand_time_derivatives(split_form.remainder, t=t, timedep_coeffs=())
     if F_dtless.empty():
         Fnew = F_dtless

--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -1,13 +1,12 @@
 from FIAT import (Bernstein,
                   DiscontinuousLagrange, Legendre,
                   GaussLobattoLegendre, GaussRadau)
-from ufl import as_ufl, as_tensor
-from ufl.algorithms.analysis import has_type
+from ufl import as_ufl, as_tensor, Form
 from .base_time_stepper import StageCoupledTimeStepper
 from .bcs import stage2spaces4bc
 from .labeling import split_quadrature, as_form
 from .ufl.estimate_degrees import TimeDegreeEstimator, get_degree_mapping
-from .ufl.deriv import TimeDerivative, expand_time_derivatives
+from .ufl.deriv import expand_time_derivatives
 from .ufl.manipulation import extract_terms, strip_dt_form
 from .scheme import create_time_quadrature, ufc_line
 from .tools import dot, reshape, replace
@@ -39,8 +38,6 @@ def getElement(basis_type, order):
 
 
 def getTermDiscGalerkin(F, L, Q, t, dt, u0, stages, test):
-    # preprocess time derivatives
-    F = expand_time_derivatives(F, t=t, timedep_coeffs=(u0,))
     v, = F.arguments()
     V = v.function_space()
     assert V == u0.function_space()
@@ -66,11 +63,13 @@ def getTermDiscGalerkin(F, L, Q, t, dt, u0, stages, test):
     usub = dot(trial_vals.T, u_np)
     dtu0sub = dot(trial_dvals.T, u_np)
 
-    if has_type(F, TimeDerivative):
-        split_form = extract_terms(F)
-        F_dtless = strip_dt_form(split_form.time)
-        F_remainder = split_form.remainder
-
+    split_form = extract_terms(F, (u0,))
+    F_time = split_form.time
+    F_remainder = split_form.remainder
+    if F_time.empty():
+        Fnew = Form([])
+    else:
+        F_dtless = strip_dt_form(F_time)
         # Jump terms
         L_at_0 = vecconst(L.tabulate(0, (0.0,))[(0,)])
         u_at_0 = L_at_0 @ u_np
@@ -85,10 +84,9 @@ def getTermDiscGalerkin(F, L, Q, t, dt, u0, stages, test):
                     v: vsub[q] * dt,
                     u0: dtu0sub[q] / dt}
             Fnew += replace(F_dtless, repl)
-    else:
-        Fnew = 0
-        F_remainder = F
 
+    # preprocess time derivatives
+    F_remainder = expand_time_derivatives(F_remainder, t=t, timedep_coeffs=(u0,))
     # Handle the rest of the terms
     for q in range(len(qpts)):
         repl = {t: t + qpts[q] * dt,

--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -63,7 +63,7 @@ def getTermDiscGalerkin(F, L, Q, t, dt, u0, stages, test):
     usub = dot(trial_vals.T, u_np)
     dtu0sub = dot(trial_dvals.T, u_np)
 
-    split_form = extract_terms(F, (u0,))
+    split_form = extract_terms(F, timedep_coeffs=(u0,))
     F_time = split_form.time
     F_remainder = split_form.remainder
     if F_time.empty():

--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -64,7 +64,7 @@ def getTermDiscGalerkin(F, L, Q, t, dt, u0, stages, test):
     dtu0sub = dot(trial_dvals.T, u_np)
 
     # preprocess time derivatives
-    split_form = split_time_derivative_terms(F, timedep_coeffs=(u0,))
+    split_form = split_time_derivative_terms(F, t=t, timedep_coeffs=(u0,))
     F_dtless = remove_time_derivatives(split_form.time)
     F_remainder = expand_time_derivatives(split_form.remainder, t=t, timedep_coeffs=())
     if F_dtless.empty():

--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -70,6 +70,18 @@ def getTermDiscGalerkin(F, L, Q, t, dt, u0, stages, test, deriv_type="strong"):
     if F_dtless.empty():
         Fnew = F_dtless
         F_remainder = F
+    elif deriv_type == "strong":
+        # Integrate by parts twice (Dt(g(u)), v)
+        # Jump terms: [(g(u), v)](t+) - [(g(u), v)](t-)
+        ref_el = L.get_reference_element()
+        L_at_0 = vecconst(L.tabulate(0, ref_el.vertices[0])[(0,)])
+        u_at_0 = dot(L_at_0.T, u_np)
+        v_at_0 = dot(L_at_0.T, v_np)
+
+        repl_tminus = {v: v_at_0}
+        repl_tplus = {v: v_at_0, u0: u_at_0}
+        Fnew = replace(F_dtless, repl_tplus) - replace(F_dtless, repl_tminus)
+        F_remainder = F
     elif deriv_type == "weak":
         # Integrate by parts once (Dt(g(u)), v)
         # Jump terms: [(g(u), v)](t+dt) - [(g(u), v)](t-)
@@ -91,18 +103,6 @@ def getTermDiscGalerkin(F, L, Q, t, dt, u0, stages, test, deriv_type="strong"):
                     u0: usub[q]}
             Fnew -= replace(F_dtless, repl)
         F_remainder = split_form.remainder
-    elif deriv_type == "strong":
-        # Integrate by parts twice (Dt(g(u)), v)
-        # Jump terms: [(g(u), v)](t+) - [(g(u), v)](t-)
-        ref_el = L.get_reference_element()
-        L_at_0 = vecconst(L.tabulate(0, ref_el.vertices[0])[(0,)])
-        u_at_0 = dot(L_at_0.T, u_np)
-        v_at_0 = dot(L_at_0.T, v_np)
-
-        repl_tminus = {v: v_at_0}
-        repl_tplus = {v: v_at_0, u0: u_at_0}
-        Fnew = replace(F_dtless, repl_tplus) - replace(F_dtless, repl_tminus)
-        F_remainder = F
     else:
         raise ValueError(f"Unrecongnized deriv_type {deriv_type}")
 

--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -6,7 +6,7 @@ from .base_time_stepper import StageCoupledTimeStepper
 from .bcs import stage2spaces4bc
 from .labeling import split_quadrature, as_form
 from .ufl.estimate_degrees import TimeDegreeEstimator, get_degree_mapping
-from .ufl.deriv import expand_time_derivatives
+from .ufl.deriv import TimeDerivative, expand_time_derivatives
 from .ufl.manipulation import split_time_derivative_terms, remove_time_derivatives
 from .scheme import create_time_quadrature, ufc_line
 from .tools import dot, reshape, replace
@@ -37,7 +37,7 @@ def getElement(basis_type, order):
         return DiscontinuousLagrange(ufc_line, order, variant=variant)
 
 
-def getTermDiscGalerkin(F, L, Q, t, dt, u0, stages, test):
+def getTermDiscGalerkin(F, L, Q, t, dt, u0, stages, test, deriv_type="strong"):
     v, = F.arguments()
     V = v.function_space()
     assert V == u0.function_space()
@@ -54,7 +54,7 @@ def getTermDiscGalerkin(F, L, Q, t, dt, u0, stages, test):
 
     trial_vals = vecconst(basis_vals)
     test_vals_w = vecconst(basis_vals_w)
-    test_dvals_w = vecconst(basis_dvals_w)
+    trial_dvals = vecconst(basis_dvals)
     qpts = vecconst(qpts.reshape((-1,)))
 
     # set up the pieces we need to work with to do our substitutions
@@ -62,43 +62,63 @@ def getTermDiscGalerkin(F, L, Q, t, dt, u0, stages, test):
     u_np = reshape(stages, (-1, *u0.ufl_shape))
     vsub = dot(test_vals_w.T, v_np)
     usub = dot(trial_vals.T, u_np)
-    dtvsub = dot(test_dvals_w.T, v_np)
+    dtusub = dot(trial_dvals.T, u_np)
 
     # preprocess time derivatives
     split_form = split_time_derivative_terms(F, t=t, timedep_coeffs=(u0,))
     F_dtless = remove_time_derivatives(split_form.time)
-    F_remainder = expand_time_derivatives(split_form.remainder, t=t, timedep_coeffs=())
     if F_dtless.empty():
         Fnew = F_dtless
-    else:
-        # Integrate by parts in time (Dt(g(u)), v)
-        # Jump terms: [(g(u), v)](t+dt) - [(g(u), v)](t)
+        F_remainder = F
+    elif deriv_type == "weak":
+        # Integrate by parts once (Dt(g(u)), v)
+        # Jump terms: [(g(u), v)](t+dt) - [(g(u), v)](t-)
         ref_el = L.get_reference_element()
         L_at_01 = vecconst(L.tabulate(0, ref_el.vertices)[(0,)])
         u_at_01 = dot(L_at_01.T, u_np)
         v_at_01 = dot(L_at_01.T, v_np)
 
-        repl_old = {v: v_at_01[0]}
-        repl_new = {v: v_at_01[1], u0: u_at_01[1], t: t + dt}
-        Fnew = replace(F_dtless, repl_new) - replace(F_dtless, repl_old)
+        repl_tminus = {v: v_at_01[0]}
+        repl_tnew = {v: v_at_01[1], u0: u_at_01[1], t: t + dt}
+        Fnew = replace(F_dtless, repl_tnew) - replace(F_dtless, repl_tminus)
 
         # Terms with time derivatives: -(g(u), Dt(v))
+        test_dvals_w = vecconst(basis_dvals_w)
+        dtvsub = dot(test_dvals_w.T, v_np)
         for q in range(len(qpts)):
             repl = {t: t + qpts[q] * dt,
                     v: dtvsub[q],
                     u0: usub[q]}
             Fnew -= replace(F_dtless, repl)
+        F_remainder = split_form.remainder
+    elif deriv_type == "strong":
+        # Integrate by parts twice (Dt(g(u)), v)
+        # Jump terms: [(g(u), v)](t+) - [(g(u), v)](t-)
+        ref_el = L.get_reference_element()
+        L_at_0 = vecconst(L.tabulate(0, ref_el.vertices[0])[(0,)])
+        u_at_0 = dot(L_at_0.T, u_np)
+        v_at_0 = dot(L_at_0.T, v_np)
+
+        repl_tminus = {v: v_at_0}
+        repl_tplus = {v: v_at_0, u0: u_at_0}
+        Fnew = replace(F_dtless, repl_tplus) - replace(F_dtless, repl_tminus)
+        F_remainder = F
+    else:
+        raise ValueError(f"Unrecongnized deriv_type {deriv_type}")
 
     # Handle the rest of the terms
+    F_remainder = expand_time_derivatives(F_remainder, t=t, timedep_coeffs=(u0,))
+    dtu0 = TimeDerivative(u0)
     for q in range(len(qpts)):
         repl = {t: t + qpts[q] * dt,
                 v: vsub[q] * dt,
-                u0: usub[q]}
+                u0: usub[q],
+                dtu0: dtusub[q] / dt}
         Fnew += replace(F_remainder, repl)
     return Fnew
 
 
-def getFormDiscGalerkin(F, L, Qdefault, t, dt, u0, stages, bcs=None):
+def getFormDiscGalerkin(F, L, Qdefault, t, dt, u0, stages, bcs=None, deriv_type="strong"):
     """Given a time-dependent variational form, trial and test spaces, and
     a quadrature rule, produce UFL for the Discontinuous Galerkin-in-Time method.
 
@@ -116,6 +136,7 @@ def getFormDiscGalerkin(F, L, Qdefault, t, dt, u0, stages, bcs=None):
     :arg bcs: optionally, a :class:`DirichletBC` object (or iterable thereof)
          containing (possibly time-dependent) boundary conditions imposed
          on the system.
+    :arg deriv_type: either `"weak"` or `"strong"`.
 
     On output, we return a tuple consisting of two parts:
 
@@ -204,6 +225,7 @@ class DiscontinuousGalerkinTimeStepper(StageCoupledTimeStepper):
         assert order >= 0, "DG must be order >= 0"
 
         self.basis_type = basis_type = scheme.basis_type
+        self.deriv_type = scheme.deriv_type
 
         V = u0.function_space()
         self.num_fields = len(V)
@@ -230,7 +252,8 @@ class DiscontinuousGalerkinTimeStepper(StageCoupledTimeStepper):
 
         super().__init__(F, t, dt, u0, num_stages, bcs=bcs, **kwargs)
 
-    def get_form_and_bcs(self, stages, F=None, bcs=None, basis_type=None, order=None, quadrature=None):
+    def get_form_and_bcs(self, stages, F=None, bcs=None, basis_type=None, order=None,
+                         quadrature=None, deriv_type=None):
         if bcs is None:
             bcs = self.orig_bcs
         if basis_type is None:
@@ -241,10 +264,12 @@ class DiscontinuousGalerkinTimeStepper(StageCoupledTimeStepper):
             el = self.el
         else:
             el = getElement(basis_type, order)
+        deriv_type = deriv_type or self.deriv_type
         return getFormDiscGalerkin(F or self.F,
                                    el,
                                    quadrature or self.quadrature,
-                                   self.t, self.dt, self.u0, stages, bcs)
+                                   self.t, self.dt, self.u0, stages,
+                                   bcs=bcs, deriv_type=deriv_type)
 
     def _update(self):
         stages_np = np.array(self.stages.subfunctions, dtype=object)

--- a/irksome/scheme.py
+++ b/irksome/scheme.py
@@ -39,8 +39,10 @@ class DiscontinuousGalerkinScheme(GalerkinScheme):
                  quadrature_degree=None,
                  quadrature_scheme=None,
                  deriv_type="strong"):
-        assert order >= 0, f"{type(self).__name__} must have order >= 0"
-        assert deriv_type in {"weak", "strong"}
+        if order < 0:
+            raise ValueError(f"{type(self).__name__} must have order >= 0")
+        if deriv_type not in {"weak", "strong"}:
+            raise ValueError(f"deriv_type must be either weak or strong.")
         self.deriv_type = deriv_type
         super().__init__(order, basis_type=basis_type,
                          quadrature_degree=quadrature_degree,
@@ -53,7 +55,8 @@ class ContinuousPetrovGalerkinScheme(GalerkinScheme):
                  basis_type=None,
                  quadrature_degree=None,
                  quadrature_scheme=None):
-        assert order >= 1, f"{type(self).__name__} must have order >= 1"
+        if order < 1:
+            raise ValueError(f"{type(self).__name__} must have order >= 1")
         super().__init__(order, basis_type=basis_type,
                          quadrature_degree=quadrature_degree,
                          quadrature_scheme=quadrature_scheme)
@@ -65,7 +68,8 @@ class GalerkinCollocationScheme(ContinuousPetrovGalerkinScheme):
                  stage_type="deriv",
                  quadrature_degree=None,
                  quadrature_scheme=None):
-        assert order >= 1, f"{type(self).__name__} must have order >= 1"
+        if order < 1:
+            raise ValueError(f"{type(self).__name__} must have order >= 1")
         if quadrature_scheme is None:
             test_type = "spectral"
         elif quadrature_scheme in {"radau", "lobatto"}:

--- a/irksome/scheme.py
+++ b/irksome/scheme.py
@@ -42,7 +42,7 @@ class DiscontinuousGalerkinScheme(GalerkinScheme):
         if order < 0:
             raise ValueError(f"{type(self).__name__} must have order >= 0")
         if deriv_type not in {"weak", "strong"}:
-            raise ValueError(f"deriv_type must be either weak or strong.")
+            raise ValueError("deriv_type must be either weak or strong.")
         self.deriv_type = deriv_type
         super().__init__(order, basis_type=basis_type,
                          quadrature_degree=quadrature_degree,

--- a/irksome/scheme.py
+++ b/irksome/scheme.py
@@ -37,8 +37,11 @@ class DiscontinuousGalerkinScheme(GalerkinScheme):
     def __init__(self, order,
                  basis_type=None,
                  quadrature_degree=None,
-                 quadrature_scheme=None):
+                 quadrature_scheme=None,
+                 deriv_type="strong"):
         assert order >= 0, f"{type(self).__name__} must have order >= 0"
+        assert deriv_type in {"weak", "strong"}
+        self.deriv_type = deriv_type
         super().__init__(order, basis_type=basis_type,
                          quadrature_degree=quadrature_degree,
                          quadrature_scheme=quadrature_scheme)

--- a/irksome/stage_derivative.py
+++ b/irksome/stage_derivative.py
@@ -323,9 +323,10 @@ class AdaptiveTimeStepper(StageDerivativeTimeStepper):
         self.err_old = 0.0
         self.contreject = 0
 
-        F = expand_time_derivatives(F, t=t, timedep_coeffs=(u0,))
-        split_form = extract_terms(F)
-        self.dtless_form = -split_form.remainder
+        split_form = extract_terms(F, timedep_coeffs=(u0,))
+        F_remainder = split_form.remainder
+        F_remainder = expand_time_derivatives(F_remainder, t=t, timedep_coeffs=(u0,))
+        self.dtless_form = -F_remainder
 
         # Set up and cache boundary conditions for error estimate
         embbc = []

--- a/irksome/stage_derivative.py
+++ b/irksome/stage_derivative.py
@@ -323,7 +323,7 @@ class AdaptiveTimeStepper(StageDerivativeTimeStepper):
         self.err_old = 0.0
         self.contreject = 0
 
-        split_form = split_time_derivative_terms(F, timedep_coeffs=(u0,))
+        split_form = split_time_derivative_terms(F, t=t, timedep_coeffs=(u0,))
         F_remainder = expand_time_derivatives(split_form.remainder, t=t, timedep_coeffs=())
         self.dtless_form = -F_remainder
 

--- a/irksome/stage_derivative.py
+++ b/irksome/stage_derivative.py
@@ -10,7 +10,7 @@ from .constant import vecconst
 from .tools import AI, dot, replace, reshape, fields_to_components
 from .ufl.deriv import Dt, TimeDerivative, expand_time_derivatives
 from .bcs import EmbeddedBCData, BCStageData, extract_bcs, bc2space, stage2spaces4bc
-from .ufl.manipulation import extract_terms
+from .ufl.manipulation import split_time_derivative_terms
 from .base_time_stepper import StageCoupledTimeStepper
 
 
@@ -323,9 +323,8 @@ class AdaptiveTimeStepper(StageDerivativeTimeStepper):
         self.err_old = 0.0
         self.contreject = 0
 
-        split_form = extract_terms(F, timedep_coeffs=(u0,))
-        F_remainder = split_form.remainder
-        F_remainder = expand_time_derivatives(F_remainder, t=t, timedep_coeffs=(u0,))
+        split_form = split_time_derivative_terms(F, timedep_coeffs=(u0,))
+        F_remainder = expand_time_derivatives(split_form.remainder, t=t, timedep_coeffs=())
         self.dtless_form = -F_remainder
 
         # Set up and cache boundary conditions for error estimate

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -12,7 +12,7 @@ from .bcs import stage2spaces4bc
 from .tableaux.ButcherTableaux import CollocationButcherTableau
 from .ufl.deriv import expand_time_derivatives
 from .ufl.manipulation import split_time_derivative_terms, remove_time_derivatives
-from .tools import AI, is_ode, dot, reshape, replace
+from .tools import AI, dot, reshape, replace
 from .constant import vecconst
 from .base_time_stepper import StageCoupledTimeStepper
 
@@ -73,9 +73,6 @@ def getFormStage(F, butch, t, dt, u0, stages, bcs=None, splitting=AI, vandermond
        - `bcnew`, a list of :class:`firedrake.DirichletBC` objects to be posed
          on the stages
     """
-    # we can only do DAE-type problems correctly if one assumes a stiffly-accurate method.
-    assert is_ode(F, u0) or butch.is_stiffly_accurate
-
     v, = F.arguments()
     V = v.function_space()
     assert V == u0.function_space()

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -11,7 +11,7 @@ from ufl.constantvalue import as_ufl
 from .bcs import stage2spaces4bc
 from .tableaux.ButcherTableaux import CollocationButcherTableau
 from .ufl.deriv import expand_time_derivatives
-from .ufl.manipulation import extract_terms, strip_dt_form
+from .ufl.manipulation import split_time_derivative_terms, remove_time_derivatives
 from .tools import AI, is_ode, dot, reshape, replace
 from .constant import vecconst
 from .base_time_stepper import StageCoupledTimeStepper
@@ -104,8 +104,8 @@ def getFormStage(F, butch, t, dt, u0, stages, bcs=None, splitting=AI, vandermond
     # assuming we have something of the form inner(Dt(g(u0)), v)*dx
     # For each stage i, this gets replaced with
     # inner((g(stages[i]) - g(u0))/dt, v)*dx
-    split_form = extract_terms(F, timedep_coeffs=(u0,))
-    F_dtless = strip_dt_form(split_form.time)
+    split_form = split_time_derivative_terms(F, timedep_coeffs=(u0,))
+    F_dtless = remove_time_derivatives(split_form.time)
     F_remainder = expand_time_derivatives(split_form.remainder, t=t, timedep_coeffs=())
 
     Fnew = Form([])
@@ -223,9 +223,8 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
         t = self.t
         dt = self.dt
         u0 = self.u0
-        split_form = extract_terms(F, timedep_coeffs=(u0,))
-        F_remainder = split_form.remainder
-        F_remainder = expand_time_derivatives(F_remainder, t=t, timedep_coeffs=(u0,))
+        split_form = split_time_derivative_terms(F, timedep_coeffs=(u0,))
+        F_remainder = expand_time_derivatives(split_form.remainder, t=t, timedep_coeffs=())
         u_np = to_value(self.u0, self.stages, self.vandermonde)
 
         for i in range(self.num_stages):

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -109,12 +109,18 @@ def getFormStage(F, butch, t, dt, u0, stages, bcs=None, splitting=AI, vandermond
     F_remainder = expand_time_derivatives(split_form.remainder, t=t, timedep_coeffs=())
 
     Fnew = Form([])
-    # Terms with time derivatives
+    # Terms with time derivatives: use two evaluations so that
+    # Dt(g(u)) is discretised as g(U_i) - g(u0), not g(U_i - u0).
+    # These are identical for linear g but differ for nonlinear g,
+    # and the two-evaluation form is what gives mass conservation.
     for i in range(num_stages):
-        repl = {t: t + c[i] * dt,
-                v: A2invTv[i],
-                u0: as_tensor(w_np[i]) - u0}
-        Fnew += replace(F_dtless, repl)
+        repl_new = {t: t + c[i] * dt,
+                    v: A2invTv[i],
+                    u0: w_np[i]}
+        # Evaluate g at the old solution u0 (not substituted) and
+        # old time t (not substituted).
+        repl_old = {v: A2invTv[i]}
+        Fnew += replace(F_dtless, repl_new) - replace(F_dtless, repl_old)
 
     # Handle the rest of the terms
     for i in range(num_stages):

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -5,7 +5,7 @@ from FIAT.barycentric_interpolation import LagrangePolynomialSet
 from firedrake import (Function, NonlinearVariationalProblem,
                        NonlinearVariationalSolver, TestFunction, dx,
                        inner)
-from ufl import as_tensor, zero
+from ufl import as_tensor, Form
 from ufl.constantvalue import as_ufl
 
 from .bcs import stage2spaces4bc
@@ -104,13 +104,11 @@ def getFormStage(F, butch, t, dt, u0, stages, bcs=None, splitting=AI, vandermond
     # assuming we have something of the form inner(Dt(g(u0)), v)*dx
     # For each stage i, this gets replaced with
     # inner((g(stages[i]) - g(u0))/dt, v)*dx
-    split_form = extract_terms(F, (u0,))
+    split_form = extract_terms(F, timedep_coeffs=(u0,))
     F_dtless = strip_dt_form(split_form.time)
-    F_remainder = split_form.remainder
-    # preprocess time derivatives
-    F_remainder = expand_time_derivatives(F_remainder, t=t, timedep_coeffs=(u0,))
+    F_remainder = expand_time_derivatives(split_form.remainder, t=t, timedep_coeffs=())
 
-    Fnew = zero()
+    Fnew = Form([])
     # Terms with time derivatives
     for i in range(num_stages):
         repl = {t: t + c[i] * dt,

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -225,7 +225,7 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
         t = self.t
         dt = self.dt
         u0 = self.u0
-        split_form = extract_terms(F, (u0,))
+        split_form = extract_terms(F, timedep_coeffs=(u0,))
         F_remainder = split_form.remainder
         F_remainder = expand_time_derivatives(F_remainder, t=t, timedep_coeffs=(u0,))
         u_np = to_value(self.u0, self.stages, self.vandermonde)

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -104,7 +104,7 @@ def getFormStage(F, butch, t, dt, u0, stages, bcs=None, splitting=AI, vandermond
     # assuming we have something of the form inner(Dt(g(u0)), v)*dx
     # For each stage i, this gets replaced with
     # inner((g(stages[i]) - g(u0))/dt, v)*dx
-    split_form = split_time_derivative_terms(F, timedep_coeffs=(u0,))
+    split_form = split_time_derivative_terms(F, t=t, timedep_coeffs=(u0,))
     F_dtless = remove_time_derivatives(split_form.time)
     F_remainder = expand_time_derivatives(split_form.remainder, t=t, timedep_coeffs=())
 
@@ -223,7 +223,7 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
         t = self.t
         dt = self.dt
         u0 = self.u0
-        split_form = split_time_derivative_terms(F, timedep_coeffs=(u0,))
+        split_form = split_time_derivative_terms(F, t=t, timedep_coeffs=(u0,))
         F_remainder = expand_time_derivatives(split_form.remainder, t=t, timedep_coeffs=())
         u_np = to_value(self.u0, self.stages, self.vandermonde)
 

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -73,8 +73,6 @@ def getFormStage(F, butch, t, dt, u0, stages, bcs=None, splitting=AI, vandermond
        - `bcnew`, a list of :class:`firedrake.DirichletBC` objects to be posed
          on the stages
     """
-    # preprocess time derivatives
-    F = expand_time_derivatives(F, t=t, timedep_coeffs=(u0,))
     # we can only do DAE-type problems correctly if one assumes a stiffly-accurate method.
     assert is_ode(F, u0) or butch.is_stiffly_accurate
 
@@ -106,9 +104,11 @@ def getFormStage(F, butch, t, dt, u0, stages, bcs=None, splitting=AI, vandermond
     # assuming we have something of the form inner(Dt(g(u0)), v)*dx
     # For each stage i, this gets replaced with
     # inner((g(stages[i]) - g(u0))/dt, v)*dx
-    split_form = extract_terms(F)
+    split_form = extract_terms(F, (u0,))
     F_dtless = strip_dt_form(split_form.time)
     F_remainder = split_form.remainder
+    # preprocess time derivatives
+    F_remainder = expand_time_derivatives(F_remainder, t=t, timedep_coeffs=(u0,))
 
     Fnew = zero()
     # Terms with time derivatives
@@ -215,23 +215,25 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
     def get_update_solver(self, update_solver_parameters):
         # only form update stuff if we need it
         # which means neither stiffly accurate nor Vandermonde
-        F = expand_time_derivatives(self.F, t=self.t, timedep_coeffs=(self.u0,))
-        v, = F.arguments()
+        v, = self.F.arguments()
         unew = Function(self.u0.function_space())
         Fupdate = inner(unew - self.u0, v) * dx
 
         C = vecconst(self.butcher_tableau.c)
         B = vecconst(self.butcher_tableau.b)
+        F = self.F
         t = self.t
         dt = self.dt
         u0 = self.u0
-        split_form = extract_terms(F)
+        split_form = extract_terms(F, (u0,))
+        F_remainder = split_form.remainder
+        F_remainder = expand_time_derivatives(F_remainder, t=t, timedep_coeffs=(u0,))
         u_np = to_value(self.u0, self.stages, self.vandermonde)
 
         for i in range(self.num_stages):
             repl = {t: t + C[i] * dt,
                     u0: u_np[i]}
-            Fupdate += dt * B[i] * replace(split_form.remainder, repl)
+            Fupdate += dt * B[i] * replace(F_remainder, repl)
 
         # And the BC's for the update -- just the original BC at t+dt
         update_bcs = []

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -117,4 +117,4 @@ def is_ode(f, u):
         op, = k.ufl_operands
         Dtbits.extend(op[i] for i in numpy.ndindex(op.ufl_shape))
     ubits = [u[i] for i in numpy.ndindex(u.ufl_shape)]
-    return set(Dtbits) == set(ubits)
+    return set(ubits) <= set(Dtbits)

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -7,7 +7,7 @@ from ufl import as_tensor
 from ufl import replace as ufl_replace
 from pyop2.types import MixedDat
 
-from .ufl.deriv import TimeDerivative, expand_time_derivatives
+from .ufl.deriv import TimeDerivative
 
 
 def dot(A, B):
@@ -111,7 +111,6 @@ def IA(A):
 def is_ode(f, u):
     """Given a form defined over a function `u`, checks if
     (each bit of) u appears under a time derivative."""
-    f = expand_time_derivatives(f, timedep_coeffs=(u,))
     derivs = extract_type(f, TimeDerivative)
     Dtbits = []
     for k in derivs:

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -7,7 +7,7 @@ from ufl import as_tensor
 from ufl import replace as ufl_replace
 from pyop2.types import MixedDat
 
-from .ufl.deriv import TimeDerivative
+from .ufl.deriv import TimeDerivative, expand_time_derivatives
 
 
 def dot(A, B):
@@ -111,6 +111,7 @@ def IA(A):
 def is_ode(f, u):
     """Given a form defined over a function `u`, checks if
     (each bit of) u appears under a time derivative."""
+    f = expand_time_derivatives(f, timedep_coeffs=(u,))
     derivs = extract_type(f, TimeDerivative)
     Dtbits = []
     for k in derivs:

--- a/irksome/ufl/manipulation.py
+++ b/irksome/ufl/manipulation.py
@@ -12,7 +12,7 @@ from typing import NamedTuple, List
 from ufl.corealg.dag_traverser import DAGTraverser
 from ufl.classes import (Argument, BaseForm,
                          Cofunction, Coefficient, ConstantValue,
-                         Expr, Form, Integral, SpatialCoordinate)
+                         Expr, Form, FormSum, Integral, SpatialCoordinate)
 
 from .deriv import TimeDerivative
 
@@ -150,18 +150,25 @@ def extract_terms(form: Form, timedep_coeffs: List[Coefficient]) -> SplitTimeFor
     :raises ValueError: if the form does not apply anything other than
         first-order time derivatives to a single coefficient.
     """
-    dt_finder = TimeDerivativeCoefficientFinder(timedep_coeffs=timedep_coeffs)
+    remainder = Form([])
+    if isinstance(form, FormSum):
+        # Assume that TimeDerivative cannot occur on BaseForms
+        terms = form.components()
+        remainder = sum(f for f in terms if not isinstance(f, Form))
+        form = sum(f for f in terms if isinstance(f, Form))
+
+    time_finder = TimeDerivativeCoefficientFinder(timedep_coeffs=timedep_coeffs)
     time_terms = []
     rest_terms = []
     for itg in form.integrals():
-        if dt_finder(itg):
+        if time_finder(itg):
             time_terms.append(itg)
         else:
             rest_terms.append(itg)
 
     time_terms = check_integrals(time_terms, expect_time_derivative=True)
     rest_terms = check_integrals(rest_terms, expect_time_derivative=False)
-    return SplitTimeForm(time=Form(time_terms), remainder=Form(rest_terms))
+    return SplitTimeForm(time=Form(time_terms), remainder=Form(rest_terms)+remainder)
 
 
 class TimeDerivativeRemover(DAGTraverser):

--- a/irksome/ufl/manipulation.py
+++ b/irksome/ufl/manipulation.py
@@ -15,9 +15,9 @@ from ufl.corealg.traversal import traverse_unique_terminals
 from ufl.corealg.dag_traverser import DAGTraverser
 from ufl.classes import (
     BaseForm, CellAvg, Coefficient, ComponentTensor,
-    Conj, Derivative, Division, Dot, Expr, FacetAvg,
+    Conj, Cross, Derivative, Division, Dot, Expr, FacetAvg,
     Form, FormSum, Indexed, IndexSum, Inner, Integral,
-    ListTensor, NegativeRestricted, Outer, PositiveRestricted,
+    ListTensor, MultiIndex, NegativeRestricted, Outer, PositiveRestricted,
     Product, Sum, Variable,
 )
 
@@ -38,7 +38,10 @@ class TimeDerivativeChecker(DAGTraverser):
     """
     def __init__(self, timedep_coeffs, **kwargs):
         super().__init__(**kwargs)
-        self.timedep_coeffs = frozenset(timedep_coeffs)
+        terminals = []
+        for c in timedep_coeffs:
+            terminals.extend(ci for ci in traverse_unique_terminals(c) if not isinstance(ci, MultiIndex))
+        self.timedep_coeffs = frozenset(terminals)
 
     # Work around singledispatchmethod inheritance issue;
     # see https://bugs.python.org/issue36457.
@@ -75,12 +78,18 @@ class TimeDerivativeChecker(DAGTraverser):
 
     @process.register(Product)
     @process.register(Inner)
+    @process.register(Cross)
     @process.register(Dot)
     @process.register(Outer)
     @DAGTraverser.postorder
     def product(self, o, a, b):
+        oa, ob = o.ufl_operands
         if a and b:
             raise ValueError("Can't take product of TimeDerivatives")
+        if a and frozenset(traverse_unique_terminals(ob)) & self.timedep_coeffs:
+            raise ValueError("Can't take product of TimeDerivative and time-dependent coefficients")
+        if b and frozenset(traverse_unique_terminals(oa)) & self.timedep_coeffs:
+            raise ValueError("Can't take product of TimeDerivative and time-dependent coefficients")
         return a or b
 
     @process.register(PositiveRestricted)

--- a/irksome/ufl/manipulation.py
+++ b/irksome/ufl/manipulation.py
@@ -36,12 +36,17 @@ class TimeDerivativeChecker(DAGTraverser):
     """Check that TimeDerivative appears linearly and return the Coefficients
        under TimeDerivatives.
     """
-    def __init__(self, timedep_coeffs, **kwargs):
+    def __init__(self, t, timedep_coeffs, **kwargs):
         super().__init__(**kwargs)
         terminals = []
         for c in timedep_coeffs:
             terminals.extend(ci for ci in traverse_unique_terminals(c) if not isinstance(ci, MultiIndex))
         self.timedep_coeffs = frozenset(terminals)
+        self.t = t
+
+    def check_time_dependence(self, expr):
+        expr_terminals = frozenset(traverse_unique_terminals(expr))
+        return (self.t in expr_terminals) or len(self.timedep_coeffs & expr_terminals) > 0
 
     # Work around singledispatchmethod inheritance issue;
     # see https://bugs.python.org/issue36457.
@@ -86,9 +91,9 @@ class TimeDerivativeChecker(DAGTraverser):
         oa, ob = o.ufl_operands
         if a and b:
             raise ValueError("Can't take product of TimeDerivatives")
-        if a and frozenset(traverse_unique_terminals(ob)) & self.timedep_coeffs:
+        if a and self.check_time_dependence(ob):
             raise ValueError("Can't take product of TimeDerivative and time-dependent coefficients")
-        if b and frozenset(traverse_unique_terminals(oa)) & self.timedep_coeffs:
+        if b and self.check_time_dependence(oa):
             raise ValueError("Can't take product of TimeDerivative and time-dependent coefficients")
         return a or b
 
@@ -110,6 +115,7 @@ class TimeDerivativeChecker(DAGTraverser):
 
 
 def check_integrals(integrals: Sequence[Integral],
+                    t: Expr = None,
                     timedep_coeffs: Sequence[Coefficient] = (),
                     expect_time_derivative: bool = True):
     """Check a list of integrals for linearity in the time derivative.
@@ -124,7 +130,7 @@ def check_integrals(integrals: Sequence[Integral],
     if len(integrals) == 0:
         return integrals
 
-    mapper = TimeDerivativeChecker(timedep_coeffs)
+    mapper = TimeDerivativeChecker(t, timedep_coeffs)
     time_derivatives = set(chain.from_iterable(map(mapper, integrals)))
     howmany = int(expect_time_derivative)
     if len(time_derivatives) != howmany:
@@ -144,13 +150,17 @@ def summands(o: Expr) -> FrozenSet[Expr]:
         return frozenset([o])
 
 
-def split_time_derivative_terms(form: BaseForm, timedep_coeffs: Sequence[Coefficient] = ()) -> SplitTimeForm:
+def split_time_derivative_terms(form: BaseForm,
+                                t: Expr = None,
+                                timedep_coeffs: Sequence[Coefficient] = ()
+                                ) -> SplitTimeForm:
     """Split terms from a :class:`~ufl.Form`.
 
     This splits a form (a sum of integrals) into those integrals which
     do contain a :class:`~.TimeDerivative` acting on `timedep_coeffs` and those that don't.
 
     :arg form: The form to split.
+    :arg t: The time variable.
     :arg timedep_coeffs: The time-dependent coefficients.
     :returns: a :class:`~.SplitTimeForm` tuple.
     :raises ValueError: if the form does not apply anything other than
@@ -164,7 +174,7 @@ def split_time_derivative_terms(form: BaseForm, timedep_coeffs: Sequence[Coeffic
         remainder = sum(w*f for w, f in zip(weights, components) if not isinstance(f, Form))
         form = sum(w*f for w, f in zip(weights, components) if isinstance(f, Form))
 
-    mapper = TimeDerivativeChecker(timedep_coeffs)
+    mapper = TimeDerivativeChecker(t, timedep_coeffs)
     rest_terms = []
     time_terms = []
     for integral in form.integrals():

--- a/irksome/ufl/manipulation.py
+++ b/irksome/ufl/manipulation.py
@@ -13,11 +13,11 @@ from typing import NamedTuple, Sequence
 from ufl.corealg.traversal import traverse_unique_terminals
 from ufl.corealg.dag_traverser import DAGTraverser
 from ufl.classes import (
-    BaseForm, Coefficient, Expr, Form, FormSum, Integral,
-    Division, Product, Dot, Inner, Outer,
-    PositiveRestricted, NegativeRestricted,
-    CellAvg, FacetAvg, Conj, Derivative,
-    Variable, Sum, ListTensor,
+    BaseForm, CellAvg, Coefficient, ComponentTensor,
+    Conj, Derivative, Division, Dot, Expr, FacetAvg,
+    Form, FormSum, Indexed, IndexSum, Inner, Integral,
+    ListTensor, NegativeRestricted, Outer, PositiveRestricted,
+    Product, Sum, Variable,
 )
 
 from .deriv import TimeDerivative
@@ -88,6 +88,9 @@ class TimeDerivativeChecker(DAGTraverser):
     @process.register(Variable)
     @process.register(Sum)
     @process.register(ListTensor)
+    @process.register(Indexed)
+    @process.register(IndexSum)
+    @process.register(ComponentTensor)
     @DAGTraverser.postorder
     def linear_op(self, o, *ops):
         return tuple(set(chain(*ops)))
@@ -112,14 +115,15 @@ def check_integrals(integrals: Sequence[Integral],
     time_derivatives = set(chain.from_iterable(map(mapper, integrals)))
     howmany = int(expect_time_derivative)
     if len(time_derivatives) != howmany:
-        raise ValueError(f"Expecting {howmany} TimeDerivatives, not {len(time_derivatives)}")
+        raise ValueError(f"Expecting time derivative applied to {howmany} "
+                         f"coefficients, not {len(time_derivatives)}")
 
 
 def extract_terms(form: BaseForm, timedep_coeffs: Sequence[Coefficient] = ()) -> SplitTimeForm:
     """Extract terms from a :class:`~ufl.Form`.
 
     This splits a form (a sum of integrals) into those integrals which
-    do contain a :class:`~.TimeDerivative` acting on `u0` and those that don't.
+    do contain a :class:`~.TimeDerivative` acting on `timedep_coeffs` and those that don't.
 
     :arg form: The form to split.
     :arg timedep_coeffs: The time-dependent coefficients.
@@ -130,9 +134,10 @@ def extract_terms(form: BaseForm, timedep_coeffs: Sequence[Coefficient] = ()) ->
     remainder = Form([])
     if isinstance(form, FormSum):
         # Assume that TimeDerivative cannot occur on BaseForms
-        terms = form.components()
-        remainder = sum(f for f in terms if not isinstance(f, Form))
-        form = sum(f for f in terms if isinstance(f, Form))
+        weights = form.weights()
+        components = form.components()
+        remainder = sum(w*f for w, f in zip(weights, components) if not isinstance(f, Form))
+        form = sum(w*f for w, f in zip(weights, components) if isinstance(f, Form))
 
     time_finder = TimeDerivativeChecker(timedep_coeffs)
     time_terms = []
@@ -141,10 +146,8 @@ def extract_terms(form: BaseForm, timedep_coeffs: Sequence[Coefficient] = ()) ->
         tcoeffs = time_finder(itg)
         if len(tcoeffs) == 0:
             rest_terms.append(itg)
-        elif len(tcoeffs) == 1:
-            time_terms.append(itg)
         else:
-            raise ValueError("Expecting 1 or 0 time-dependent coefficients under TimeDerivative")
+            time_terms.append(itg)
 
     return SplitTimeForm(time=Form(time_terms), remainder=Form(rest_terms)+remainder)
 

--- a/irksome/ufl/manipulation.py
+++ b/irksome/ufl/manipulation.py
@@ -77,8 +77,11 @@ class TimeDerivativeChecker(DAGTraverser):
     @process.register(Division)
     @DAGTraverser.postorder
     def division(self, o, a, b):
+        oa, ob = o.ufl_operands
         if b:
             raise ValueError("Can't divide by TimeDerivative")
+        if a and self.check_time_dependence(ob):
+            raise ValueError("Can't divide TimeDerivative by time-dependent expression")
         return a
 
     @process.register(Product)
@@ -92,7 +95,7 @@ class TimeDerivativeChecker(DAGTraverser):
         if a and b:
             raise ValueError("Can't take product of TimeDerivatives")
         if (a and self.check_time_dependence(ob)) or (b and self.check_time_dependence(oa)):
-            raise ValueError("Can't take product of TimeDerivative and time-dependent coefficients")
+            raise ValueError("Can't take product of TimeDerivative and time-dependent expression")
         return a or b
 
     @process.register(PositiveRestricted)

--- a/irksome/ufl/manipulation.py
+++ b/irksome/ufl/manipulation.py
@@ -16,7 +16,6 @@ from tsfc.ufl_utils import ufl_reuse_if_untouched
 from ufl.algebra import Conj, Division, Product, Sum
 from ufl.averaging import CellAvg, FacetAvg
 from ufl.classes import MultiIndex
-from ufl.coefficient import Coefficient
 from ufl.constantvalue import Zero
 from ufl.core.expr import Expr
 from ufl.core.operator import Operator
@@ -26,11 +25,15 @@ from ufl.differentiation import Derivative
 from ufl.form import Form, FormSum
 from ufl.indexed import Indexed
 from ufl.indexsum import IndexSum
-from ufl.integral import Integral
 from ufl.restriction import NegativeRestricted, PositiveRestricted
 from ufl.tensoralgebra import Dot, Inner, Outer
 from ufl.tensors import ComponentTensor, ListTensor
-from ufl.variable import Variable
+
+from ufl.form import BaseForm
+from ufl.classes import (Argument, Cofunction, Coefficient, ConstantValue,
+                         Integral, SpatialCoordinate, Variable)
+from ufl.corealg.dag_traverser import DAGTraverser
+from functools import singledispatchmethod
 
 from .deriv import TimeDerivative
 
@@ -229,3 +232,77 @@ def strip_dt_form(F):
 
     # Return the form stripped of its time derivatives
     return Fnew
+
+
+class CoefficientFinder(DAGTraverser):
+    """Determines whether an expression depends on a set of coefficients.
+    """
+    def __init__(self, coefficient_mapping=None, **kwargs):
+        super().__init__(**kwargs)
+        if coefficient_mapping is None:
+            coefficient_mapping = {}
+        self.coefficient_mapping = coefficient_mapping
+
+    # Work around singledispatchmethod inheritance issue;
+    # see https://bugs.python.org/issue36457.
+    @singledispatchmethod
+    def process(self, o):
+        return super().process(o)
+
+    @process.register(BaseForm)
+    @process.register(Expr)
+    @DAGTraverser.postorder
+    def generic(self, o, *ops):
+        return any(ops)
+
+    @process.register(Argument)
+    @process.register(Cofunction)
+    @process.register(Coefficient)
+    @process.register(ConstantValue)
+    @process.register(SpatialCoordinate)
+    def terminal(self, o):
+        return o in self.coefficient_mapping
+
+
+class TimeDerivativeCoefficientFinder(DAGTraverser):
+    """Determines whether an expression depends on TimeDerivative of a coefficient
+    """
+    def __init__(self, coefficient_mapping, **kwargs):
+        super().__init__(**kwargs)
+        self.rules = CoefficientFinder(coefficient_mapping=coefficient_mapping)
+
+    # Work around singledispatchmethod inheritance issue;
+    # see https://bugs.python.org/issue36457.
+    @singledispatchmethod
+    def process(self, o):
+        return super().process(o)
+
+    @process.register(TimeDerivative)
+    def time_derivative(self, o):
+        f, = o.ufl_operands
+        return self.rules(f)
+
+    @process.register(BaseForm)
+    @process.register(Expr)
+    @DAGTraverser.postorder
+    def generic(self, o, *ops):
+        return any(ops)
+
+    @process.register(Integral)
+    def integral(self, o):
+        return self(o.integrand())
+
+
+def split_dt_form(form, u0):
+    """Split a Form into terms that contain Dt(g(u)) and the rest
+    """
+    coefficient_mapping = {u0,}
+    coefficient_finder = TimeDerivativeCoefficientFinder(coefficient_mapping=coefficient_mapping)
+    time = []
+    rest = []
+    for itg in form.integrals():
+        if coefficient_finder(itg):
+            time.append(itg)
+        else:
+            rest.append(itg)
+    return Form(time), Form(rest)

--- a/irksome/ufl/manipulation.py
+++ b/irksome/ufl/manipulation.py
@@ -9,10 +9,10 @@ derivative from those that don't (via :func:`~.extract_terms`).
 from functools import singledispatchmethod
 from typing import NamedTuple, List, Sequence
 
+from ufl.corealg.traversal import traverse_unique_terminals
 from ufl.corealg.dag_traverser import DAGTraverser
-from ufl.classes import (Argument, BaseForm,
-                         Cofunction, Coefficient, ConstantValue,
-                         Expr, Form, FormSum, Integral, SpatialCoordinate)
+from ufl.classes import (BaseForm, Coefficient,
+                         Expr, Form, FormSum, Integral)
 
 from .deriv import TimeDerivative
 
@@ -79,42 +79,14 @@ def check_integrals(integrals: List[Integral], expect_time_derivative: bool = Tr
     return integrals
 
 
-class CoefficientFinder(DAGTraverser):
-    """Determines whether an expression depends on a set of coefficients.
-    """
-    def __init__(self, timedep_coeffs=None, **kwargs):
-        super().__init__(**kwargs)
-        if timedep_coeffs is None:
-            timedep_coeffs = {}
-        self.timedep_coeffs = timedep_coeffs
-
-    # Work around singledispatchmethod inheritance issue;
-    # see https://bugs.python.org/issue36457.
-    @singledispatchmethod
-    def process(self, o):
-        return super().process(o)
-
-    @process.register(BaseForm)
-    @process.register(Expr)
-    @DAGTraverser.postorder
-    def generic(self, o, *ops):
-        return any(ops)
-
-    @process.register(Argument)
-    @process.register(Cofunction)
-    @process.register(Coefficient)
-    @process.register(ConstantValue)
-    @process.register(SpatialCoordinate)
-    def terminal(self, o):
-        return o in self.timedep_coeffs
-
-
 class TimeDerivativeCoefficientFinder(DAGTraverser):
     """Determines whether an expression depends on TimeDerivative of a coefficient
     """
     def __init__(self, timedep_coeffs, **kwargs):
         super().__init__(**kwargs)
-        self.rules = CoefficientFinder(timedep_coeffs=timedep_coeffs)
+        if timedep_coeffs is None:
+            timedep_coeffs = {}
+        self.timedep_coeffs = set(timedep_coeffs)
 
     # Work around singledispatchmethod inheritance issue;
     # see https://bugs.python.org/issue36457.
@@ -135,7 +107,8 @@ class TimeDerivativeCoefficientFinder(DAGTraverser):
     @process.register(TimeDerivative)
     def time_derivative(self, o):
         f, = o.ufl_operands
-        return self.rules(f)
+        terminals = set(traverse_unique_terminals(f))
+        return len(terminals & self.timedep_coeffs) > 0
 
 
 def extract_terms(form: Form, timedep_coeffs: Sequence[Coefficient] | None = None) -> SplitTimeForm:

--- a/irksome/ufl/manipulation.py
+++ b/irksome/ufl/manipulation.py
@@ -8,14 +8,12 @@ derivative from those that don't (via :func:`~.extract_terms`).
 """
 from functools import singledispatchmethod
 from itertools import chain
-from typing import NamedTuple, List, Sequence
+from typing import NamedTuple, Sequence
 
-from ufl.algorithms import extract_coefficients
 from ufl.corealg.traversal import traverse_unique_terminals
 from ufl.corealg.dag_traverser import DAGTraverser
 from ufl.classes import (
-    BaseForm, Coefficient,
-    Expr, Form, FormSum, Integral,
+    BaseForm, Coefficient, Expr, Form, FormSum, Integral,
     Division, Product, Dot, Inner, Outer,
     PositiveRestricted, NegativeRestricted,
     CellAvg, FacetAvg, Conj, Derivative,
@@ -29,16 +27,17 @@ __all__ = ("SplitTimeForm", "check_integrals", "extract_terms")
 
 class SplitTimeForm(NamedTuple):
     """A container for a form split into time terms and a remainder."""
-    time: Form
-    remainder: Form
+    time: BaseForm
+    remainder: BaseForm
 
 
 class TimeDerivativeChecker(DAGTraverser):
     """Check that TimeDerivative appears linearly and return the Coefficients
        under TimeDerivatives.
     """
-    def __init__(self, **kwargs):
+    def __init__(self, timedep_coeffs, **kwargs):
         super().__init__(**kwargs)
+        self.timedep_coeffs = set(timedep_coeffs)
 
     # Work around singledispatchmethod inheritance issue;
     # see https://bugs.python.org/issue36457.
@@ -53,16 +52,23 @@ class TimeDerivativeChecker(DAGTraverser):
     @process.register(TimeDerivative)
     def time_derivative(self, o):
         f, = o.ufl_operands
-        return tuple(extract_coefficients(f))
+        terminals = set(traverse_unique_terminals(f))
+        return tuple(terminals & self.timedep_coeffs)
 
     @process.register(Expr)
     @DAGTraverser.postorder
     def nonlinear_op(self, o, *ops):
         if any(ops):
-            raise ValueError("Can't apply nonlinear operator to time derivative")
+            raise ValueError("Can't apply nonlinear operator to TimeDerivative")
         return ()
 
     @process.register(Division)
+    @DAGTraverser.postorder
+    def division(self, o, a, b):
+        if b:
+            raise ValueError("Can't divide by TimeDerivative")
+        return a
+
     @process.register(Product)
     @process.register(Inner)
     @process.register(Dot)
@@ -70,7 +76,7 @@ class TimeDerivativeChecker(DAGTraverser):
     @DAGTraverser.postorder
     def product(self, o, a, b):
         if a and b:
-            raise ValueError("Can't take product of time derivatives")
+            raise ValueError("Can't take product of TimeDerivatives")
         return a or b
 
     @process.register(PositiveRestricted)
@@ -87,9 +93,9 @@ class TimeDerivativeChecker(DAGTraverser):
         return tuple(set(chain(*ops)))
 
 
-def check_integrals(integrals: List[Integral],
+def check_integrals(integrals: Sequence[Integral],
                     timedep_coeffs: Sequence[Coefficient] = (),
-                    expect_time_derivative: bool = True) -> List[Integral]:
+                    expect_time_derivative: bool = True):
     """Check a list of integrals for linearity in the time derivative.
 
     :arg integrals: list of integrals.
@@ -102,49 +108,14 @@ def check_integrals(integrals: List[Integral],
     if len(integrals) == 0:
         return integrals
 
-    mapper = TimeDerivativeChecker()
+    mapper = TimeDerivativeChecker(timedep_coeffs)
     time_derivatives = set(chain.from_iterable(map(mapper, integrals)))
-
-    if expect_time_derivative and time_derivatives != set(timedep_coeffs):
-        raise ValueError(f"Expecting 1 TimeDerivative, not {len(time_derivatives)}")
-
-    if not expect_time_derivative and len(time_derivatives & set(timedep_coeffs)) > 0:
-        raise ValueError("Not expecting a TimeDerivative of this coefficient")
-
-    return integrals
+    howmany = int(expect_time_derivative)
+    if len(time_derivatives) != howmany:
+        raise ValueError(f"Expecting {howmany} TimeDerivatives, not {len(time_derivatives)}")
 
 
-class TimeDerivativeCoefficientFinder(DAGTraverser):
-    """Determines whether an expression depends on TimeDerivative of a coefficient
-    """
-    def __init__(self, timedep_coeffs, **kwargs):
-        super().__init__(**kwargs)
-        self.timedep_coeffs = set(timedep_coeffs)
-
-    # Work around singledispatchmethod inheritance issue;
-    # see https://bugs.python.org/issue36457.
-    @singledispatchmethod
-    def process(self, o):
-        return super().process(o)
-
-    @process.register(BaseForm)
-    @process.register(Expr)
-    @DAGTraverser.postorder
-    def generic(self, o, *ops):
-        return any(ops)
-
-    @process.register(Integral)
-    def integral(self, o):
-        return self(o.integrand())
-
-    @process.register(TimeDerivative)
-    def time_derivative(self, o):
-        f, = o.ufl_operands
-        terminals = set(traverse_unique_terminals(f))
-        return len(terminals & self.timedep_coeffs) > 0
-
-
-def extract_terms(form: Form, timedep_coeffs: Sequence[Coefficient] = ()) -> SplitTimeForm:
+def extract_terms(form: BaseForm, timedep_coeffs: Sequence[Coefficient] = ()) -> SplitTimeForm:
     """Extract terms from a :class:`~ufl.Form`.
 
     This splits a form (a sum of integrals) into those integrals which
@@ -163,17 +134,18 @@ def extract_terms(form: Form, timedep_coeffs: Sequence[Coefficient] = ()) -> Spl
         remainder = sum(f for f in terms if not isinstance(f, Form))
         form = sum(f for f in terms if isinstance(f, Form))
 
-    time_finder = TimeDerivativeCoefficientFinder(timedep_coeffs)
+    time_finder = TimeDerivativeChecker(timedep_coeffs)
     time_terms = []
     rest_terms = []
     for itg in form.integrals():
-        if time_finder(itg):
+        tcoeffs = time_finder(itg)
+        if len(tcoeffs) == 0:
+            rest_terms.append(itg)
+        elif len(tcoeffs) == 1:
             time_terms.append(itg)
         else:
-            rest_terms.append(itg)
+            raise ValueError("Expecting 1 or 0 time-dependent coefficients under TimeDerivative")
 
-    time_terms = check_integrals(time_terms, timedep_coeffs, expect_time_derivative=True)
-    rest_terms = check_integrals(rest_terms, timedep_coeffs, expect_time_derivative=False)
     return SplitTimeForm(time=Form(time_terms), remainder=Form(rest_terms)+remainder)
 
 
@@ -206,7 +178,7 @@ class TimeDerivativeRemover(DAGTraverser):
         return f
 
 
-def strip_dt_form(F):
+def strip_dt_form(F: Form):
     """Helper function to strip all time derivatives from a Form"""
     stripper = TimeDerivativeRemover()
 

--- a/irksome/ufl/manipulation.py
+++ b/irksome/ufl/manipulation.py
@@ -4,7 +4,7 @@ terms.
 These can be used to do some basic checking of the suitability of a
 :class:`~ufl.Form` for use in Irksome (via :func:`~.check_integrals`), and
 splitting out terms in the :class:`~ufl.Form` that contain a time
-derivative from those that don't (via :func:`~.extract_terms`).
+derivative from those that don't (via :func:`~.split_time_derivative_terms`).
 """
 from functools import singledispatchmethod
 from itertools import chain
@@ -23,7 +23,7 @@ from ufl.classes import (
 
 from .deriv import TimeDerivative
 
-__all__ = ("SplitTimeForm", "check_integrals", "extract_terms")
+__all__ = ("SplitTimeForm", "check_integrals", "split_time_derivative_terms", "remove_time_derivatives")
 
 
 class SplitTimeForm(NamedTuple):
@@ -135,8 +135,8 @@ def summands(o: Expr) -> FrozenSet[Expr]:
         return frozenset([o])
 
 
-def extract_terms(form: BaseForm, timedep_coeffs: Sequence[Coefficient] = ()) -> SplitTimeForm:
-    """Extract terms from a :class:`~ufl.Form`.
+def split_time_derivative_terms(form: BaseForm, timedep_coeffs: Sequence[Coefficient] = ()) -> SplitTimeForm:
+    """Split terms from a :class:`~ufl.Form`.
 
     This splits a form (a sum of integrals) into those integrals which
     do contain a :class:`~.TimeDerivative` acting on `timedep_coeffs` and those that don't.
@@ -204,7 +204,7 @@ class TimeDerivativeRemover(DAGTraverser):
         return f
 
 
-def strip_dt_form(F: Form):
+def remove_time_derivatives(F: Form):
     """Helper function to strip all time derivatives from a Form"""
     stripper = TimeDerivativeRemover()
 

--- a/irksome/ufl/manipulation.py
+++ b/irksome/ufl/manipulation.py
@@ -103,9 +103,7 @@ def check_integrals(integrals: List[Integral],
         return integrals
 
     mapper = TimeDerivativeChecker()
-    time_derivatives = set()
-    for integral in integrals:
-        time_derivatives.update(mapper(integral))
+    time_derivatives = set(chain.from_iterable(map(mapper, integrals)))
 
     if expect_time_derivative and time_derivatives != set(timedep_coeffs):
         raise ValueError(f"Expecting 1 TimeDerivative, not {len(time_derivatives)}")
@@ -121,8 +119,6 @@ class TimeDerivativeCoefficientFinder(DAGTraverser):
     """
     def __init__(self, timedep_coeffs, **kwargs):
         super().__init__(**kwargs)
-        if timedep_coeffs is None:
-            timedep_coeffs = {}
         self.timedep_coeffs = set(timedep_coeffs)
 
     # Work around singledispatchmethod inheritance issue;
@@ -148,7 +144,7 @@ class TimeDerivativeCoefficientFinder(DAGTraverser):
         return len(terminals & self.timedep_coeffs) > 0
 
 
-def extract_terms(form: Form, timedep_coeffs: Sequence[Coefficient] | None = None) -> SplitTimeForm:
+def extract_terms(form: Form, timedep_coeffs: Sequence[Coefficient] = ()) -> SplitTimeForm:
     """Extract terms from a :class:`~ufl.Form`.
 
     This splits a form (a sum of integrals) into those integrals which

--- a/irksome/ufl/manipulation.py
+++ b/irksome/ufl/manipulation.py
@@ -38,7 +38,7 @@ class TimeDerivativeChecker(DAGTraverser):
     """
     def __init__(self, timedep_coeffs, **kwargs):
         super().__init__(**kwargs)
-        self.timedep_coeffs = set(timedep_coeffs)
+        self.timedep_coeffs = frozenset(timedep_coeffs)
 
     # Work around singledispatchmethod inheritance issue;
     # see https://bugs.python.org/issue36457.
@@ -57,14 +57,14 @@ class TimeDerivativeChecker(DAGTraverser):
             raise ValueError("Can only handle first-order systems")
         f, = o.ufl_operands
         terminals = set(traverse_unique_terminals(f))
-        return tuple(terminals & self.timedep_coeffs)
+        return frozenset(terminals & self.timedep_coeffs)
 
     @process.register(Expr)
     @DAGTraverser.postorder
     def nonlinear_op(self, o, *ops):
         if any(ops):
             raise ValueError("Can't apply nonlinear operator to TimeDerivative")
-        return ()
+        return frozenset()
 
     @process.register(Division)
     @DAGTraverser.postorder
@@ -97,7 +97,7 @@ class TimeDerivativeChecker(DAGTraverser):
     @process.register(ComponentTensor)
     @DAGTraverser.postorder
     def linear_op(self, o, *ops):
-        return tuple(set(chain(*ops)))
+        return frozenset(chain(*ops))
 
 
 def check_integrals(integrals: Sequence[Integral],

--- a/irksome/ufl/manipulation.py
+++ b/irksome/ufl/manipulation.py
@@ -7,7 +7,7 @@ splitting out terms in the :class:`~ufl.Form` that contain a time
 derivative from those that don't (via :func:`~.extract_terms`).
 """
 from functools import singledispatchmethod
-from typing import NamedTuple, List
+from typing import NamedTuple, List, Sequence
 
 from ufl.corealg.dag_traverser import DAGTraverser
 from ufl.classes import (Argument, BaseForm,
@@ -138,7 +138,7 @@ class TimeDerivativeCoefficientFinder(DAGTraverser):
         return self.rules(f)
 
 
-def extract_terms(form: Form, timedep_coeffs: List[Coefficient]) -> SplitTimeForm:
+def extract_terms(form: Form, timedep_coeffs: Sequence[Coefficient] | None = None) -> SplitTimeForm:
     """Extract terms from a :class:`~ufl.Form`.
 
     This splits a form (a sum of integrals) into those integrals which
@@ -157,7 +157,7 @@ def extract_terms(form: Form, timedep_coeffs: List[Coefficient]) -> SplitTimeFor
         remainder = sum(f for f in terms if not isinstance(f, Form))
         form = sum(f for f in terms if isinstance(f, Form))
 
-    time_finder = TimeDerivativeCoefficientFinder(timedep_coeffs=timedep_coeffs)
+    time_finder = TimeDerivativeCoefficientFinder(timedep_coeffs)
     time_terms = []
     rest_terms = []
     for itg in form.integrals():
@@ -201,7 +201,7 @@ class TimeDerivativeRemover(DAGTraverser):
 
 
 def strip_dt_form(F):
-    """Helper function to strip all time derivatives from a form"""
+    """Helper function to strip all time derivatives from a Form"""
     stripper = TimeDerivativeRemover()
 
     # Strip dt from all the integrals in the form

--- a/irksome/ufl/manipulation.py
+++ b/irksome/ufl/manipulation.py
@@ -8,7 +8,8 @@ derivative from those that don't (via :func:`~.extract_terms`).
 """
 from functools import singledispatchmethod
 from itertools import chain
-from typing import NamedTuple, Sequence
+from operator import or_
+from typing import NamedTuple, Sequence, FrozenSet
 
 from ufl.corealg.traversal import traverse_unique_terminals
 from ufl.corealg.dag_traverser import DAGTraverser
@@ -50,7 +51,10 @@ class TimeDerivativeChecker(DAGTraverser):
         return self(o.integrand())
 
     @process.register(TimeDerivative)
-    def time_derivative(self, o):
+    @DAGTraverser.postorder
+    def time_derivative(self, o, *ops):
+        if any(ops):
+            raise ValueError("Can only handle first-order systems")
         f, = o.ufl_operands
         terminals = set(traverse_unique_terminals(f))
         return tuple(terminals & self.timedep_coeffs)
@@ -119,6 +123,18 @@ def check_integrals(integrals: Sequence[Integral],
                          f"coefficients, not {len(time_derivatives)}")
 
 
+def summands(o: Expr) -> FrozenSet[Expr]:
+    """Flatten a sum tree into a set of summands
+
+    :arg o: the expression to flatten.
+    :returns: a frozenset of the summands such that sum(r) == o (up to
+        order of arguments)."""
+    if isinstance(o, Sum):
+        return or_(*map(summands, o.ufl_operands))
+    else:
+        return frozenset([o])
+
+
 def extract_terms(form: BaseForm, timedep_coeffs: Sequence[Coefficient] = ()) -> SplitTimeForm:
     """Extract terms from a :class:`~ufl.Form`.
 
@@ -139,15 +155,22 @@ def extract_terms(form: BaseForm, timedep_coeffs: Sequence[Coefficient] = ()) ->
         remainder = sum(w*f for w, f in zip(weights, components) if not isinstance(f, Form))
         form = sum(w*f for w, f in zip(weights, components) if isinstance(f, Form))
 
-    time_finder = TimeDerivativeChecker(timedep_coeffs)
-    time_terms = []
+    mapper = TimeDerivativeChecker(timedep_coeffs)
     rest_terms = []
-    for itg in form.integrals():
-        tcoeffs = time_finder(itg)
-        if len(tcoeffs) == 0:
-            rest_terms.append(itg)
-        else:
-            time_terms.append(itg)
+    time_terms = []
+    for integral in form.integrals():
+        rest = []
+        time = []
+        for term in summands(integral.integrand()):
+            tcoeffs = mapper(term)
+            if len(tcoeffs) == 0:
+                rest.append(term)
+            else:
+                time.append(term)
+        if len(rest):
+            rest_terms.append(integral.reconstruct(integrand=sum(rest)))
+        if len(time):
+            time_terms.append(integral.reconstruct(integrand=sum(time)))
 
     return SplitTimeForm(time=Form(time_terms), remainder=Form(rest_terms)+remainder)
 

--- a/irksome/ufl/manipulation.py
+++ b/irksome/ufl/manipulation.py
@@ -7,12 +7,20 @@ splitting out terms in the :class:`~ufl.Form` that contain a time
 derivative from those that don't (via :func:`~.extract_terms`).
 """
 from functools import singledispatchmethod
+from itertools import chain
 from typing import NamedTuple, List, Sequence
 
+from ufl.algorithms import extract_coefficients
 from ufl.corealg.traversal import traverse_unique_terminals
 from ufl.corealg.dag_traverser import DAGTraverser
-from ufl.classes import (BaseForm, Coefficient,
-                         Expr, Form, FormSum, Integral)
+from ufl.classes import (
+    BaseForm, Coefficient,
+    Expr, Form, FormSum, Integral,
+    Division, Product, Dot, Inner, Outer,
+    PositiveRestricted, NegativeRestricted,
+    CellAvg, FacetAvg, Conj, Derivative,
+    Variable, Sum, ListTensor,
+)
 
 from .deriv import TimeDerivative
 
@@ -26,7 +34,8 @@ class SplitTimeForm(NamedTuple):
 
 
 class TimeDerivativeChecker(DAGTraverser):
-    """Determines whether an expression depends on a set of coefficients.
+    """Check that TimeDerivative appears linearly and return the Coefficients
+       under TimeDerivatives.
     """
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -37,45 +46,73 @@ class TimeDerivativeChecker(DAGTraverser):
     def process(self, o):
         return super().process(o)
 
-    @process.register(BaseForm)
-    @process.register(Expr)
-    @DAGTraverser.postorder
-    def generic(self, o, *ops):
-        return sum(ops)
-
-    @process.register(TimeDerivative)
-    @DAGTraverser.postorder
-    def time_derivative(self, o, op):
-        return op + 1
-
     @process.register(Integral)
     def integral(self, o):
         return self(o.integrand())
 
-    @process.register(Form)
-    def form(self, o):
-        return sum(self(itg) for itg in o.integrals())
+    @process.register(TimeDerivative)
+    def time_derivative(self, o):
+        f, = o.ufl_operands
+        return tuple(extract_coefficients(f))
+
+    @process.register(Expr)
+    @DAGTraverser.postorder
+    def nonlinear_op(self, o, *ops):
+        if any(ops):
+            raise ValueError("Can't apply nonlinear operator to time derivative")
+        return ()
+
+    @process.register(Division)
+    @process.register(Product)
+    @process.register(Inner)
+    @process.register(Dot)
+    @process.register(Outer)
+    @DAGTraverser.postorder
+    def product(self, o, a, b):
+        if a and b:
+            raise ValueError("Can't take product of time derivatives")
+        return a or b
+
+    @process.register(PositiveRestricted)
+    @process.register(NegativeRestricted)
+    @process.register(CellAvg)
+    @process.register(FacetAvg)
+    @process.register(Conj)
+    @process.register(Derivative)
+    @process.register(Variable)
+    @process.register(Sum)
+    @process.register(ListTensor)
+    @DAGTraverser.postorder
+    def linear_op(self, o, *ops):
+        return tuple(set(chain(*ops)))
 
 
-def check_integrals(integrals: List[Integral], expect_time_derivative: bool = True) -> List[Integral]:
+def check_integrals(integrals: List[Integral],
+                    timedep_coeffs: Sequence[Coefficient] = (),
+                    expect_time_derivative: bool = True) -> List[Integral]:
     """Check a list of integrals for linearity in the time derivative.
 
     :arg integrals: list of integrals.
+    :arg timedep_coeffs: The time-dependent coefficients.
     :arg expect_time_derivative: Are we expecting to see a time
         derivative?
     :raises ValueError: if we are expecting a time derivative and
         don't see one, or time derivatives are applied nonlinearly, to
         more than one coefficient, or more than first order."""
-    return integrals
-    # TODO
+    if len(integrals) == 0:
+        return integrals
+
     mapper = TimeDerivativeChecker()
-    time_derivatives = 0
+    time_derivatives = set()
     for integral in integrals:
-        time_derivatives += mapper(integral)
-    howmany = int(expect_time_derivative)
-    if len(time_derivatives - {()}) != howmany:
-        raise ValueError(f"Expecting time derivative applied to {howmany}"
-                         f"coefficients, not {len(time_derivatives - {()})}")
+        time_derivatives.update(mapper(integral))
+
+    if expect_time_derivative and time_derivatives != set(timedep_coeffs):
+        raise ValueError(f"Expecting 1 TimeDerivative, not {len(time_derivatives)}")
+
+    if not expect_time_derivative and len(time_derivatives & set(timedep_coeffs)) > 0:
+        raise ValueError("Not expecting a TimeDerivative of this coefficient")
+
     return integrals
 
 
@@ -139,8 +176,8 @@ def extract_terms(form: Form, timedep_coeffs: Sequence[Coefficient] | None = Non
         else:
             rest_terms.append(itg)
 
-    time_terms = check_integrals(time_terms, expect_time_derivative=True)
-    rest_terms = check_integrals(rest_terms, expect_time_derivative=False)
+    time_terms = check_integrals(time_terms, timedep_coeffs, expect_time_derivative=True)
+    rest_terms = check_integrals(rest_terms, timedep_coeffs, expect_time_derivative=False)
     return SplitTimeForm(time=Form(time_terms), remainder=Form(rest_terms)+remainder)
 
 

--- a/irksome/ufl/manipulation.py
+++ b/irksome/ufl/manipulation.py
@@ -6,34 +6,13 @@ These can be used to do some basic checking of the suitability of a
 splitting out terms in the :class:`~ufl.Form` that contain a time
 derivative from those that don't (via :func:`~.extract_terms`).
 """
-from functools import partial, singledispatch
-from itertools import chain
-from operator import contains, or_
-from typing import Callable, FrozenSet, List, NamedTuple, Tuple, Union
-
-from gem.node import Memoizer
-from tsfc.ufl_utils import ufl_reuse_if_untouched
-from ufl.algebra import Conj, Division, Product, Sum
-from ufl.averaging import CellAvg, FacetAvg
-from ufl.classes import MultiIndex
-from ufl.constantvalue import Zero
-from ufl.core.expr import Expr
-from ufl.core.operator import Operator
-from ufl.core.terminal import Terminal
-from ufl.corealg.traversal import traverse_unique_terminals
-from ufl.differentiation import Derivative
-from ufl.form import Form, FormSum
-from ufl.indexed import Indexed
-from ufl.indexsum import IndexSum
-from ufl.restriction import NegativeRestricted, PositiveRestricted
-from ufl.tensoralgebra import Dot, Inner, Outer
-from ufl.tensors import ComponentTensor, ListTensor
-
-from ufl.form import BaseForm
-from ufl.classes import (Argument, Cofunction, Coefficient, ConstantValue,
-                         Integral, SpatialCoordinate, Variable)
-from ufl.corealg.dag_traverser import DAGTraverser
 from functools import singledispatchmethod
+from typing import NamedTuple, List
+
+from ufl.corealg.dag_traverser import DAGTraverser
+from ufl.classes import (Argument, BaseForm,
+                         Cofunction, Coefficient, ConstantValue,
+                         Expr, Form, Integral, SpatialCoordinate)
 
 from .deriv import TimeDerivative
 
@@ -46,98 +25,36 @@ class SplitTimeForm(NamedTuple):
     remainder: Form
 
 
-def _filter(o: Expr, self: Memoizer) -> Expr:
-    if not isinstance(o, Expr):
-        raise AssertionError(f"Cannot handle term with type {type(o)}")
-    if self.predicate(o):
-        return Zero(shape=o.ufl_shape,
-                    free_indices=o.ufl_free_indices,
-                    index_dimensions=o.ufl_index_dimensions)
-    else:
-        return ufl_reuse_if_untouched(o, *map(self, o.ufl_operands))
+class TimeDerivativeChecker(DAGTraverser):
+    """Determines whether an expression depends on a set of coefficients.
+    """
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
 
+    # Work around singledispatchmethod inheritance issue;
+    # see https://bugs.python.org/issue36457.
+    @singledispatchmethod
+    def process(self, o):
+        return super().process(o)
 
-def remove_if(expr: Expr, predicate: Callable[[Expr], bool]) -> Expr:
-    """Remove terms from an expression that match a predicate.
+    @process.register(BaseForm)
+    @process.register(Expr)
+    @DAGTraverser.postorder
+    def generic(self, o, *ops):
+        return sum(ops)
 
-    This is done by replacing matching terms by an
-    appropriately-shaped :class:`~.Zero`, so only works to remove
-    terms that are linear in the expression.
+    @process.register(TimeDerivative)
+    @DAGTraverser.postorder
+    def time_derivative(self, o, op):
+        return op + 1
 
-    :arg expr: the expression to remove terms from.
-    :arg predicate: a function that indicates if an expression should
-        be kept or not.
-    :returns: A potentially new expression with terms matching the
-        predicate removed."""
-    mapper = Memoizer(_filter)
-    mapper.predicate = predicate
-    return mapper(expr)
+    @process.register(Integral)
+    def integral(self, o):
+        return self(o.integrand())
 
-
-Result = Union[Tuple[()], Tuple[Coefficient, ...]]
-
-
-@singledispatch
-def _check_time_terms(o, self: Memoizer) -> Result:
-    raise AssertionError(f"Unhandled type {type(o)}")
-
-
-@_check_time_terms.register(TimeDerivative)
-def _check_timederiv(o: TimeDerivative, self: Memoizer) -> Result:
-    op, = o.ufl_operands
-    if self(op):
-        # op already has a TimeDerivative applied to it
-        raise ValueError("Can only handle first-order systems")
-    terminals = tuple(set([x for x in traverse_unique_terminals(op) if not isinstance(x, MultiIndex)]))
-    if len(terminals) != 1 or not isinstance(terminals[0], Coefficient):
-        raise ValueError("Time derivative must apply to a single coefficient")
-    return terminals
-
-
-@_check_time_terms.register(Expr)
-def _check_nonlinearop(o: Union[Terminal, Operator], self: Memoizer) -> Result:
-    if any(map(self, o.ufl_operands)):
-        raise ValueError("Can't apply nonlinear operator to time derivative")
-    return ()
-
-
-@_check_time_terms.register(Division)
-def _check_division(o: Division, self: Memoizer) -> Result:
-    a, b = map(self, o.ufl_operands)
-    if b:
-        raise ValueError("Can't divide by time derivative")
-    return a
-
-
-@_check_time_terms.register(Product)
-@_check_time_terms.register(Inner)
-@_check_time_terms.register(Dot)
-@_check_time_terms.register(Outer)
-def _check_product(o: Operator, self: Memoizer) -> Result:
-    a, b = map(self, o.ufl_operands)
-    if a and b:
-        raise ValueError("Can't take product of time derivatives")
-    return a or b
-
-
-@_check_time_terms.register(PositiveRestricted)
-@_check_time_terms.register(NegativeRestricted)
-@_check_time_terms.register(CellAvg)
-@_check_time_terms.register(FacetAvg)
-@_check_time_terms.register(Conj)
-@_check_time_terms.register(Derivative)
-@_check_time_terms.register(Variable)
-@_check_time_terms.register(Sum)
-@_check_time_terms.register(ListTensor)
-def _check_linearop(o: Operator, self: Memoizer) -> Result:
-    return tuple(set(chain(*map(self, o.ufl_operands))))
-
-
-@_check_time_terms.register(Indexed)
-@_check_time_terms.register(IndexSum)
-@_check_time_terms.register(ComponentTensor)
-def _check_indexed(o: Operator, self: Memoizer) -> Result:
-    return self(o.ufl_operands[0])
+    @process.register(Form)
+    def form(self, o):
+        return sum(self(itg) for itg in o.integrals())
 
 
 def check_integrals(integrals: List[Integral], expect_time_derivative: bool = True) -> List[Integral]:
@@ -149,10 +66,12 @@ def check_integrals(integrals: List[Integral], expect_time_derivative: bool = Tr
     :raises ValueError: if we are expecting a time derivative and
         don't see one, or time derivatives are applied nonlinearly, to
         more than one coefficient, or more than first order."""
-    mapper = Memoizer(_check_time_terms)
-    time_derivatives = set()
+    return integrals
+    # TODO
+    mapper = TimeDerivativeChecker()
+    time_derivatives = 0
     for integral in integrals:
-        time_derivatives.update(mapper(integral.integrand()))
+        time_derivatives += mapper(integral)
     howmany = int(expect_time_derivative)
     if len(time_derivatives - {()}) != howmany:
         raise ValueError(f"Expecting time derivative applied to {howmany}"
@@ -160,88 +79,14 @@ def check_integrals(integrals: List[Integral], expect_time_derivative: bool = Tr
     return integrals
 
 
-def summands(o: Expr) -> FrozenSet[Expr]:
-    """Flatten a sum tree into a set of summands
-
-    :arg o: the expression to flatten.
-    :returns: a frozenset of the summands such that sum(r) == o (up to
-        order of arguments)."""
-    if isinstance(o, Sum):
-        return or_(*map(summands, o.ufl_operands))
-    else:
-        return frozenset([o])
-
-
-def extract_terms(form: Form) -> SplitTimeForm:
-    """Extract terms from a :class:`~ufl.Form`.
-
-    This splits a form (a sum of integrals) into those integrals which
-    do contain a :class:`~.TimeDerivative` and those that don't.
-
-    :arg form: The form to split.
-    :returns: a :class:`~.SplitTimeForm` tuple.
-    :raises ValueError: if the form does not apply anything other than
-        first-order time derivatives to a single coefficient.
-    """
-    if isinstance(form, FormSum):
-        # Assume that TimeDerivative cannot occur on BaseForms
-        form = next((f for f in form.components() if isinstance(f, Form)), Form([]))
-    time_terms = []
-    rest_terms = []
-    for integral in form.integrals():
-        integrand = integral.integrand()
-        rest = remove_if(integrand, lambda o: isinstance(o, TimeDerivative))
-        time = remove_if(integrand, partial(contains, summands(rest)))
-        if not isinstance(time, Zero):
-            time_terms.append(integral.reconstruct(integrand=time))
-        if not isinstance(rest, Zero):
-            rest_terms.append(integral.reconstruct(integrand=rest))
-
-    time_terms = check_integrals(time_terms, expect_time_derivative=True)
-    rest_terms = check_integrals(rest_terms, expect_time_derivative=False)
-    return SplitTimeForm(time=Form(time_terms), remainder=Form(rest_terms))
-
-
-# Helper function to strip the time derivative from expressions, base case
-@singledispatch
-def strip_dt(e, self):
-    os = e.ufl_operands
-    if os:
-        stripped_os = map(self, os)
-        return ufl_reuse_if_untouched(e, *stripped_os)
-    return e
-
-
-# Case for time derivatives, returning the operand
-@strip_dt.register(TimeDerivative)
-def strip_dt_td(e, self):
-    o, = e.ufl_operands
-    return self(o)
-
-
-# Helper function to strip all time derivatives from a form
-def strip_dt_form(F):
-    if isinstance(F, Zero):
-        # Avoid applying the time derivative stripper to zero forms
-        return F
-
-    stripper = Memoizer(strip_dt)
-
-    # Strip dt from all the integrals in the form
-    Fnew = Form([i.reconstruct(integrand=stripper(i.integrand())) for i in F.integrals()])
-
-    # Return the form stripped of its time derivatives
-    return Fnew
-
-
 class CoefficientFinder(DAGTraverser):
     """Determines whether an expression depends on a set of coefficients.
     """
-    def __init__(self, coefficient_mapping=None, **kwargs):
+    def __init__(self, timedep_coeffs=None, **kwargs):
         super().__init__(**kwargs)
-        if coefficient_mapping is None:
-            coefficient_mapping = {}
-        self.coefficient_mapping = coefficient_mapping
+        if timedep_coeffs is None:
+            timedep_coeffs = {}
+        self.timedep_coeffs = timedep_coeffs
 
     # Work around singledispatchmethod inheritance issue;
     # see https://bugs.python.org/issue36457.
@@ -261,26 +106,21 @@ class CoefficientFinder(DAGTraverser):
     @process.register(ConstantValue)
     @process.register(SpatialCoordinate)
     def terminal(self, o):
-        return o in self.coefficient_mapping
+        return o in self.timedep_coeffs
 
 
 class TimeDerivativeCoefficientFinder(DAGTraverser):
     """Determines whether an expression depends on TimeDerivative of a coefficient
     """
-    def __init__(self, coefficient_mapping, **kwargs):
+    def __init__(self, timedep_coeffs, **kwargs):
         super().__init__(**kwargs)
-        self.rules = CoefficientFinder(coefficient_mapping=coefficient_mapping)
+        self.rules = CoefficientFinder(timedep_coeffs=timedep_coeffs)
 
     # Work around singledispatchmethod inheritance issue;
     # see https://bugs.python.org/issue36457.
     @singledispatchmethod
     def process(self, o):
         return super().process(o)
-
-    @process.register(TimeDerivative)
-    def time_derivative(self, o):
-        f, = o.ufl_operands
-        return self.rules(f)
 
     @process.register(BaseForm)
     @process.register(Expr)
@@ -292,17 +132,73 @@ class TimeDerivativeCoefficientFinder(DAGTraverser):
     def integral(self, o):
         return self(o.integrand())
 
+    @process.register(TimeDerivative)
+    def time_derivative(self, o):
+        f, = o.ufl_operands
+        return self.rules(f)
 
-def split_dt_form(form, u0):
-    """Split a Form into terms that contain Dt(g(u)) and the rest
+
+def extract_terms(form: Form, timedep_coeffs: List[Coefficient]) -> SplitTimeForm:
+    """Extract terms from a :class:`~ufl.Form`.
+
+    This splits a form (a sum of integrals) into those integrals which
+    do contain a :class:`~.TimeDerivative` acting on `u0` and those that don't.
+
+    :arg form: The form to split.
+    :arg timedep_coeffs: The time-dependent coefficients.
+    :returns: a :class:`~.SplitTimeForm` tuple.
+    :raises ValueError: if the form does not apply anything other than
+        first-order time derivatives to a single coefficient.
     """
-    coefficient_mapping = {u0,}
-    coefficient_finder = TimeDerivativeCoefficientFinder(coefficient_mapping=coefficient_mapping)
-    time = []
-    rest = []
+    dt_finder = TimeDerivativeCoefficientFinder(timedep_coeffs=timedep_coeffs)
+    time_terms = []
+    rest_terms = []
     for itg in form.integrals():
-        if coefficient_finder(itg):
-            time.append(itg)
+        if dt_finder(itg):
+            time_terms.append(itg)
         else:
-            rest.append(itg)
-    return Form(time), Form(rest)
+            rest_terms.append(itg)
+
+    time_terms = check_integrals(time_terms, expect_time_derivative=True)
+    rest_terms = check_integrals(rest_terms, expect_time_derivative=False)
+    return SplitTimeForm(time=Form(time_terms), remainder=Form(rest_terms))
+
+
+class TimeDerivativeRemover(DAGTraverser):
+    """Removes TimeDerivative from an expression"""
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+    # Work around singledispatchmethod inheritance issue;
+    # see https://bugs.python.org/issue36457.
+    @singledispatchmethod
+    def process(self, o):
+        return super().process(o)
+
+    @process.register(Expr)
+    def generic(self, o):
+        return self.reuse_if_untouched(o)
+
+    @process.register(Integral)
+    def integral(self, o):
+        return o.reconstruct(integrand=self(o.integrand()))
+
+    @process.register(Form)
+    def form(self, o):
+        return Form([self(itg) for itg in o.integrals()])
+
+    @process.register(TimeDerivative)
+    def time_derivative(self, o):
+        f, = o.ufl_operands
+        return f
+
+
+def strip_dt_form(F):
+    """Helper function to strip all time derivatives from a form"""
+    stripper = TimeDerivativeRemover()
+
+    # Strip dt from all the integrals in the form
+    Fnew = stripper(F)
+
+    # Return the form stripped of its time derivatives
+    return Fnew

--- a/irksome/ufl/manipulation.py
+++ b/irksome/ufl/manipulation.py
@@ -91,9 +91,7 @@ class TimeDerivativeChecker(DAGTraverser):
         oa, ob = o.ufl_operands
         if a and b:
             raise ValueError("Can't take product of TimeDerivatives")
-        if a and self.check_time_dependence(ob):
-            raise ValueError("Can't take product of TimeDerivative and time-dependent coefficients")
-        if b and self.check_time_dependence(oa):
+        if (a and self.check_time_dependence(ob)) or (b and self.check_time_dependence(oa)):
             raise ValueError("Can't take product of TimeDerivative and time-dependent coefficients")
         return a or b
 

--- a/tests/test_mass_conservation.py
+++ b/tests/test_mass_conservation.py
@@ -8,57 +8,44 @@ directly in the stage equations.
 """
 import pytest
 from firedrake import (
-    Function, FunctionSpace, TestFunction,
+    Constant, Function, FunctionSpace, TestFunction,
     UnitSquareMesh, assemble, ds, dx, exp, grad, inner,
 )
-from irksome import BackwardEuler, Dt, MeshConstant, RadauIIA, TimeStepper
+from irksome import BackwardEuler, DiscontinuousGalerkinScheme, Dt, RadauIIA, TimeStepper
 
 
-# Exponential soil model
-theta_r = 0.15
-theta_s = 0.45
-alpha = 0.328
-Ks = 1e-5
-
-N = 10
-dt_val = 100.0
-nstep = 50
-flux = 1e-6
-
-
-def theta(h):
-    return theta_r + (theta_s - theta_r) * exp(alpha * h)
-
-
-def conductivity(h):
-    return Ks * exp(alpha * h)
-
-
-def run_richards(butcher_tableau, stage_type):
+def run_richards(scheme, **kwargs):
     """Run the problem and return cumulative mass balance error."""
+    # Exponential soil model
+    theta_r = 0.15
+    theta_s = 0.45
+    alpha = 0.328
+    Ks = 1e-5
+    theta = lambda h: theta_r + (theta_s - theta_r) * exp(alpha * h)
+    conductivity = lambda h: Ks * exp(alpha * h)
+
+    N = 10
+    dt_val = 100
+    nstep = 50
+    flux = 1e-6
+
     mesh = UnitSquareMesh(N, N)
     V = FunctionSpace(mesh, "CG", 1)
     h = Function(V, name="h").assign(-1.0)
     v = TestFunction(V)
 
-    MC = MeshConstant(mesh)
-    t = MC.Constant(0.0)
-    dt = MC.Constant(dt_val)
+    t = Constant(0.0)
+    dt = Constant(dt_val)
 
     F = inner(Dt(theta(h)), v) * dx
     F += inner(conductivity(h) * grad(h), grad(v)) * dx
-    F -= flux * v * ds(4)
+    F -= inner(flux, v) * ds(4)
 
-    stepper = TimeStepper(F, butcher_tableau, t, dt, h,
+    stepper = TimeStepper(F, scheme, t, dt, h,
                           solver_parameters={
-                              "mat_type": "aij",
-                              "snes_type": "newtonls",
-                              "ksp_type": "preonly",
-                              "pc_type": "lu",
-                              "pc_factor_mat_solver_type": "mumps",
                               "snes_atol": 1e-14,
                           },
-                          stage_type=stage_type)
+                          **kwargs)
 
     mass_form = theta(h) * dx
     curr_mass = assemble(mass_form)
@@ -69,25 +56,26 @@ def run_richards(butcher_tableau, stage_type):
         stepper.advance()
         t.assign(float(t) + float(dt))
         curr_mass = assemble(mass_form)
-        cum_error += abs(abs(curr_mass - prev_mass) - dt_val * flux)
+        cum_error += abs(abs(curr_mass - prev_mass) - float(dt) * flux)
 
     return cum_error
 
 
-@pytest.mark.parametrize("tableau", [BackwardEuler(), RadauIIA(2)],
+@pytest.mark.parametrize("scheme", [BackwardEuler(), RadauIIA(2)],
                          ids=["BackwardEuler", "RadauIIA2"])
-def test_mass_conservation_stage_value(tableau):
-    """Stage value stepper with Dt(theta(h)) should conserve mass."""
-    err = run_richards(tableau, "value")
+def test_mass_conservation_stage_value(scheme):
+    """Test mass conservation with Dt(theta(h))"""
+    err = run_richards(scheme, stage_type="value")
     assert err < 1e-10, (
         f"mass error should be near machine precision, got {err:.2e}"
     )
 
 
-def test_mass_conservation_fails_stage_derivative():
-    """Stage derivative must apply the chain rule, so the linearisation
-    error means mass is not conserved to machine precision."""
-    err = run_richards(BackwardEuler(), "deriv")
-    assert err > 1e-8, (
-        f"stage derivative should NOT conserve mass, got {err:.2e}"
+@pytest.mark.parametrize("order", [0, 1])
+def test_mass_conservation_dg(order):
+    """Test mass conservation with Dt(theta(h))"""
+    scheme = DiscontinuousGalerkinScheme(order)
+    err = run_richards(scheme)
+    assert err < 1e-10, (
+        f"mass error should be near machine precision, got {err:.2e}"
     )

--- a/tests/test_mass_conservation.py
+++ b/tests/test_mass_conservation.py
@@ -83,10 +83,11 @@ def test_mass_conservation_stage_value(scheme):
 
 
 @pytest.mark.parametrize("order", [0, 1, 2])
-def test_mass_conservation_dg(order):
+@pytest.mark.parametrize("deriv_type", ["strong", "weak"])
+def test_mass_conservation_dg(order, deriv_type):
     """Test mass conservation with Dt(theta(h))"""
-    scheme = DiscontinuousGalerkinScheme(order)
+    scheme = DiscontinuousGalerkinScheme(order, deriv_type=deriv_type)
     err = run_richards(scheme)
-    assert err < 10*np.finfo(np.dtype(err)).eps, (
+    assert err < 200*np.finfo(np.dtype(err)).eps, (
         f"mass error should be near machine precision, got {err:.2e}"
     )

--- a/tests/test_mass_conservation.py
+++ b/tests/test_mass_conservation.py
@@ -1,0 +1,93 @@
+"""Check mass conservation for Dt(theta(h)) with nonlinear theta.
+
+Richards-like diffusion on a unit square, CG1, exponential soil
+model, pure Neumann BCs.  The total moisture should change by
+exactly the boundary flux each step.  Stiffly accurate methods
+give u_new = U_s, so the conservative finite difference appears
+directly in the stage equations.
+"""
+import pytest
+from firedrake import (
+    Function, FunctionSpace, TestFunction,
+    UnitSquareMesh, assemble, ds, dx, exp, grad, inner,
+)
+from irksome import BackwardEuler, Dt, MeshConstant, RadauIIA, TimeStepper
+
+
+# Exponential soil model
+theta_r = 0.15
+theta_s = 0.45
+alpha = 0.328
+Ks = 1e-5
+
+N = 10
+dt_val = 100.0
+nstep = 50
+flux = 1e-6
+
+
+def theta(h):
+    return theta_r + (theta_s - theta_r) * exp(alpha * h)
+
+
+def conductivity(h):
+    return Ks * exp(alpha * h)
+
+
+def run_richards(butcher_tableau, stage_type):
+    """Run the problem and return cumulative mass balance error."""
+    mesh = UnitSquareMesh(N, N)
+    V = FunctionSpace(mesh, "CG", 1)
+    h = Function(V, name="h").assign(-1.0)
+    v = TestFunction(V)
+
+    MC = MeshConstant(mesh)
+    t = MC.Constant(0.0)
+    dt = MC.Constant(dt_val)
+
+    F = inner(Dt(theta(h)), v) * dx
+    F += inner(conductivity(h) * grad(h), grad(v)) * dx
+    F -= flux * v * ds(4)
+
+    stepper = TimeStepper(F, butcher_tableau, t, dt, h,
+                          solver_parameters={
+                              "mat_type": "aij",
+                              "snes_type": "newtonls",
+                              "ksp_type": "preonly",
+                              "pc_type": "lu",
+                              "pc_factor_mat_solver_type": "mumps",
+                              "snes_atol": 1e-14,
+                          },
+                          stage_type=stage_type)
+
+    mass_form = theta(h) * dx
+    curr_mass = assemble(mass_form)
+    cum_error = 0.0
+
+    for step in range(nstep):
+        prev_mass = curr_mass
+        stepper.advance()
+        t.assign(float(t) + float(dt))
+        curr_mass = assemble(mass_form)
+        cum_error += abs(abs(curr_mass - prev_mass) - dt_val * flux)
+
+    return cum_error
+
+
+@pytest.mark.parametrize("tableau", [BackwardEuler(), RadauIIA(2)],
+                         ids=["BackwardEuler", "RadauIIA2"])
+def test_mass_conservation_stage_value(tableau):
+    """Stage value stepper with Dt(theta(h)) should conserve mass."""
+    err = run_richards(tableau, "value")
+    assert err < 1e-10, (
+        f"mass error should be near machine precision, got {err:.2e}"
+    )
+
+
+def test_mass_conservation_fails_stage_derivative():
+    """Stage derivative must apply the chain rule, so the linearisation
+    error means mass is not conserved to machine precision."""
+    err = run_richards(BackwardEuler(), "deriv")
+    assert err > 1e-8, (
+        f"stage derivative should NOT conserve mass, got {err:.2e}"
+    )

--- a/tests/test_mass_conservation.py
+++ b/tests/test_mass_conservation.py
@@ -12,22 +12,22 @@ from firedrake import (
     UnitSquareMesh, assemble, ds, dx, exp, grad, inner,
 )
 from irksome import BackwardEuler, DiscontinuousGalerkinScheme, Dt, RadauIIA, TimeStepper
+import numpy as np
 
 
 def run_richards(scheme, **kwargs):
     """Run the problem and return cumulative mass balance error."""
     # Exponential soil model
-    theta_r = 0.15
-    theta_s = 0.45
-    alpha = 0.328
-    Ks = 1e-5
+    theta_r = Constant(0.15)
+    theta_s = Constant(0.45)
+    alpha = Constant(0.328)
+    Ks = Constant(1e-5)
     theta = lambda h: theta_r + (theta_s - theta_r) * exp(alpha * h)
     conductivity = lambda h: Ks * exp(alpha * h)
 
     N = 10
     dt_val = 100
     nstep = 50
-    flux = 1e-6
 
     mesh = UnitSquareMesh(N, N)
     V = FunctionSpace(mesh, "CG", 1)
@@ -36,6 +36,7 @@ def run_richards(scheme, **kwargs):
 
     t = Constant(0.0)
     dt = Constant(dt_val)
+    flux = Constant(1e-6)
 
     F = inner(Dt(theta(h)), v) * dx
     F += inner(conductivity(h) * grad(h), grad(v)) * dx
@@ -43,22 +44,30 @@ def run_richards(scheme, **kwargs):
 
     stepper = TimeStepper(F, scheme, t, dt, h,
                           solver_parameters={
+                              "snes_rtol": 1e-10,
                               "snes_atol": 1e-14,
                           },
                           **kwargs)
 
-    mass_form = theta(h) * dx
+    area = assemble(1*ds(4, domain=mesh))
+    # Interpolate a Constant into V to force the same quadrature rule
+    one = Function(V).interpolate(Constant(1))
+    mass_form = inner(theta(h), one) * dx
     curr_mass = assemble(mass_form)
-    cum_error = 0.0
+    total_error = 0.0
 
     for step in range(nstep):
-        prev_mass = curr_mass
+        if step == 10:
+            dt.assign(0.5*dt)
+            flux.assign(4*flux)
+        expected_mass = curr_mass + area * float(flux) * float(dt)
         stepper.advance()
-        t.assign(float(t) + float(dt))
+        t.assign(t + dt)
         curr_mass = assemble(mass_form)
-        cum_error += abs(abs(curr_mass - prev_mass) - float(dt) * flux)
+        total_error += abs(curr_mass - expected_mass)
 
-    return cum_error
+    mean_error = total_error / float(t)
+    return mean_error
 
 
 @pytest.mark.parametrize("scheme", [BackwardEuler(), RadauIIA(2)],
@@ -66,16 +75,16 @@ def run_richards(scheme, **kwargs):
 def test_mass_conservation_stage_value(scheme):
     """Test mass conservation with Dt(theta(h))"""
     err = run_richards(scheme, stage_type="value")
-    assert err < 1e-10, (
+    assert err < 10*np.finfo(np.dtype(err)).eps, (
         f"mass error should be near machine precision, got {err:.2e}"
     )
 
 
-@pytest.mark.parametrize("order", [0, 1])
+@pytest.mark.parametrize("order", [0, 1, 2])
 def test_mass_conservation_dg(order):
     """Test mass conservation with Dt(theta(h))"""
     scheme = DiscontinuousGalerkinScheme(order)
     err = run_richards(scheme)
-    assert err < 1e-10, (
+    assert err < 10*np.finfo(np.dtype(err)).eps, (
         f"mass error should be near machine precision, got {err:.2e}"
     )

--- a/tests/test_mass_conservation.py
+++ b/tests/test_mass_conservation.py
@@ -16,12 +16,13 @@ import numpy as np
 
 
 def run_richards(scheme, **kwargs):
-    """Run the problem and return cumulative mass balance error."""
+    """Run the problem and return mean mass balance error."""
     # Exponential soil model
     theta_r = Constant(0.15)
     theta_s = Constant(0.45)
     alpha = Constant(0.328)
     Ks = Constant(1e-5)
+
     theta = lambda h: theta_r + (theta_s - theta_r) * exp(alpha * h)
     conductivity = lambda h: Ks * exp(alpha * h)
 
@@ -50,14 +51,15 @@ def run_richards(scheme, **kwargs):
                           **kwargs)
 
     area = assemble(1*ds(4, domain=mesh))
-    # Interpolate a Constant into V to force the same quadrature rule
+    # Interpolate a Constant into V to compute mass with the same quadrature rule
     one = Function(V).interpolate(Constant(1))
     mass_form = inner(theta(h), one) * dx
     curr_mass = assemble(mass_form)
     total_error = 0.0
 
     for step in range(nstep):
-        if step == 10:
+        if step > 0 and step % 10 == 0:
+            # Update the time step and the flux
             dt.assign(0.5*dt)
             flux.assign(4*flux)
         expected_mass = curr_mass + area * float(flux) * float(dt)

--- a/tests/test_time_form_splitting.py
+++ b/tests/test_time_form_splitting.py
@@ -5,6 +5,10 @@ from ufl import (Coefficient, FunctionSpace, Mesh,
                  TestFunction, dx, grad, inner, sin, triangle)
 from finat.ufl import FiniteElement, MixedElement, VectorElement
 from ufl.algorithms.domain_analysis import group_form_integrals
+try:
+    from ufl import MeshSequence
+except ImportError:
+    MeshSequence = lambda meshes: meshes[0]
 
 
 def sig(form):
@@ -30,7 +34,7 @@ def Q(mesh):
 
 @pytest.fixture
 def W(V, Q):
-    mesh = V.ufl_domain()
+    mesh = MeshSequence((V.ufl_domain(), Q.ufl_domain()))
     return FunctionSpace(mesh, MixedElement(V.ufl_element(), Q.ufl_element()))
 
 
@@ -44,13 +48,13 @@ def test_can_split(V):
     F = (inner(c, c)*inner(Dt(u), v) + inner(grad(u), grad(v))
          + inner(c, v) + inner(Dt(u), v))*dx
 
-    split = extract_terms(F)
+    split = extract_terms(F, timedep_coeffs=(u,))
 
     expect_t = (inner(c, c)*inner(Dt(u), v) + inner(Dt(u), v))*dx
     expect_no_t = inner(grad(u), grad(v))*dx + inner(c, v)*dx
 
-    assert sig(expect_t) == sig(split.time)
-    assert sig(expect_no_t) == sig(split.remainder)
+    assert sig(expect_t) == sig(split.time), f"{expect_t} \n!= {split.time}"
+    assert sig(expect_no_t) == sig(split.remainder), f"{expect_no_t} \n!= {split.remainder}"
 
 
 def test_can_split_mixed(W):
@@ -63,13 +67,13 @@ def test_can_split_mixed(W):
     F = (inner(c, c)*inner(Dt(u), v) + inner(grad(u), grad(v))
          + inner(c, v) + inner(Dt(u), v))*dx
 
-    split = extract_terms(F)
+    split = extract_terms(F, timedep_coeffs=(u,))
 
     expect_t = (inner(c, c)*inner(Dt(u), v) + inner(Dt(u), v))*dx
     expect_no_t = inner(grad(u), grad(v))*dx + inner(c, v)*dx
 
-    assert sig(expect_t) == sig(split.time)
-    assert sig(expect_no_t) == sig(split.remainder)
+    assert sig(expect_t) == sig(split.time), f"{expect_t} \n!= {split.time}"
+    assert sig(expect_no_t) == sig(split.remainder), f"{expect_no_t} \n!= {split.remainder}"
 
 
 def test_can_split_mixed_split(W):
@@ -85,13 +89,13 @@ def test_can_split_mixed_split(W):
     F = (inner(c, c)*inner(Dt(u0), v0) + inner(grad(u), grad(v))
          + inner(c, v) + inner(Dt(u), v))*dx
 
-    split = extract_terms(F)
+    split = extract_terms(F, timedep_coeffs=(u,))
 
     expect_t = (inner(c, c)*inner(Dt(u0), v0) + inner(Dt(u), v))*dx
     expect_no_t = inner(grad(u), grad(v))*dx + inner(c, v)*dx
 
-    assert sig(expect_t) == sig(split.time)
-    assert sig(expect_no_t) == sig(split.remainder)
+    assert sig(expect_t) == sig(split.time), f"{expect_t} \n!= {split.time}"
+    assert sig(expect_no_t) == sig(split.remainder), f"{expect_no_t} \n!= {split.remainder}"
 
 
 def test_only_first_order(V):
@@ -107,7 +111,7 @@ def test_only_first_order(V):
          + inner(Dt(u), v))*dx
 
     with pytest.raises(ValueError):
-        check_integrals(F.integrals(), expect_time_derivative=True)
+        check_integrals(F.integrals(), timedep_coeffs=(u,), expect_time_derivative=True)
 
 
 @pytest.mark.parametrize("typ", ["mul", "div", "sin"])
@@ -128,7 +132,7 @@ def test_Dt_linear(V, typ):
         F += inner(sin(Dt(u)[0]), v[0])*dx
 
     with pytest.raises(ValueError):
-        check_integrals(F.integrals(), expect_time_derivative=True)
+        check_integrals(F.integrals(), timedep_coeffs=(u,), expect_time_derivative=True)
 
 
 def test_expecting_time_derivative(V):
@@ -141,10 +145,10 @@ def test_expecting_time_derivative(V):
     F = (inner(grad(u), grad(v)) + inner(c, v))*dx
 
     with pytest.raises(ValueError):
-        check_integrals(F.integrals(), expect_time_derivative=True)
+        check_integrals(F.integrals(), timedep_coeffs=(u,), expect_time_derivative=True)
 
-    check_integrals(F.integrals(), expect_time_derivative=False)
+    check_integrals(F.integrals(), timedep_coeffs=(u,), expect_time_derivative=False)
 
     F += inner(Dt(u), v)*dx
     with pytest.raises(ValueError):
-        check_integrals(F.integrals(), expect_time_derivative=False)
+        check_integrals(F.integrals(), timedep_coeffs=(u,), expect_time_derivative=False)

--- a/tests/test_time_form_splitting.py
+++ b/tests/test_time_form_splitting.py
@@ -1,6 +1,6 @@
 import pytest
 from irksome import Dt
-from irksome.ufl.manipulation import check_integrals, extract_terms
+from irksome.ufl.manipulation import check_integrals, split_time_derivative_terms
 from ufl import (Coefficient, FunctionSpace, Mesh,
                  TestFunction, dx, grad, inner, sin, triangle)
 from finat.ufl import FiniteElement, MixedElement, VectorElement
@@ -48,7 +48,7 @@ def test_can_split(V):
     F = (inner(c, c)*inner(Dt(u), v) + inner(grad(u), grad(v))
          + inner(c, v) + inner(Dt(u), v))*dx
 
-    split = extract_terms(F, timedep_coeffs=(u,))
+    split = split_time_derivative_terms(F, timedep_coeffs=(u,))
 
     expect_t = (inner(c, c)*inner(Dt(u), v) + inner(Dt(u), v))*dx
     expect_no_t = inner(grad(u), grad(v))*dx + inner(c, v)*dx
@@ -67,7 +67,7 @@ def test_can_split_mixed(W):
     F = (inner(c, c)*inner(Dt(u), v) + inner(grad(u), grad(v))
          + inner(c, v) + inner(Dt(u), v))*dx
 
-    split = extract_terms(F, timedep_coeffs=(u,))
+    split = split_time_derivative_terms(F, timedep_coeffs=(u,))
 
     expect_t = (inner(c, c)*inner(Dt(u), v) + inner(Dt(u), v))*dx
     expect_no_t = inner(grad(u), grad(v))*dx + inner(c, v)*dx
@@ -89,7 +89,7 @@ def test_can_split_mixed_split(W):
     F = (inner(c, c)*inner(Dt(u0), v0) + inner(grad(u), grad(v))
          + inner(c, v) + inner(Dt(u), v))*dx
 
-    split = extract_terms(F, timedep_coeffs=(u,))
+    split = split_time_derivative_terms(F, timedep_coeffs=(u,))
 
     expect_t = (inner(c, c)*inner(Dt(u0), v0) + inner(Dt(u), v))*dx
     expect_no_t = inner(grad(u), grad(v))*dx + inner(c, v)*dx


### PR DESCRIPTION
Currently, we splat out time derivatives of `Dt(g(u))` in equations eagerly, but this is inconsistent with how collocation schemes are formulated.  Instead, we want to keep this term together, which can help with mass conservation for things like Richards equation.  A similar feature appears in DG time stepping, where the derivation requires us to work on `Dt(g(u))` itself to IBP twice.  

This PR only addresses stage-value, but we can adapt some of the UFL manipulation to DG later.

It seems that stage derivative is essentially hopeless here, there's no way to do substitution on `Dt(g(u))` without splatting out the derivatives.

cPG may be salvagable, but that's an open question.