### PR TITLE
Exception if irksome is imported too late.

### DIFF
--- a/irksome/__init__.py
+++ b/irksome/__init__.py
@@ -9,7 +9,10 @@ from .tableaux.ButcherTableaux import (
     RadauIIA,
 )
 from .tableaux.pep_explicit_rk import PEPRK
-from .ufl.deriv import Dt, expand_time_derivatives
+from .ufl.deriv import Dt, expand_time_derivatives, check_irksome_import_order
+
+check_irksome_import_order()
+
 from .tableaux.dirk_imex_tableaux import DIRK_IMEX
 from .tableaux.ars_dirk_imex_tableaux import ARS_DIRK_IMEX
 from .tableaux.sspk_tableau import SSPK_DIRK_IMEX, SSPButcherTableau

--- a/irksome/ufl/deriv.py
+++ b/irksome/ufl/deriv.py
@@ -46,6 +46,9 @@ def check_irksome_import_order():
             """
         )
     if expected_cache_size:
+        # In the cases where Firedrake/UFL has already instantiated
+        # multifunctions, clear the cache and reinstantiate them now that
+        # TimeDerivative has been added to the UFL typecode list.
         MultiFunction._handlers_cache = {}
     if "ufl.formatting.ufl2unicode" in sys.modules:
         from ufl.formatting import ufl2unicode

--- a/irksome/ufl/deriv.py
+++ b/irksome/ufl/deriv.py
@@ -1,7 +1,7 @@
 from functools import singledispatchmethod
 from importlib import metadata
+import sys
 
-import ufl
 from ufl.constantvalue import as_ufl
 from ufl.core.ufl_type import ufl_type
 from ufl.corealg.dag_traverser import DAGTraverser
@@ -47,8 +47,9 @@ def check_irksome_import_order():
         )
     if expected_cache_size:
         MultiFunction._handlers_cache = {}
-        ufl.formatting.ufl2unicode._precrules \
-            = ufl.formatting.ufl2unicode.PrecedenceRules()
+    if "ufl.formatting.ufl2unicode" in sys.modules:
+        from ufl.formatting import ufl2unicode
+        ufl2unicode._precrules = ufl2unicode.PrecedenceRules()
     if expected_cache_size > 1:
         from firedrake.formmanipulation import ExtractSubBlock
         ExtractSubBlock.index_inliner = ExtractSubBlock.IndexInliner()

--- a/irksome/ufl/deriv.py
+++ b/irksome/ufl/deriv.py
@@ -1,5 +1,7 @@
 from functools import singledispatchmethod
+from importlib import metadata
 
+import ufl
 from ufl.constantvalue import as_ufl
 from ufl.core.ufl_type import ufl_type
 from ufl.corealg.dag_traverser import DAGTraverser
@@ -26,12 +28,30 @@ def check_irksome_import_order():
     This restriction can be removed once all MultiFunctions have been
     transitioned to ufl.corealg.dag_traverser.DAGTraverser."""
 
-    if MultiFunction._handlers_cache:
+    try:
+        firedrake_version = metadata.version("firedrake")
+    except metadata.PackageNotFoundError:
+        # Firedrake not yet imported, the handler cache should be clean.
+        expected_cache_size = 0
+    else:
+        if firedrake_version < "2026.04":
+            expected_cache_size = 2
+        else:
+            expected_cache_size = 1
+
+    if len(MultiFunction._handlers_cache) > expected_cache_size:
         raise IrksomeImportOrderException(
             """A UFL multifunction has already run.
             Irksome needs to be imported earlier.
             """
         )
+    if expected_cache_size:
+        MultiFunction._handlers_cache = {}
+        ufl.formatting.ufl2unicode._precrules \
+            = ufl.formatting.ufl2unicode.PrecedenceRules()
+    if expected_cache_size > 1:
+        from firedrake.formmanipulation import ExtractSubBlock
+        ExtractSubBlock.index_inliner = ExtractSubBlock.IndexInliner()
 
 
 @ufl_type(num_ops=1,

--- a/irksome/ufl/deriv.py
+++ b/irksome/ufl/deriv.py
@@ -10,6 +10,28 @@ from ufl.form import BaseForm
 from ufl.classes import (Coefficient, Conj, Curl, ConstantValue, Derivative,
                          Div, Expr, Grad, Indexed, ReferenceGrad,
                          ReferenceValue, SpatialCoordinate, Variable)
+from ufl.corealg.multifunction import MultiFunction
+
+
+class IrksomeImportOrderException(Exception):
+    pass
+
+
+def check_irksome_import_order():
+    """Check that irksome has been imported early enough.
+
+    Due to the inadequacies of the UFL type system, it is not possible to
+    define a new UFL type once any ufl MultiFunction has been used.
+
+    This restriction can be removed once all MultiFunctions have been
+    transitioned to ufl.corealg.dag_traverser.DAGTraverser."""
+
+    if MultiFunction._handlers_cache:
+        raise IrksomeImportOrderException(
+            """A UFL multifunction has already run.
+            Irksome needs to be imported earlier.
+            """
+        )
 
 
 @ufl_type(num_ops=1,


### PR DESCRIPTION
Due to the inadequacies of how ufl MultiFunction works, Irksome must be imported before any UFL MultiFunction runs. This PR causes a slightly better exception if the import is too late.

Firedrake instantiates 2 UFL Multifunctions at import time (1 from 2026.04 release onwards). This PR also cleans up those at Irksome import time.