### PR TITLE
Remove mass solve from stage_type value

### DIFF
--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -203,10 +203,26 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
             self._update = self._update_collocation
 
         elif (not butcher_tableau.is_stiffly_accurate) and (basis_type != "Bernstein"):
-            self.unew, self.update_solver = self.get_update_solver(update_solver_parameters)
-            self._update = self._update_general
+            try:
+                Ainv = vecconst(numpy.linalg.inv(butcher_tableau.A))
+                b = vecconst(butcher_tableau.b)
+                self.bAinv = dot(b, Ainv)
+                self.bAinv_one = 1-numpy.sum(self.bAinv)
+                self._update = self._update_Ainv
+            except numpy.linalg.LinAlgError:
+                self.unew, self.update_solver = self.get_update_solver(update_solver_parameters)
+                self._update = self._update_general
         else:
             self._update = self._update_stiff_acc
+
+    def _update_Ainv(self):
+        nf = self.num_fields
+        ns = self.num_stages
+        scale = self.bAinv_one
+        bAinv = self.bAinv
+        for i, u0bit in enumerate(self.u0.subfunctions):
+            u0bit *= scale
+            u0bit += sum(self.stages.subfunctions[nf * s + i] * bAinv[s] for s in range(ns))
 
     def _update_stiff_acc(self):
         for i, u0bit in enumerate(self.u0.subfunctions):

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -204,10 +204,10 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
 
         elif (not butcher_tableau.is_stiffly_accurate) and (basis_type != "Bernstein"):
             try:
-                Ainv = vecconst(numpy.linalg.inv(butcher_tableau.A))
-                b = vecconst(butcher_tableau.b)
-                self.bAinv = dot(b, Ainv)
-                self.bAinv_one = 1-numpy.sum(self.bAinv)
+                A = butcher_tableau.A
+                b = butcher_tableau.b
+                self.bAinv = vecconst(numpy.linalg.solve(A.T, b))
+                self.update_scale = 1-numpy.sum(self.bAinv)
                 self._update = self._update_Ainv
             except numpy.linalg.LinAlgError:
                 self.unew, self.update_solver = self.get_update_solver(update_solver_parameters)
@@ -218,7 +218,7 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
     def _update_Ainv(self):
         nf = self.num_fields
         ns = self.num_stages
-        scale = self.bAinv_one
+        scale = self.update_scale
         bAinv = self.bAinv
         for i, u0bit in enumerate(self.u0.subfunctions):
             u0bit *= scale

--- a/tests/test_dae.py
+++ b/tests/test_dae.py
@@ -1,8 +1,10 @@
-from firedrake import (Function, FunctionSpace, TestFunction, TestFunctions,
-                       UnitTriangleMesh, VectorFunctionSpace, div, dx, grad,
-                       inner, split)
-from irksome import Dt
+from firedrake import (Constant, DirichletBC, FacetNormal, Function, FunctionSpace, SpatialCoordinate, TestFunction, TestFunctions,
+                       UnitTriangleMesh, UnitSquareMesh, VectorFunctionSpace, as_vector, div, dot, ds, dx, errornorm, grad,
+                       inner, project, split)
+from irksome import Dt, GaussLegendre, RadauIIA, TimeStepper
 from irksome.tools import is_ode
+import pytest
+import numpy as np
 
 
 # tests the is_ode tool to confirm it's determined whether something is an
@@ -42,3 +44,49 @@ def test_foo():
 
     assert not is_ode(F, up)
     assert is_ode(F + inner(Dt(p), w) * dx, up)
+
+
+@pytest.mark.parametrize('tableau', [RadauIIA, GaussLegendre])
+@pytest.mark.parametrize('temporal_degree', [2, 3])
+@pytest.mark.parametrize('stage_type', ["deriv", "value"])
+def test_mixed_heat(tableau, temporal_degree, stage_type):
+
+    msh = UnitSquareMesh(4, 4)
+    V = FunctionSpace(msh, "RT", 3)
+    W = FunctionSpace(msh, "DG", 2)
+    Z = V * W
+
+    butcher_tableau = tableau(temporal_degree)
+
+    dt = Constant(0.05)
+    t = Constant(0.0)
+
+    x, y = SpatialCoordinate(msh)
+
+    u_exact = (x*(1-x)+y*(1-y))*(1+t)
+    q_exact = -grad(u_exact)
+    qu_exact = as_vector([q_exact[0], q_exact[1], u_exact])
+    f = Dt(u_exact) + div(q_exact)
+
+    qu = project(qu_exact, Z)
+    q, u = split(qu)
+
+    v, w = TestFunctions(Z)
+    n = FacetNormal(msh)
+
+    F = (inner(Dt(u), w) * dx + inner(div(q), w) * dx - inner(f, w) * dx
+         + inner(q, v) * dx - inner(u, div(v)) * dx - inner(u_exact, dot(v, n))*ds)
+
+    bc = DirichletBC(Z.sub(0), q_exact, "on_boundary")
+
+    stepper = TimeStepper(F, butcher_tableau, t, dt, qu, bcs=bc,
+                          stage_type=stage_type)
+
+    e_vals = []
+    for i in range(2):
+        stepper.advance()
+
+        t.assign(float(t)+float(dt))
+        e_vals.append(errornorm(qu_exact, qu))
+
+    assert np.allclose(e_vals, 0)

--- a/tests/test_dae.py
+++ b/tests/test_dae.py
@@ -1,8 +1,12 @@
-from firedrake import (Constant, DirichletBC, FacetNormal, Function, FunctionSpace, SpatialCoordinate, TestFunction, TestFunctions,
-                       UnitTriangleMesh, UnitSquareMesh, VectorFunctionSpace, as_vector, div, dot, ds, dx, errornorm, grad,
-                       inner, project, split)
-from irksome import Dt, GaussLegendre, RadauIIA, TimeStepper
+from firedrake import (Constant, DirichletBC, FacetNormal, Function,
+                       FunctionSpace, SpatialCoordinate, TestFunction,
+                       TestFunctions, UnitTriangleMesh,
+                       UnitSquareMesh, VectorFunctionSpace, as_vector,
+                       div, dot, ds, dx, errornorm, exp, grad, inner,
+                       pi, project, sin, split)
+from irksome import Dt, GaussLegendre, LobattoIIIC, RadauIIA, TimeStepper
 from irksome.tools import is_ode
+from irksome.constant import vecconst
 import pytest
 import numpy as np
 
@@ -88,5 +92,60 @@ def test_mixed_heat(tableau, temporal_degree, stage_type):
 
         t.assign(float(t)+float(dt))
         e_vals.append(errornorm(qu_exact, qu))
+
+    assert np.allclose(e_vals, 0)
+
+
+def test_mixed_heat_twoways():
+
+    msh = UnitSquareMesh(8, 8)
+    V = FunctionSpace(msh, "RT", 2)
+    W = FunctionSpace(msh, "DG", 1)
+    Z = V * W
+
+    butcher_tableau = LobattoIIIC(2)
+
+    dt = Constant(0.05)
+    t = Constant(0.0)
+
+    x, y = SpatialCoordinate(msh)
+
+    u_exact = sin(pi*x)*sin(pi*y)*exp(-2*(pi**2)*t)
+    q_exact = -grad(u_exact)
+    qu_exact = as_vector([q_exact[0], q_exact[1], u_exact])
+
+    qu = project(qu_exact, Z)
+    q, u = split(qu)
+
+    qu2 = project(qu_exact, Z)
+    q2, u2 = split(qu2)
+
+    v, w = TestFunctions(Z)
+    n = FacetNormal(msh)
+
+    F = (inner(Dt(u), w) * dx + inner(div(q), w) * dx
+         + inner(q, v) * dx - inner(u, div(v)) * dx - inner(u_exact, dot(v, n))*ds)
+    F2 = (inner(Dt(u2), w) * dx + inner(div(q2), w) * dx
+          + inner(q2, v) * dx - inner(u2, div(v)) * dx - inner(u_exact, dot(v, n))*ds)
+
+    bc = DirichletBC(Z.sub(0), q_exact, "on_boundary")
+
+    stepper = TimeStepper(F, butcher_tableau, t, dt, qu, bcs=bc,
+                          stage_type="value")
+    stepper2 = TimeStepper(F2, butcher_tableau, t, dt, qu2, bcs=bc,
+                           stage_type="value")
+    A = butcher_tableau.A
+    b = butcher_tableau.b
+    stepper2.bAinv = vecconst(np.linalg.solve(A.T, b))
+    stepper2.update_scale = 1-np.sum(stepper2.bAinv)
+    stepper2._update = stepper2._update_Ainv
+
+    e_vals = []
+    for i in range(2):
+        stepper.advance()
+        stepper2.advance()
+
+        t.assign(float(t)+float(dt))
+        e_vals.append(errornorm(qu2, qu))
 
     assert np.allclose(e_vals, 0)


### PR DESCRIPTION
The current implementation of `stage_type == "value"` fails when solving a DAE and using a non-stiffly accurate BT.  The math(s) behind that implementation are based on ODEs, so this is really just a case that fell through the cracks.

Doing a little pencil-and-paper work, you can easily reformulate the update to work for ODEs and DAEs, based on the computed stage values, without the mass solve.  This should be faster than what we had before, so it seems like this should be the default way we do things when the BT is not stiffly accurate...