### PR TITLE
LinearVariationalProblem/Solver interface

### DIFF
--- a/demos/heat/demo_heat.py.rst
+++ b/demos/heat/demo_heat.py.rst
@@ -32,7 +32,7 @@ As usual, we need to import firedrake::
 
 We will also need to import certain items from irksome::
 
-  from irksome import GaussLegendre, Dt, MeshConstant, TimeStepper
+  from irksome import GaussLegendre, Dt, TimeStepper
 
 We will create the Butcher tableau for the lowest-order Gauss-Legendre
 Runge-Kutta method, which is more commonly known as the implicit
@@ -55,9 +55,8 @@ standard Firedrake fashion::
 
 We define variables to store the time step and current time value::
 
-  MC = MeshConstant(msh)
-  dt = MC.Constant(10.0 / N)
-  t = MC.Constant(0.0)
+  dt = Constant(10.0 / N)
+  t = Constant(0.0)
 
 This defines the right-hand side using the method of manufactured solutions::
 
@@ -84,10 +83,7 @@ standard UFL notation, augmented by the ``Dt`` operator from Irksome::
 
 Later demos will show how to use Firedrake's sophisticated interface
 to PETSc for efficient block solvers, but for now, we will solve the
-system with a direct method (Note: the matrix type needs to be
-explicitly set to aij if sparse direct factorization were used with a
-multi-stage method, as we wind up with a mixed problem that Firedrake
-will assemble into a PETSc MatNest otherwise)::
+system with a direct method. ::
 
   luparams = {"mat_type": "aij",
               "ksp_type": "preonly",
@@ -96,7 +92,7 @@ will assemble into a PETSc MatNest otherwise)::
 Most of Irksome's magic happens in the :class:`.TimeStepper`.  It
 transforms our semidiscrete form `F` into a fully discrete form for
 the stage unknowns and sets up a variational problem to solve for the
-stages at each time step.::
+stages at each time step. ::
 
   stepper = TimeStepper(F, butcher_tableau, t, dt, u, bcs=bc,
                         solver_parameters=luparams)
@@ -107,12 +103,48 @@ problem to compute the Runge-Kutta stage values and then updates the solution.::
 
   while (float(t) < 1.0):
       if (float(t) + float(dt) > 1.0):
-          dt.assign(1.0 - float(t))
+          dt.assign(1.0 - t)
       stepper.advance()
       print(float(t))
-      t.assign(float(t) + float(dt))
+      t.assign(t + dt)
 
 Finally, we print out the relative :math:`L^2` error::
+
+  print()
+  print(norm(u-uexact)/norm(uexact))
+
+So far we have neglected the fact that the problem is linear, and that the
+Jacobian is time-independent. We can instead formulate the semidiscrete form
+`F` in terms of a :class:`TrialFunction`, and specify the option
+``constant_jacobian``. So that the factorization is not redone at each time
+step. ::
+
+  dt.assign(10.0 / N)
+  t.assign(0)
+
+  u = Function(V)
+  u.interpolate(uexact)
+
+  v = TestFunction(V)
+  w = TrialFunction(V)
+  F = inner(Dt(w), v)*dx + inner(grad(w), grad(v))*dx - inner(rhs, v)*dx
+
+  linear_stepper = TimeStepper(F, butcher_tableau, t, dt, u, bcs=bc,
+                               constant_jacobian=True,
+                               solver_parameters=luparams)
+
+We can flag the Jacobian for an update by calling :meth:`invalidate_jacobian`,
+in case ``dt`` is changed ::
+
+  while (float(t) < 1.0):
+      if (float(t) + float(dt) > 1.0):
+          linear_stepper.invalidate_jacobian()
+          dt.assign(1.0 - t)
+      linear_stepper.advance()
+      print(float(t))
+      t.assign(t + dt)
+
+Finally, we see that we obtain same relative :math:`L^2` error from before::
 
   print()
   print(norm(u-uexact)/norm(uexact))

--- a/demos/heat/demo_heat.py.rst
+++ b/demos/heat/demo_heat.py.rst
@@ -116,7 +116,7 @@ Finally, we print out the relative :math:`L^2` error::
 So far we have neglected the fact that the problem is linear, and that the
 Jacobian is time-independent. We can instead formulate the semidiscrete form
 `F` in terms of a :class:`TrialFunction`, and specify the option
-``constant_jacobian``. So that the factorization is not redone at each time
+``constant_jacobian``, so that the factorization is not redone at each time
 step. ::
 
   dt.assign(10.0 / N)

--- a/irksome/base_time_stepper.py
+++ b/irksome/base_time_stepper.py
@@ -228,3 +228,9 @@ class StageCoupledTimeStepper(BaseTimeStepper):
             raise ValueError("Unknown bounds type")
 
         return (slb, sub)
+
+    def invalidate_jacobian(self):
+        """
+        Forces the matrix to be reassembled next time it is required.
+        """
+        LinearVariationalSolver.invalidate_jacobian(self.solver)

--- a/irksome/base_time_stepper.py
+++ b/irksome/base_time_stepper.py
@@ -50,43 +50,43 @@ class StageCoupledTimeStepper(BaseTimeStepper):
     compute the stages (e.g. fully implicit RK, Galerkin-in-time)
 
     :arg F: A :class:`ufl.Form` instance describing the semi-discrete problem
-            F(t, u; v) == 0, where `u` is the unknown
-            :class:`firedrake.Function and `v` is the
-            :class:firedrake.TestFunction`. To specify a linear problem,
-            `F` must be of the form a(t; w, v) - L(t; v) where
-            `w` is a :class:firedrake.TrialFunction`.
-    :arg t: a :class:`Function` on the Real space over the same mesh as
-         `u0`.  This serves as a variable referring to the current time.
-    :arg dt: a :class:`Function` on the Real space over the same mesh as
-         `u0`.  This serves as a variable referring to the current time step.
-         The user may adjust this value between time steps.
+        ``F(t, u; v) == 0``, where ``u`` is the unknown
+        :class:`firedrake.Function` and ``v`` is the
+        :class:`firedrake.TestFunction`. To specify a linear problem,
+        ``F`` must be of the form ``a(t; w, v) - L(t; v)``, where
+        ``w`` is a :class:`firedrake.TrialFunction`.
+    :arg Fexp: A :class:`ufl.Form` instance describing the part of the
+    :arg t: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as ``u0``.  This serves as
+        a variable referring to the current time.
+    :arg dt: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as ``u0``.  This serves as
+        a variable referring to the current time step size.
+        The user may adjust this value between time steps.
     :arg u0: A :class:`firedrake.Function` containing the current
-            state of the problem to be solved.
+        state of the problem to be solved.
     :arg num_stages: The number of stages to solve for.  It could be the number of
-            RK stages or relate to the polynomial degree (Galerkin)
-    :arg bcs: An iterable of :class:`firedrake.DirichletBC` or `firedrake.EquationBC`
-            containing the strongly-enforced boundary conditions.  Irksome will
-            manipulate these to obtain boundary conditions for each
-            stage of the RK method.  Support for `firedrake.EquationBC` is limited
-            to the stage derivative formulation with DAE style BCs.
+        RK stages or relate to the polynomial degree (Galerkin)
+    :arg bcs: An iterable of :class:`firedrake.DirichletBC` or :class:`firedrake.EquationBC`
+        containing the strongly-enforced boundary conditions.  Irksome will
+        manipulate these to obtain boundary conditions for each
+        stage of the RK method.  Support for `firedrake.EquationBC` is limited
+        to the stage derivative formulation with DAE style BCs.
     :arg Fp: A :class:`ufl.Form` instance to precondition the semi-discrete linearization.
     :arg solver_parameters: An optional :class:`dict` of solver parameters that
-            will be used in solving the algebraic problem associated
-            with each time step.
+        will be used in solving the algebraic problem associated
+        with each time step.
     :arg appctx: An optional :class:`dict` containing application context.
-            This gets included with particular things that Irksome will
-            pass into the nonlinear solver so that, say, user-defined preconditioners
-            have access to it.
-    :arg nullspace: A list of tuples of the form (index, VSB) where
-            index is an index into the function space associated with
-            `u` and VSB is a :class: `firedrake.VectorSpaceBasis`
-            instance to be passed to a
-            `firedrake.MixedVectorSpaceBasis` over the larger space
-            associated with the Runge-Kutta method
+        This gets included with particular things that Irksome will
+        pass into the nonlinear solver so that, say, user-defined preconditioners
+        have access to it.
+    :arg nullspace: A :class:`firedrake.VectorSpaceBasis`
+        or :class:`firedrake.MixedVectorSpaceBasis` specifying a nullspace
+        over the space of ``u0``.
     :arg splitting: An optional kwarg (not used by all superclasses)
     :arg bc_type: An optional kwarg (not used by all superclasses)
     :arg butcher_tableau: A :class:`ButcherTableau` instance giving
-            the Runge-Kutta method to be used for time marching.
+        the Runge-Kutta method to be used for time marching.
     :arg bounds: An optional kwarg used in certain bounds-constrained methods.
     """
     def __init__(self, F, t, dt, u0, num_stages,

--- a/irksome/base_time_stepper.py
+++ b/irksome/base_time_stepper.py
@@ -1,6 +1,11 @@
 from abc import abstractmethod
-from firedrake import derivative, Function, NonlinearVariationalProblem, NonlinearVariationalSolver
+from firedrake import (
+    derivative, replace, lhs, rhs, Function, TrialFunction,
+    LinearVariationalProblem, LinearVariationalSolver,
+    NonlinearVariationalProblem, NonlinearVariationalSolver,
+)
 from firedrake.petsc import PETSc
+from .labeling import as_form, as_linear_form
 from .tools import AI, getNullspace, flatten_dats
 from .backend import get_backend
 import ufl
@@ -47,7 +52,9 @@ class StageCoupledTimeStepper(BaseTimeStepper):
     :arg F: A :class:`ufl.Form` instance describing the semi-discrete problem
             F(t, u; v) == 0, where `u` is the unknown
             :class:`firedrake.Function and `v` is the
-            :class:firedrake.TestFunction`.
+            :class:firedrake.TestFunction`. To specify a linear problem,
+            `F` must be of the form a(t; w, v) - L(t; v) where
+            `w` is a :class:firedrake.TrialFunction`.
     :arg t: a :class:`Function` on the Real space over the same mesh as
          `u0`.  This serves as a variable referring to the current time.
     :arg dt: a :class:`Function` on the Real space over the same mesh as
@@ -90,6 +97,11 @@ class StageCoupledTimeStepper(BaseTimeStepper):
                  butcher_tableau=None, bounds=None,
                  **kwargs):
 
+        use_linear_variational_solver = False
+        if len(as_form(F).arguments()) == 2:
+            F = as_linear_form(F, u0)
+            use_linear_variational_solver = True
+
         super().__init__(F, t, dt, u0,
                          bcs=bcs, appctx=appctx, nullspace=nullspace)
 
@@ -111,6 +123,7 @@ class StageCoupledTimeStepper(BaseTimeStepper):
         Fbig, bigBCs = self.get_form_and_bcs(stages)
         Jpbig = None
         if Fp is not None:
+            Fp = as_linear_form(Fp, u0)
             Fpbig, _ = self.get_form_and_bcs(stages, F=Fp, bcs=())
             Jpbig = derivative(Fpbig, stages)
 
@@ -122,13 +135,29 @@ class StageCoupledTimeStepper(BaseTimeStepper):
 
         self.bigBCs = bigBCs
 
-        self.problem = NonlinearVariationalProblem(
-            Fbig, stages, bcs=bigBCs, Jp=Jpbig,
-            form_compiler_parameters=kwargs.pop("form_compiler_parameters", None),
-            is_linear=kwargs.pop("is_linear", False),
-            restrict=kwargs.pop("restrict", False),
-        )
-        self.solver = NonlinearVariationalSolver(
+        if use_linear_variational_solver:
+            Fbig = replace(Fbig, {stages: TrialFunction(stages.function_space())})
+            abig = lhs(Fbig)
+            Lbig = rhs(Fbig)
+            problem = LinearVariationalProblem(
+                abig, Lbig, stages, bcs=bigBCs, aP=Jpbig,
+                form_compiler_parameters=kwargs.pop("form_compiler_parameters", None),
+                constant_jacobian=kwargs.pop("constant_jacobian", False),
+                restrict=kwargs.pop("restrict", False),
+            )
+            solver_constructor = LinearVariationalSolver
+            # FIXME
+            solver_constructor = NonlinearVariationalSolver
+        else:
+            problem = NonlinearVariationalProblem(
+                Fbig, stages, bcs=bigBCs, Jp=Jpbig,
+                form_compiler_parameters=kwargs.pop("form_compiler_parameters", None),
+                is_linear=kwargs.pop("is_linear", False),
+                restrict=kwargs.pop("restrict", False),
+            )
+            solver_constructor = NonlinearVariationalSolver
+        self.problem = problem
+        self.solver = solver_constructor(
             self.problem, appctx=self.appctx,
             nullspace=nullspace,
             transpose_nullspace=transpose_nullspace,

--- a/irksome/base_time_stepper.py
+++ b/irksome/base_time_stepper.py
@@ -55,7 +55,6 @@ class StageCoupledTimeStepper(BaseTimeStepper):
         :class:`firedrake.TestFunction`. To specify a linear problem,
         ``F`` must be of the form ``a(t; w, v) - L(t; v)``, where
         ``w`` is a :class:`firedrake.TrialFunction`.
-    :arg Fexp: A :class:`ufl.Form` instance describing the part of the
     :arg t: a :class:`firedrake.Constant` or :class:`firedrake.Function`
         on the Real space over the same mesh as ``u0``.  This serves as
         a variable referring to the current time.

--- a/irksome/base_time_stepper.py
+++ b/irksome/base_time_stepper.py
@@ -97,10 +97,10 @@ class StageCoupledTimeStepper(BaseTimeStepper):
                  butcher_tableau=None, bounds=None,
                  **kwargs):
 
-        use_linear_variational_solver = False
+        is_linear = False
         if len(as_form(F).arguments()) == 2:
             F = as_linear_form(F, u0)
-            use_linear_variational_solver = True
+            is_linear = True
 
         super().__init__(F, t, dt, u0,
                          bcs=bcs, appctx=appctx, nullspace=nullspace)
@@ -135,7 +135,7 @@ class StageCoupledTimeStepper(BaseTimeStepper):
 
         self.bigBCs = bigBCs
 
-        if use_linear_variational_solver:
+        if is_linear:
             Fbig = replace(Fbig, {stages: TrialFunction(stages.function_space())})
             abig = lhs(Fbig)
             Lbig = rhs(Fbig)
@@ -146,8 +146,6 @@ class StageCoupledTimeStepper(BaseTimeStepper):
                 restrict=kwargs.pop("restrict", False),
             )
             solver_constructor = LinearVariationalSolver
-            # FIXME
-            solver_constructor = NonlinearVariationalSolver
         else:
             problem = NonlinearVariationalProblem(
                 Fbig, stages, bcs=bigBCs, Jp=Jpbig,
@@ -155,7 +153,9 @@ class StageCoupledTimeStepper(BaseTimeStepper):
                 is_linear=kwargs.pop("is_linear", False),
                 restrict=kwargs.pop("restrict", False),
             )
+            problem._constant_jacobian = kwargs.pop("constant_jacobian", False)
             solver_constructor = NonlinearVariationalSolver
+
         self.problem = problem
         self.solver = solver_constructor(
             self.problem, appctx=self.appctx,

--- a/irksome/dirk_stepper.py
+++ b/irksome/dirk_stepper.py
@@ -1,5 +1,6 @@
 import numpy
 from firedrake import (derivative, Function,
+                       LinearVariationalSolver,
                        NonlinearVariationalProblem,
                        NonlinearVariationalSolver)
 from ufl.constantvalue import as_ufl
@@ -9,6 +10,7 @@ from .constant import vecconst
 from .tools import replace
 from .constant import MeshConstant
 from .bcs import bc2space
+from .labeling import as_linear_form
 
 
 def getFormDIRK(F, ks, butch, t, dt, u0, bcs=None, kgac=None):
@@ -119,6 +121,7 @@ class DIRKTimeStepper:
         # "ks" is a list of functions for the stage values
         # that we update as we go.  We need to remember the
         # stage values we've computed earlier in the time step...
+        F = as_linear_form(F, u0)
 
         stage_F, kgac, bcnew, (a_vals, d_val) = getFormDIRK(
             F, self.ks, butcher_tableau, t, dt, u0, bcs=bcs)
@@ -129,6 +132,7 @@ class DIRKTimeStepper:
 
         stage_Jp = None
         if Fp is not None:
+            Fp = as_linear_form(Fp, u0)
             stage_Fp, *_ = self.get_form_and_bcs(self.ks, F=Fp, bcs=())
             stage_Jp = derivative(stage_Fp, k)
 
@@ -145,6 +149,7 @@ class DIRKTimeStepper:
             is_linear=kwargs.pop("is_linear", False),
             restrict=kwargs.pop("restrict", False),
         )
+        self.problem._constant_jacobian = kwargs.pop("constant_jacobian", False)
         self.solver = NonlinearVariationalSolver(
             self.problem, appctx=appctx,
             nullspace=nullspace,
@@ -210,3 +215,9 @@ class DIRKTimeStepper:
                            self.t, self.dt,
                            self.u0,
                            bcs=bcs, kgac=self.kgac)
+
+    def invalidate_jacobian(self):
+        """
+        Forces the matrix to be reassembled next time it is required.
+        """
+        LinearVariationalSolver.invalidate_jacobian(self.solver)

--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -122,7 +122,7 @@ def getFormDiscGalerkin(F, L, Qdefault, t, dt, u0, stages, bcs=None, deriv_type=
     """Given a time-dependent variational form, trial and test spaces, and
     a quadrature rule, produce UFL for the Discontinuous Galerkin-in-Time method.
 
-    :arg F: UFL form for the semidiscrete ODE/DAE
+    :arg F: a :class:`ufl.Form` instance describing the semi-discrete problem.
     :arg L: A :class:`FIAT.FiniteElement` for the test and trial functions in time
     :arg Qdefault: A :class:`FIAT.QuadratureRule` for the time integration
     :arg t: a :class:`Function` on the Real space over the same mesh as
@@ -191,36 +191,29 @@ class DiscontinuousGalerkinTimeStepper(StageCoupledTimeStepper):
     """Front-end class for advancing a time-dependent PDE via a Discontinuous Galerkin
     in time method
 
-    :arg F: A :class:`ufl.Form` instance describing the semi-discrete problem
-            F(t, u; v) == 0, where `u` is the unknown
-            :class:`firedrake.Function and `v` is the
-            :class:firedrake.TestFunction`.
+    :arg F: a :class:`ufl.Form` instance describing the semi-discrete problem.
     :arg scheme: a :class:`DiscontinuousGalerkinScheme` instance describing the order,
-         basis type, default quadrature scheme, and time derivative integration type.
-    :arg t: a :class:`Function` on the Real space over the same mesh as
-         `u0`.  This serves as a variable referring to the current time.
-    :arg dt: a :class:`Function` on the Real space over the same mesh as
-         `u0`.  This serves as a variable referring to the current time step.
-         The user may adjust this value between time steps.
+        basis type, default quadrature scheme, and time derivative integration type.
+    :arg t: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as `u0`.  This serves as
+        a variable referring to the current time.
+    :arg dt: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as `u0`.  This serves as
+        a variable referring to the current time step size.
     :arg u0: A :class:`firedrake.Function` containing the current
-            state of the problem to be solved.
+        state of the problem to be solved.
     :arg bcs: An iterable of :class:`firedrake.DirichletBC` containing
-            the strongly-enforced boundary conditions.  Irksome will
-            manipulate these to obtain boundary conditions for each
-            stage of the method.
+        the strongly-enforced boundary conditions.  Irksome will
+        manipulate these to obtain boundary conditions for each
+        stage of the method.
     :arg solver_parameters: A :class:`dict` of solver parameters that
-            will be used in solving the algebraic problem associated
-            with each time step.
+        will be used in solving the algebraic problem associated
+        with each time step.
     :arg appctx: An optional :class:`dict` containing application context.
-            This gets included with particular things that Irksome will
-            pass into the nonlinear solver so that, say, user-defined preconditioners
-            have access to it.
-    :arg nullspace: A list of tuples of the form (index, VSB) where
-            index is an index into the function space associated with
-            `u` and VSB is a :class: `firedrake.VectorSpaceBasis`
-            instance to be passed to a
-            `firedrake.MixedVectorSpaceBasis` over the larger space
-            associated with the Runge-Kutta method
+        This gets included with particular things that Irksome will
+        pass into the nonlinear solver so that, say, user-defined preconditioners
+        have access to it.
+    :arg nullspace: An optional nullspace object.
     """
     def __init__(self, F, scheme, t, dt, u0, bcs=None, basis_type=None,
                  quadrature=None, **kwargs):

--- a/irksome/galerkin_stepper.py
+++ b/irksome/galerkin_stepper.py
@@ -118,7 +118,7 @@ def getFormGalerkin(F, L_trial, L_test, Qdefault, t, dt, u0, stages, bcs=None, b
     """Given a time-dependent variational form, trial and test spaces, and
     a quadrature rule, produce UFL for the Galerkin-in-Time method.
 
-    :arg F: UFL form for the semidiscrete ODE/DAE
+    :arg F: a :class:`ufl.Form` instance describing the semi-discrete problem.
     :arg L_trial: A :class:`FIAT.FiniteElement` for the trial functions in time
     :arg L_test: A :class:`FIAT.FinteElement` for the test functions in time
     :arg Qdefault: A :class:`FIAT.QuadratureRule` for the time integration.
@@ -133,7 +133,7 @@ def getFormGalerkin(F, L_trial, L_test, Qdefault, t, dt, u0, stages, bcs=None, b
     :arg u0: a :class:`Function` referring to the state of
          the PDE system at time `t`
     :arg stages: a :class:`Function` representing the stages to be solved for.
-    :kwarg bcs: optionally, a :class:`DirichletBC` object (or iterable thereof)
+    :kwarg bcs: optionally, a :class:`firedrake.DirichletBC` object (or iterable thereof)
          containing (possibly time-dependent) boundary conditions imposed
          on the system.
     :kwarg bc_type: How to manipulate the strongly-enforced boundary
@@ -142,7 +142,7 @@ def getFormGalerkin(F, L_trial, L_test, Qdefault, t, dt, u0, stages, bcs=None, b
          constraints in the style of a differential-algebraic
          equation, or "ODE", which evaluates the temporal degrees of
          freedom of the boundary data.
-         Currently there is no support for `firedrake.EquationBC`.
+         Currently there is no support for :class:`firedrake.EquationBC`.
     :kwarg aux_indices: a list of field indices to be discretized in the test space
          rather than trial space.
 
@@ -252,45 +252,39 @@ class ContinuousPetrovGalerkinTimeStepper(StageCoupledTimeStepper):
     """Front-end class for advancing a time-dependent PDE via a Galerkin
     in time method
 
-    :arg F: A :class:`ufl.Form` instance describing the semi-discrete problem
-            F(t, u; v) == 0, where `u` is the unknown
-            :class:`firedrake.Function and `v` is the
-            :class:firedrake.TestFunction`.
+    :arg F: a :class:`ufl.Form` instance describing the semi-discrete problem.
     :arg scheme: :class:`ContinuousPetrovGalerkinScheme` encoding the order,
-         basis type, and default quadrature rule of the method.
-    :arg t: a :class:`Function` on the Real space over the same mesh as
-         `u0`.  This serves as a variable referring to the current time.
-    :arg dt: a :class:`Function` on the Real space over the same mesh as
-         `u0`.  This serves as a variable referring to the current time step.
-         The user may adjust this value between time steps.
+        basis type, and default quadrature rule of the method.
+    :arg t: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as `u0`.  This serves as
+        a variable referring to the current time.
+    :arg dt: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as `u0`.  This serves as
+        a variable referring to the current time step size.
+        The user may adjust this value between time steps.
     :arg u0: A :class:`firedrake.Function` containing the current
-            state of the problem to be solved.
+        state of the problem to be solved.
     :kwarg bcs: An iterable of :class:`firedrake.DirichletBC` containing
-            the strongly-enforced boundary conditions.  Irksome will
-            manipulate these to obtain boundary conditions for each
-            stage of the method.
+        the strongly-enforced boundary conditions.  Irksome will
+        manipulate these to obtain boundary conditions for each
+        stage of the method.
     :kwarg bc_type: How to manipulate the strongly-enforced boundary
-         conditions to derive the stage boundary conditions.  Should
-         be a string, either "DAE", which implements BCs as
-         constraints in the style of a differential-algebraic
-         equation, or "ODE", which evaluates the temporal degrees of
-         freedom of the boundary data.
-         Currently there is no support for `firedrake.EquationBC`.
+        conditions to derive the stage boundary conditions.  Should
+        be a string, either "DAE", which implements BCs as
+        constraints in the style of a differential-algebraic
+        equation, or "ODE", which evaluates the temporal degrees of
+        freedom of the boundary data.
+        Currently there is no support for `firedrake.EquationBC`.
     :kwarg solver_parameters: A :class:`dict` of solver parameters that
-            will be used in solving the algebraic problem associated
-            with each time step.
+        will be used in solving the algebraic problem associated
+        with each time step.
     :kwarg appctx: An optional :class:`dict` containing application context.
-            This gets included with particular things that Irksome will
-            pass into the nonlinear solver so that, say, user-defined preconditioners
-            have access to it.
-    :kwarg nullspace: A list of tuples of the form (index, VSB) where
-            index is an index into the function space associated with
-            `u` and VSB is a :class: `firedrake.VectorSpaceBasis`
-            instance to be passed to a
-            `firedrake.MixedVectorSpaceBasis` over the larger space
-            associated with the Runge-Kutta method
+        This gets included with particular things that Irksome will
+        pass into the nonlinear solver so that, say, user-defined preconditioners
+        have access to it.
+    :kwarg nullspace: An optional nullspace object.
     :kwarg aux_indices: a list of field indices to be discretized in the test space
-            rather than trial space.
+        rather than trial space.
     """
     def __init__(self, F, scheme, t, dt, u0, bcs=None,
                  bc_type=None, aux_indices=None, **kwargs):

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -635,3 +635,4 @@ class DIRKIMEXMethod:
         Forces the matrix to be reassembled next time it is required.
         """
         LinearVariationalSolver.invalidate_jacobian(self.solver)
+        LinearVariationalSolver.invalidate_jacobian(self.mass_solver)

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -635,4 +635,3 @@ class DIRKIMEXMethod:
         Forces the matrix to be reassembled next time it is required.
         """
         LinearVariationalSolver.invalidate_jacobian(self.solver)
-        LinearVariationalSolver.invalidate_jacobian(self.mass_solver)

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -1,6 +1,7 @@
 import FIAT
 import numpy as np
-from firedrake import (Function, NonlinearVariationalProblem,
+from firedrake import (Function, LinearVariationalSolver,
+                       NonlinearVariationalProblem,
                        NonlinearVariationalSolver, TestFunction,
                        as_ufl, dx, inner)
 from ufl import zero
@@ -11,6 +12,7 @@ from .stage_value import getFormStage
 from .tools import AI, IA, reshape, replace, getNullspace, get_stage_space
 from .bcs import bc2space
 from .constant import MeshConstant, ConstantOrZero
+from .labeling import as_linear_form
 
 
 def riia_explicit_coeffs(k):
@@ -121,35 +123,39 @@ class RadauIIAIMEXMethod:
     one expects convergence to the solution that would have been
     obtained from fully-implicit RadauIIA method.
 
-    :arg F: A :class:`ufl.Form` instance describing the implicit part
-            of the semi-discrete problem
-            F(t, u; v) == 0, where `u` is the unknown
-            :class:`firedrake.Function and `v` is the
-            :class:firedrake.TestFunction`.
+    :arg F: A :class:`ufl.Form` instance describing the implicit part of
+        the semi-discrete problem
+        ``F(t, u; v) == 0``, where ``u`` is the unknown
+        :class:`firedrake.Function` and ``v`` is the
+        :class:`firedrake.TestFunction`. To specify a linear problem,
+        ``F`` must be of the form ``a(t; w, v) - L(t; v)``, where
+        ``w`` is a :class:`firedrake.TrialFunction`.
     :arg Fexp: A :class:`ufl.Form` instance describing the part of the
-            PDE that is explicitly split off.
+        PDE that is explicitly split off.
     :arg butcher_tableau: A :class:`ButcherTableau` instance giving
-            the Runge-Kutta method to be used for time marching.
-            Only RadauIIA is allowed here (but it can be any number of stages).
-    :arg t: a :class:`Function` on the Real space over the same mesh as
-         `u0`.  This serves as a variable referring to the current time.
-    :arg dt: a :class:`Function` on the Real space over the same mesh as
-         `u0`.  This serves as a variable referring to the current time step.
-         The user may adjust this value between time steps.
+        the Runge-Kutta method to be used for time marching.
+        Only RadauIIA is allowed here (but it can be any number of stages).
+    :arg t: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as ``u0``.  This serves as
+        a variable referring to the current time.
+    :arg dt: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as ``u0``.  This serves as
+        a variable referring to the current time step size.
+        The user may adjust this value between time steps.
     :arg u0: A :class:`firedrake.Function` containing the current
-            state of the problem to be solved.
+        state of the problem to be solved.
     :arg bcs: An iterable of :class:`firedrake.DirichletBC` containing
-            the strongly-enforced boundary conditions.  Irksome will
-            manipulate these to obtain boundary conditions for each
-            stage of the RK method.
+        the strongly-enforced boundary conditions.  Irksome will
+        manipulate these to obtain boundary conditions for each
+        stage of the RK method.
     :arg it_solver_parameters: A :class:`dict` of solver parameters that
-            will be used in solving the algebraic problem associated
-            with the iterator.
+        will be used in solving the algebraic problem associated
+        with the iterator.
     :arg prop_solver_parameters: A :class:`dict` of solver parameters that
-            will be used in solving the algebraic problem associated
-            with the propagator.
+        will be used in solving the algebraic problem associated
+        with the propagator.
     :arg splitting: A callable used to factor the Butcher matrix,
-            currently, only AI is supported.
+        currently, only AI is supported.
     :arg appctx: An optional :class:`dict` containing application context.
     :arg nullspace: An optional null space object.
     """
@@ -161,7 +167,8 @@ class RadauIIAIMEXMethod:
                  appctx=None,
                  nullspace=None,
                  num_its_initial=0,
-                 num_its_per_step=0):
+                 num_its_per_step=0,
+                 **kwargs):
         assert isinstance(butcher_tableau, RadauIIA)
 
         self.u0 = u0
@@ -188,6 +195,12 @@ class RadauIIAIMEXMethod:
         Vbig = get_stage_space(V, self.num_stages)
         UU = Function(Vbig)
 
+        F = as_linear_form(F, u0)
+        Fexp = as_linear_form(Fexp, u0)
+        restrict = kwargs.pop("restrict", False)
+        is_linear = kwargs.pop("is_linear", False)
+        constant_jacobian = kwargs.pop("constant_jacobian", False)
+
         Fbig, bigBCs = getFormStage(
             F, butcher_tableau, t, dt, u0, UU, bcs,
             splitting=splitting)
@@ -205,9 +218,14 @@ class RadauIIAIMEXMethod:
             Fexp, butcher_tableau, u0, UU_old, t, dt, splitting)
 
         self.itprob = NonlinearVariationalProblem(
-            Fbig + Fit, UU, bcs=bigBCs)
+            Fbig + Fit, UU, bcs=bigBCs,
+            is_linear=is_linear, restrict=restrict)
         self.propprob = NonlinearVariationalProblem(
-            Fbig + Fprop, UU, bcs=bigBCs)
+            Fbig + Fprop, UU, bcs=bigBCs,
+            is_linear=is_linear, restrict=restrict)
+
+        self.itprob._constant_jacobian = constant_jacobian
+        self.propprob._constant_jacobian = constant_jacobian
 
         self.F = F
         self.orig_bcs = bcs
@@ -223,11 +241,11 @@ class RadauIIAIMEXMethod:
         self.it_solver = NonlinearVariationalSolver(
             self.itprob, appctx=appctx,
             solver_parameters=it_solver_parameters,
-            nullspace=nsp)
+            nullspace=nsp, **kwargs)
         self.prop_solver = NonlinearVariationalSolver(
             self.propprob, appctx=appctx,
             solver_parameters=prop_solver_parameters,
-            nullspace=nsp)
+            nullspace=nsp, **kwargs)
 
         num_fields = len(self.u0.function_space())
         u0split = u0.subfunctions
@@ -285,6 +303,13 @@ class RadauIIAIMEXMethod:
                             self.t, self.dt, self.u0,
                             stages, bcs=self.orig_bcs,
                             splitting=self.splitting)
+
+    def invalidate_jacobian(self):
+        """
+        Forces the matrix to be reassembled next time it is required.
+        """
+        LinearVariationalSolver.invalidate_jacobian(self.prop_solver)
+        LinearVariationalSolver.invalidate_jacobian(self.it_solver)
 
 
 def getFormsDIRKIMEX(F, Fexp, ks, khats, butch, t, dt, u0, bcs=None):
@@ -374,7 +399,7 @@ class DIRKIMEXMethod:
     """
 
     def __init__(self, F, F_explicit, butcher_tableau, t, dt, u0, bcs=None,
-                 solver_parameters=None, mass_parameters=None, appctx=None, nullspace=None):
+                 solver_parameters=None, mass_parameters=None, appctx=None, nullspace=None, **kwargs):
         assert butcher_tableau.is_dirk_imex
 
         self.num_steps = 0
@@ -393,6 +418,11 @@ class DIRKIMEXMethod:
         self.num_fields = len(u0.function_space())
         self.ks = [Function(V) for _ in range(self.num_stages)]
         self.k_hat_s = [Function(V) for _ in range(self.num_stages)]
+
+        F = as_linear_form(F, u0)
+        restrict = kwargs.pop("restrict", False)
+        is_linear = kwargs.pop("is_linear", False)
+        constant_jacobian = kwargs.pop("constant_jacobian", False)
 
         stage_F, (k, g, a, c), bcnew, Fhat, (khat, ghat, chat), (a_vals, ahat_vals, d_val) = getFormsDIRKIMEX(
             F, F_explicit, self.ks, self.k_hat_s, butcher_tableau, t, dt, u0, bcs=bcs)
@@ -414,12 +444,15 @@ class DIRKIMEXMethod:
         else:
             appctx = {**appctx, **appctx_irksome}
 
-        self.problem = NonlinearVariationalProblem(stage_F, k, bcnew)
+        self.problem = NonlinearVariationalProblem(stage_F, k, bcnew,
+                                                   is_linear=is_linear, restrict=restrict)
+        self.problem._constant_jacobian = constant_jacobian
         self.solver = NonlinearVariationalSolver(self.problem, appctx=appctx,
                                                  solver_parameters=solver_parameters,
-                                                 nullspace=nullspace)
+                                                 nullspace=nullspace, **kwargs)
 
-        self.mass_problem = NonlinearVariationalProblem(Fhat, khat)
+        self.mass_problem = NonlinearVariationalProblem(Fhat, khat, is_linear=True)
+        self.problem._constant_jacobian = True
         self.mass_solver = NonlinearVariationalSolver(self.mass_problem,
                                                       solver_parameters=mass_parameters)
 
@@ -596,3 +629,9 @@ class DIRKIMEXMethod:
 
     def solver_stats(self):
         return self.num_steps, self.num_nonlinear_iterations, self.num_linear_iterations, self.num_mass_nonlinear_iterations, self.num_mass_linear_iterations
+
+    def invalidate_jacobian(self):
+        """
+        Forces the matrix to be reassembled next time it is required.
+        """
+        LinearVariationalSolver.invalidate_jacobian(self.solver)

--- a/irksome/labeling.py
+++ b/irksome/labeling.py
@@ -166,6 +166,10 @@ def as_form(form):
 
 
 def as_linear_form(F, u0):
+    """
+    If `F` is a bilinear :class:`Form` compute a linear
+    :class:`Form` by replacing the trial function with `u0`.
+    """
     form = as_form(F)
     nargs = len(form.arguments())
     if nargs == 2:
@@ -174,5 +178,5 @@ def as_linear_form(F, u0):
         test, trial = form.arguments()
         F = replace(F, {trial: u0})
     elif nargs != 1:
-        raise ValueError("Expecting a linear Form with 1 or 2 arguments.")
+        raise ValueError("Expecting a Form with 1 or 2 arguments.")
     return F

--- a/irksome/labeling.py
+++ b/irksome/labeling.py
@@ -3,6 +3,7 @@ from ufl import BaseForm, Form, FormSum
 from firedrake.fml import Label, keep, drop, LabelledForm
 from collections import defaultdict
 from .scheme import create_time_quadrature
+from .tools import replace
 import numpy as np
 
 explicit = Label("explicit")
@@ -162,3 +163,16 @@ def as_form(form):
     if isinstance(form, LabelledForm):
         form = Form([]) if len(form) == 0 else form.form
     return form
+
+
+def as_linear_form(F, u0):
+    form = as_form(F)
+    nargs = len(form.arguments())
+    if nargs == 2:
+        if u0 in form.coefficients():
+            raise ValueError("The provided bilinear form must not depend on the solution")
+        test, trial = form.arguments()
+        F = replace(F, {trial: u0})
+    elif nargs != 1:
+        raise ValueError("Expecting a linear Form with 1 or 2 arguments.")
+    return F

--- a/irksome/labeling.py
+++ b/irksome/labeling.py
@@ -168,7 +168,8 @@ def as_form(form):
 def as_linear_form(F, u0):
     """
     If `F` is a bilinear :class:`Form` compute a linear
-    :class:`Form` by replacing the trial function with `u0`.
+    :class:`Form` by replacing the trial function with `u0`,
+    otherwise return `F`.
     """
     form = as_form(F)
     nargs = len(form.arguments())

--- a/irksome/stage_derivative.py
+++ b/irksome/stage_derivative.py
@@ -42,12 +42,12 @@ def getForm(F, butch, t, dt, u0, stages, bcs=None, bc_type=None, splitting=AI, a
         Support for `firedrake.EquationBC` in `bcs` is limited
         to DAE style BCs.
     :kwarg splitting: a callable that maps the (floating point) Butcher matrix
-        a to a pair of matrices `A1, A2` such that `butch.A = A1 A2`.  This is used
+        to a pair of matrices `A1, A2` such that `butch.A = A1 A2`.  This is used
         to vary between the classical RK formulation and Butcher's reformulation
         that leads to a denser mass matrix with block-diagonal stiffness.
         Some choices of function will assume that `butch.A` is invertible.
     :kwarg aux_indices: a list of field indices to be discretized as :class:`TimeDerivative`,
-        analogouos to :class:`ContinouosPetrovGalerkinTimeStepper`.
+        analogous to :class:`ContinouosPetrovGalerkinTimeStepper`.
 
     :returns: a 2-tuple of
        - `Fnew`, the :class:`Form`

--- a/irksome/stage_derivative.py
+++ b/irksome/stage_derivative.py
@@ -18,35 +18,36 @@ def getForm(F, butch, t, dt, u0, stages, bcs=None, bc_type=None, splitting=AI, a
     """Given a time-dependent variational form and a
     :class:`ButcherTableau`, produce UFL for the s-stage RK method.
 
-    :arg F: UFL form for the semidiscrete ODE/DAE
+    :arg F: a :class:`ufl.Form` instance describing the semi-discrete problem.
     :arg butch: the :class:`ButcherTableau` for the RK method being used to
          advance in time.
-    :arg t: a :class:`Function` on the Real space over the same mesh as
-         `u0`.  This serves as a variable referring to the current time.
-    :arg dt: a :class:`Function` on the Real space over the same mesh as
-         `u0`.  This serves as a variable referring to the current time step.
-         The user may adjust this value between time steps.
+    :arg t: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as ``u0``.  This serves as
+        a variable referring to the current time.
+    :arg dt: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as ``u0``.  This serves as
+        a variable referring to the current time step size.
     :arg u0: a :class:`Function` referring to the state of
-         the PDE system at time `t`
+        the PDE system at time `t`
     :arg stages: a :class:`Function` representing the stages to be solved for.
     :kwarg bcs: optionally, a :class:`DirichletBC` or :class:`EquationBC`
-         object (or iterable thereof) containing (possibly time-dependent)
-         boundary conditions imposed on the system.
+        object (or iterable thereof) containing (possibly time-dependent)
+        boundary conditions imposed on the system.
     :kwarg bc_type: How to manipulate the strongly-enforced boundary
-         conditions to derive the stage boundary conditions.  Should
-         be a string, either "DAE", which implements BCs as
-         constraints in the style of a differential-algebraic
-         equation, or "ODE", which takes the time derivative of the
-         boundary data and evaluates this for the stage values.
-         Support for `firedrake.EquationBC` in `bcs` is limited
-         to DAE style BCs.
+        conditions to derive the stage boundary conditions.  Should
+        be a string, either "DAE", which implements BCs as
+        constraints in the style of a differential-algebraic
+        equation, or "ODE", which takes the time derivative of the
+        boundary data and evaluates this for the stage values.
+        Support for `firedrake.EquationBC` in `bcs` is limited
+        to DAE style BCs.
     :kwarg splitting: a callable that maps the (floating point) Butcher matrix
-         a to a pair of matrices `A1, A2` such that `butch.A = A1 A2`.  This is used
-         to vary between the classical RK formulation and Butcher's reformulation
-         that leads to a denser mass matrix with block-diagonal stiffness.
-         Some choices of function will assume that `butch.A` is invertible.
+        a to a pair of matrices `A1, A2` such that `butch.A = A1 A2`.  This is used
+        to vary between the classical RK formulation and Butcher's reformulation
+        that leads to a denser mass matrix with block-diagonal stiffness.
+        Some choices of function will assume that `butch.A` is invertible.
     :kwarg aux_indices: a list of field indices to be discretized as :class:`TimeDerivative`,
-         analogouos to :class:`ContinouosPetrovGalerkinTimeStepper`.
+        analogouos to :class:`ContinouosPetrovGalerkinTimeStepper`.
 
     :returns: a 2-tuple of
        - `Fnew`, the :class:`Form`
@@ -151,45 +152,38 @@ class StageDerivativeTimeStepper(StageCoupledTimeStepper):
     """Front-end class for advancing a time-dependent PDE via a Runge-Kutta
     method formulated in terms of stage derivatives.
 
-    :arg F: A :class:`ufl.Form` instance describing the semi-discrete problem
-            F(t, u; v) == 0, where `u` is the unknown
-            :class:`firedrake.Function and `v` is the
-            :class:firedrake.TestFunction`.
+    :arg F: a :class:`ufl.Form` instance describing the semi-discrete problem.
     :arg butcher_tableau: A :class:`ButcherTableau` instance giving
-            the Runge-Kutta method to be used for time marching.
-    :arg t: a :class:`Function` on the Real space over the same mesh as
-         `u0`.  This serves as a variable referring to the current time.
-    :arg dt: a :class:`Function` on the Real space over the same mesh as
-         `u0`.  This serves as a variable referring to the current time step.
-         The user may adjust this value between time steps.
+        the Runge-Kutta method to be used for time marching.
+    :arg t: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as ``u0``.  This serves as
+        a variable referring to the current time.
+    :arg dt: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as ``u0``.  This serves as
+        a variable referring to the current time step size.
     :arg u0: A :class:`firedrake.Function` containing the current
-            state of the problem to be solved.
-    :arg bcs: An iterable of :class:`firedrake.DirichletBC` or :class:`EquationBC`
-            containing the strongly-enforced boundary conditions.  Irksome will
-            manipulate these to obtain boundary conditions for each
-            stage of the RK method.
+        state of the problem to be solved.
+    :arg bcs: An iterable of :class:`firedrake.DirichletBC` or :class:`firedrake.EquationBC`
+        containing the strongly-enforced boundary conditions.  Irksome will
+        manipulate these to obtain boundary conditions for each
+        stage of the RK method.
     :arg bc_type: How to manipulate the strongly-enforced boundary
-            conditions to derive the stage boundary conditions.
-            Should be a string, either "DAE", which implements BCs as
-            constraints in the style of a differential-algebraic
-            equation, or "ODE", which takes the time derivative of the
-            boundary data and evaluates this for the stage values.
-            Support for `firedrake.EquationBC` in `bcs` is limited
-            to DAE style BCs.
+        conditions to derive the stage boundary conditions.
+        Should be a string, either "DAE", which implements BCs as
+        constraints in the style of a differential-algebraic
+        equation, or "ODE", which takes the time derivative of the
+        boundary data and evaluates this for the stage values.
+        Support for :class:`firedrake.EquationBC` in `bcs` is limited
+        to DAE style BCs.
     :arg solver_parameters: A :class:`dict` of solver parameters that
-            will be used in solving the algebraic problem associated
-            with each time step.
+        will be used in solving the algebraic problem associated
+        with each time step.
     :arg splitting: An callable used to factor the Butcher matrix
     :arg appctx: An optional :class:`dict` containing application context.
-            This gets included with particular things that Irksome will
-            pass into the nonlinear solver so that, say, user-defined preconditioners
-            have access to it.
-    :arg nullspace: A list of tuples of the form (index, VSB) where
-            index is an index into the function space associated with
-            `u` and VSB is a :class: `firedrake.VectorSpaceBasis`
-            instance to be passed to a
-            `firedrake.MixedVectorSpaceBasis` over the larger space
-            associated with the Runge-Kutta method
+        This gets included with particular things that Irksome will
+        pass into the nonlinear solver so that, say, user-defined preconditioners
+        have access to it.
+    :arg nullspace: An optional nullspace object.
     """
     def __init__(self, F, butcher_tableau, t, dt, u0, bcs=None,
                  solver_parameters=None, splitting=AI,
@@ -240,56 +234,48 @@ class AdaptiveTimeStepper(StageDerivativeTimeStepper):
     """Front-end class for advancing a time-dependent PDE via an adaptive
     Runge-Kutta method.
 
-    :arg F: A :class:`ufl.Form` instance describing the semi-discrete problem
-            F(t, u; v) == 0, where `u` is the unknown
-            :class:`firedrake.Function and `v` is the
-            :class:firedrake.TestFunction`.
+    :arg F: a :class:`ufl.Form` instance describing the semi-discrete problem.
     :arg butcher_tableau: A :class:`ButcherTableau` instance giving
-            the Runge-Kutta method to be used for time marching.
-    :arg t: A :class:`firedrake.Constant` instance that always
-            contains the time value at the beginning of a time step
-    :arg dt: A :class:`firedrake.Constant` containing the size of the
-            current time step.  The user may adjust this value between
-            time steps; however, note that the adaptive time step
-            controls may adjust this before the step is taken.
+        the Runge-Kutta method to be used for time marching.
+    :arg t: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as `u0`.  This serves as
+        a variable referring to the current time.
+    :arg dt: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as `u0`.  This serves as
+        a variable referring to the current time step size.
     :arg u0: A :class:`firedrake.Function` containing the current
-            state of the problem to be solved.
+        state of the problem to be solved.
     :arg tol: The temporal truncation error tolerance
     :arg dtmin: Minimal acceptable time step.  An exception is raised
-            if the step size drops below this threshhold.
+        if the step size drops below this threshhold.
     :arg dtmax: Maximal acceptable time step, imposed as a hard cap;
-            this can be adjusted externally once the time-stepper is
-            instantiated, by modifying `stepper.dt_max`
+        this can be adjusted externally once the time-stepper is
+        instantiated, by modifying `stepper.dt_max`
     :arg KI: Integration gain for step-size controller.  Should be less
-            than 1/p, where p is the expected order of the scheme.  Larger
-            values lead to faster (attempted) increases in time-step size
-            when steps are accepted.  See Gustafsson, Lundh, and Soderlind,
-            BIT 1988.
+        than 1/p, where p is the expected order of the scheme.  Larger
+        values lead to faster (attempted) increases in time-step size
+        when steps are accepted.  See Gustafsson, Lundh, and Soderlind,
+        BIT 1988.
     :arg KP: Proportional gain for step-size controller. Controls dependence
-            on ratio of (error estimate)/(step size) in determining new
-            time-step size when steps are accepted.  See Gustafsson, Lundh,
-            and Soderlind, BIT 1988.
+        on ratio of (error estimate)/(step size) in determining new
+        time-step size when steps are accepted.  See Gustafsson, Lundh,
+        and Soderlind, BIT 1988.
     :arg max_reject: Maximum number of rejected timesteps in a row that
-            does not lead to a failure
+        does not lead to a failure
     :arg onscale_factor: Allowable tolerance in determining initial
-            timestep to be "on scale"
+        timestep to be "on scale"
     :arg safety_factor: Safety factor used when shrinking timestep if
-            a proposed step is rejected
+        a proposed step is rejected
     :arg gamma0_params: Solver parameters for mass matrix solve when using
-            an embedded scheme with explicit first stage
+        an embedded scheme with explicit first stage
     :arg bcs: An iterable of :class:`firedrake.DirichletBC` or :class:`EquationBC`
-            containing the strongly-enforced boundary conditions.  Irksome will
-            manipulate these to obtain boundary conditions for each
-            stage of the RK method.
+        containing the strongly-enforced boundary conditions.  Irksome will
+        manipulate these to obtain boundary conditions for each
+        stage of the RK method.
     :arg solver_parameters: A :class:`dict` of solver parameters that
-            will be used in solving the algebraic problem associated
-            with each time step.
-    :arg nullspace: A list of tuples of the form (index, VSB) where
-            index is an index into the function space associated with
-            `u` and VSB is a :class: `firedrake.VectorSpaceBasis`
-            instance to be passed to a
-            `firedrake.MixedVectorSpaceBasis` over the larger space
-            associated with the Runge-Kutta method
+        will be used in solving the algebraic problem associated
+        with each time step.
+    :arg nullspace: An optional nullspace object.
     """
     def __init__(self, F, butcher_tableau, t, dt, u0,
                  bcs=None, appctx=None, solver_parameters=None,

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -37,35 +37,37 @@ def getFormStage(F, butch, t, dt, u0, stages, bcs=None, splitting=AI, vandermond
     """Given a time-dependent variational form and a
     :class:`ButcherTableau`, produce UFL for the s-stage RK method.
 
-    :arg F: UFL form for the semidiscrete ODE/DAE
+    :arg F: a :class:`ufl.Form` instance describing the semi-discrete problem.
     :arg butch: the :class:`ButcherTableau` for the RK method being used to
-         advance in time.
-    :arg t: a :class:`Function` on the Real space over the same mesh as
-         `u0`.  This serves as a variable referring to the current time.
-    :arg dt: a :class:`Function` on the Real space over the same mesh as
-         `u0`.  This serves as a variable referring to the current time step.
-         The user may adjust this value between time steps.
+        advance in time.
+    :arg t: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as `u0`.  This serves as
+        a variable referring to the current time.
+    :arg dt: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as `u0`.  This serves as
+        a variable referring to the current time step size.
+        The user may adjust this value between time steps.
     :arg u0: a :class:`Function` referring to the state of
-         the PDE system at time `t`
+        the PDE system at time `t`
     :arg stages: a :class:`Function` representing the stages to be solved for.
-         It lives in a :class:`firedrake.FunctionSpace` corresponding to the
-         s-way tensor product of the space on which the semidiscrete
-         form lives.
+        It lives in a :class:`firedrake.FunctionSpace` corresponding to the
+        s-way tensor product of the space on which the semidiscrete
+        form lives.
     :kwarg bcs: optionally, a :class:`DirichletBC` object (or iterable thereof)
-         containing (possibly time-dependent) boundary conditions imposed
-         on the system.
+        containing (possibly time-dependent) boundary conditions imposed
+        on the system.
     :kwarg splitting: a callable that maps the (floating point) Butcher matrix
-         a to a pair of matrices `A1, A2` such that `butch.A = A1 A2`.  This is used
-         to vary between the classical RK formulation and Butcher's reformulation
-         that leads to a denser mass matrix with block-diagonal stiffness.
-         Only `AI` and `IA` are currently supported.
+        a to a pair of matrices `A1, A2` such that `butch.A = A1 A2`.  This is used
+        to vary between the classical RK formulation and Butcher's reformulation
+        that leads to a denser mass matrix with block-diagonal stiffness.
+        Only `AI` and `IA` are currently supported.
     :kwarg vandermonde: a numpy array encoding a change of basis to the Lagrange
-         polynomials associated with the collocation nodes from some other
-         (e.g. Bernstein or Chebyshev) basis.  This allows us to solve for the
-         coefficients in some basis rather than the values at particular stages,
-         which can be useful for satisfying bounds constraints.
-         If none is provided, we assume it is the identity, working in the
-         Lagrange basis.
+        polynomials associated with the collocation nodes from some other
+        (e.g. Bernstein or Chebyshev) basis.  This allows us to solve for the
+        coefficients in some basis rather than the values at particular stages,
+        which can be useful for satisfying bounds constraints.
+        If none is provided, we assume it is the identity, working in the
+        Lagrange basis.
     :kwarg aux_indices: a list of field indices, currently ignored.
 
     :returns: a 2-tuple of

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -53,55 +53,59 @@ def TimeStepper(F, method, t, dt, u0, **kwargs):
        appropriate class.
 
     :arg F: A :class:`ufl.Form` instance describing the semi-discrete problem
-            F(t, u; v) == 0, where `u` is the unknown
-            :class:`firedrake.Function and `v` iss the
-            :class:firedrake.TestFunction`.
+        ``F(t, u; v) == 0``, where ``u`` is the unknown
+        :class:`firedrake.Function` and ``v`` is the
+        :class:`firedrake.TestFunction`. To specify a linear problem,
+        ``F`` must be of the form ``a(t; w, v) - L(t; v)``, where
+        ``w`` is a :class:`firedrake.TrialFunction`.
     :arg method: A :class:`ButcherTableau` instance (for RK methods) or
-            a :class:`GalerkinScheme` instance (for CPG or DG) methods
-            to be used in time marching.
-    :arg t: a :class:`Function` on the Real space over the same mesh as
-         `u0`.  This serves as a variable referring to the current time.
-    :arg dt: a :class:`Function` on the Real space over the same mesh as
-         `u0`.  This serves as a variable referring to the current time step.
-         The user may adjust this value between time steps.
+        a :class:`GalerkinScheme` instance (for CPG or DG) methods
+        to be used in time marching.
+    :arg t: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as ``u0``.  This serves as
+        a variable referring to the current time.
+    :arg dt: a :class:`firedrake.Constant` or :class:`firedrake.Function`
+        on the Real space over the same mesh as ``u0``.  This serves as
+        a variable referring to the current time step size.
+        The user may adjust this value between time steps.
     :arg u0: A :class:`firedrake.Function` containing the current
-            state of the problem to be solved.
-    :arg bcs: An iterable of :class:`firedrake.DirichletBC` or
-            :class: `firedrake.EquationBC` containing
-            the strongly-enforced boundary conditions.  Irksome will
-            manipulate these to obtain boundary conditions for each
-            stage of the RK method.
-    :arg nullspace: A list of tuples of the form (index, VSB) where
-            index is an index into the function space associated with
-            `u` and VSB is a :class: `firedrake.VectorSpaceBasis`
-            instance to be passed to a
-            `firedrake.MixedVectorSpaceBasis` over the larger space
-            associated with the Runge-Kutta method
-    :arg stage_type: Whether to formulate in terms of a stage
-            derivatives or stage values. Support for `firedrake.EquationBC`
-            in `bcs` is limited to the stage derivative formulation.
-    :arg splitting: An callable used to factor the Butcher matrix
-    :arg bc_type: For stage derivative formulation, how to manipulate
-            the strongly-enforced boundary conditions.
-            Support for `firedrake.EquationBC` in `bcs` is limited
-            to DAE style BCs.
-    :arg solver_parameters: A :class:`dict` of solver parameters that
-            will be used in solving the algebraic problem associated
-            with each time step.
-    :arg update_solver_parameters: A :class:`dict` of parameters for
-            inverting the mass matrix at each step (only used if
-            stage_type is "value")
-    :arg adaptive_parameters: A :class:`dict` of parameters for use with
-            adaptive time stepping (only used if stage_type is "deriv")
-    :arg use_collocation_update: An optional kwarg indicating whether to use
+        state of the problem to be solved.
+    :kwarg bcs: An iterable of :class:`firedrake.DirichletBC` or
+        :class: `firedrake.EquationBC` containing
+        the strongly-enforced boundary conditions.  Irksome will
+        manipulate these to obtain boundary conditions for each
+        stage of the RK method.
+    :kwarg constant_jacobian: A boolean flag indicating whether the Jacobian
+        does not change between time steps. If ``dt`` is updated, the Jacobian
+        may be flagged for an update via :func:`invalidate_jacobian`.
+    :kwarg nullspace: A :class:`firedrake.VectorSpaceBasis`
+        or :class:`firedrake.MixedVectorSpaceBasis` specifying a nullspace
+        over the space of ``u0``.
+    :kwarg stage_type: Whether to formulate in terms of a stage
+        derivatives or stage values. Support for :class:`firedrake.EquationBC`
+        in ``bcs`` is limited to the stage derivative formulation.
+    :kwarg splitting: A callable used to factor the Butcher matrix
+    :kwarg bc_type: For stage derivative formulation, how to manipulate
+        the strongly-enforced boundary conditions.
+        Support for :class:`firedrake.EquationBC` in ``bcs`` is limited
+        to DAE style BCs.
+    :kwarg solver_parameters: A :class:`dict` of solver parameters that
+        will be used in solving the algebraic problem associated
+        with each time step.
+    :kwarg update_solver_parameters: A :class:`dict` of parameters for
+        inverting the mass matrix at each step (only used if
+        stage_type is "value")
+    :kwarg adaptive_parameters: A :class:`dict` of parameters for use with
+        adaptive time stepping (only used if stage_type is "deriv")
+    :kwarg use_collocation_update: An optional kwarg indicating whether to use
         the terminal value of the collocation polynomial as the solution
         update. This is needed to bypass the mass matrix inversion when
         enforcing bounds constraints with an RK method that is not stiffly
         accurate. Currently, only constant-in-time boundary conditions are
         supported.
     :kwarg aux_indices: Only valid for continuous Petrov Galerkin time scheme.  It
-            specifies that some of the variables in `u0` are to be treated as
-            auxiliary, that is, discretized in the lower-order DG test space.
+        specifies that some of the variables in ``u0`` are to be treated as
+        auxiliary, that is, discretized in the lower-order DG test space.
     """
     # first pluck out the cases for Galerkin in time...
 
@@ -178,8 +182,8 @@ def TimeStepper(F, method, t, dt, u0, **kwargs):
             F, method, t, dt, u0, bcs, Fp=Fp, **base_kwargs)
     elif stage_type == "imex":
         Fimp, Fexp = imex_separation(F, kwargs.get("Fexp"), stage_type)
-        appctx = base_kwargs.get("appctx")
-        nullspace = base_kwargs.get("nullspace")
+        appctx = base_kwargs.pop("appctx", None)
+        nullspace = base_kwargs.pop("nullspace", None)
         splitting = kwargs.get("splitting", AI)
         it_solver_parameters = kwargs.get("it_solver_parameters")
         prop_solver_parameters = kwargs.get("prop_solver_parameters")
@@ -190,13 +194,13 @@ def TimeStepper(F, method, t, dt, u0, **kwargs):
             Fimp, Fexp, method, t, dt, u0, bcs,
             it_solver_parameters, prop_solver_parameters,
             splitting, appctx, nullspace,
-            num_its_initial, num_its_per_step)
+            num_its_initial, num_its_per_step, **base_kwargs)
     elif stage_type == "dirkimex":
         Fimp, Fexp = imex_separation(F, kwargs.get("Fexp"), stage_type)
-        appctx = base_kwargs.get("appctx")
-        nullspace = base_kwargs.get("nullspace")
-        solver_parameters = base_kwargs.get("solver_parameters")
+        appctx = base_kwargs.pop("appctx", None)
+        nullspace = base_kwargs.pop("nullspace", None)
+        solver_parameters = base_kwargs.pop("solver_parameters", None)
         mass_parameters = kwargs.get("mass_parameters")
         return DIRKIMEXMethod(
             Fimp, Fexp, method, t, dt, u0, bcs,
-            solver_parameters, mass_parameters, appctx, nullspace)
+            solver_parameters, mass_parameters, appctx, nullspace, **base_kwargs)

--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -9,7 +9,9 @@ from .stage_derivative import StageDerivativeTimeStepper, AdaptiveTimeStepper
 from .stage_value import StageValueTimeStepper
 from .tools import AI
 
-valid_base_kwargs = ("bcs", "form_compiler_parameters", "is_linear", "restrict", "solver_parameters",
+valid_base_kwargs = ("bcs", "form_compiler_parameters",
+                     "is_linear", "constant_jacobian",
+                     "restrict", "solver_parameters",
                      "nullspace", "transpose_nullspace", "near_nullspace",
                      "appctx", "options_prefix", "pre_apply_bcs")
 

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -1,6 +1,8 @@
 from operator import mul
 from functools import reduce
 import numpy
+
+from firedrake.fml import LabelledForm, Term
 from firedrake import VectorSpaceBasis, MixedVectorSpaceBasis
 from ufl.algorithms.analysis import extract_type
 from ufl import as_tensor
@@ -96,7 +98,12 @@ def getNullspace(V, Vbig, num_stages, nullspace):
 def replace(e, mapping):
     """A wrapper for ufl.replace that allows numpy arrays."""
     cmapping = {k: as_tensor(v) for k, v in mapping.items()}
-    return ufl_replace(e, cmapping)
+    if isinstance(e, LabelledForm):
+        enew = LabelledForm(*(Term(ufl_replace(term.form, cmapping), term.labels)
+                              for term in e.terms))
+        return enew
+    else:
+        return ufl_replace(e, cmapping)
 
 
 # Utility functions that help us refactor

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
 from firedrake import (DirichletBC, Function, FunctionSpace, SpatialCoordinate,
-                       TestFunction, UnitIntervalMesh, cos, diff, div, dx,
+                       TestFunction, TrialFunction, UnitIntervalMesh, cos, diff, div, dx,
                        errornorm, exp, grad, inner, norm, pi, solve)
 from irksome import Dt, GalerkinCollocationScheme, MeshConstant, RadauIIA, TimeStepper, StageDerivativeNystromTimeStepper
 
@@ -28,23 +28,27 @@ def heat(n, deg, scheme, **kwargs):
     bcs = DirichletBC(V, uexact, "on_boundary")
     rhs = Dt(uexact) - div(grad(uexact))
 
+    # Use a TrialFunction to test the LinearVariationalSolver interface
     v = TestFunction(V)
+    w = TrialFunction(V)
     u = Function(V)
 
-    F = (inner(Dt(u), v) * dx + inner(grad(u), grad(v)) * dx
+    F = (inner(Dt(w), v) * dx + inner(grad(w), grad(v)) * dx
          - inner(rhs, v) * dx)
 
     # Ritz projection is crucial to observe the right order of convergence
     solve(inner(grad(u - uexact), grad(v)) * dx == 0, u, bcs=bcs,
           solver_parameters=params)
 
+    # set constant_jacobian=True to optimize for the linear case
+    # NOTE dt must be constant
     stepper = TimeStepper(F, scheme, t, dt, u, bcs=bcs,
                           solver_parameters=params,
+                          constant_jacobian=True,
                           **kwargs)
 
-    while float(t) < 1.0:
-        if float(t + dt) > 1.0:
-            dt.assign(1.0 - float(t))
+    nsteps = int(np.ceil(1.0/float(dt)))
+    for step in range(nsteps):
         stepper.advance()
         t.assign(t + dt)
 

--- a/tests/test_accuracy.py
+++ b/tests/test_accuracy.py
@@ -105,18 +105,19 @@ def telegraph(n, deg, scheme, **kwargs):
     rhs = Dt(uexact, 2) + Dt(uexact) - div(grad(uexact))
 
     v = TestFunction(V)
+    w = TrialFunction(V)
     u = Function(V).interpolate(uexact)
     ut = Function(V).interpolate(diff(uexact, t))
 
-    F = (inner(Dt(Dt(u) + u), v) * dx + inner(grad(u), grad(v)) * dx
+    F = (inner(Dt(Dt(w) + w), v) * dx + inner(grad(w), grad(v)) * dx
          - inner(rhs, v) * dx)
 
     stepper = StageDerivativeNystromTimeStepper(F, scheme, t, dt, u, ut,
                                                 bcs=bcs, solver_parameters=params,
+                                                constant_jacobian=True,
                                                 **kwargs)
-    while float(t) < 1.0:
-        if float(t + dt) > 1.0:
-            dt.assign(1.0 - float(t))
+    nsteps = int(np.ceil(1.0/float(dt)))
+    for step in range(nsteps):
         stepper.advance()
         t.assign(t + dt)
 

--- a/tests/test_galerkin.py
+++ b/tests/test_galerkin.py
@@ -143,25 +143,30 @@ def test_1d_heat_homogeneous_dirichletbc(order):
     u.interpolate(uexact)
 
     v = TestFunction(V)
+    w = TrialFunction(V)
     F = (
-        inner(Dt(u), v) * dx
-        + inner(grad(u), grad(v)) * dx
+        inner(Dt(w), v) * dx
+        + inner(grad(w), grad(v)) * dx
         - inner(rhs, v) * dx
     )
-    F_GL = replace(F, {u: u_GL})
 
     sparams = {"snes_type": "ksponly", "ksp_type": "preonly", "pc_type": "lu"}
 
     scheme = ContinuousPetrovGalerkinScheme(order)
-    stepper = TimeStepper(F, scheme, t, dt, u, bcs=bcs, solver_parameters=sparams)
+    stepper = TimeStepper(F, scheme, t, dt, u, bcs=bcs,
+                          solver_parameters=sparams,
+                          constant_jacobian=True)
 
     butcher_tableau = GaussLegendre(order)
-    stepper_GL = TimeStepper(F_GL, butcher_tableau, t, dt, u_GL, bcs=bcs,
-                             solver_parameters=sparams)
+    stepper_GL = TimeStepper(F, butcher_tableau, t, dt, u_GL, bcs=bcs,
+                             solver_parameters=sparams,
+                             constant_jacobian=True)
 
     t_end = 1.0
     while float(t) < t_end:
         if float(t + dt) > t_end:
+            stepper.invalidate_jacobian()
+            stepper_GL.invalidate_jacobian()
             dt.assign(t_end - t)
         stepper.advance()
         stepper_GL.advance()

--- a/tests/test_imex.py
+++ b/tests/test_imex.py
@@ -1,6 +1,4 @@
 import numpy as np
-
-import numpy as np
 import pytest
 from firedrake import *
 from irksome import Dt, MeshConstant, TimeStepper, ARS_DIRK_IMEX, SSPK_DIRK_IMEX

--- a/tests/test_imex.py
+++ b/tests/test_imex.py
@@ -1,5 +1,6 @@
 from math import isclose
 
+import numpy as np
 import pytest
 from firedrake import *
 from irksome import Dt, MeshConstant, TimeStepper, ARS_DIRK_IMEX, SSPK_DIRK_IMEX
@@ -101,9 +102,10 @@ def heat_dirichletbc(butcher_tableau):
     u = Function(V)
     u.interpolate(uexact)
     v = TestFunction(V)
+    w = TrialFunction(V)
     F = (
-        inner(Dt(u), v) * dx
-        + inner(grad(u), grad(v)) * dx
+        inner(Dt(w), v) * dx
+        + inner(grad(w), grad(v)) * dx
     )
     Fexp = -inner(rhs, v) * dx
 
@@ -117,13 +119,15 @@ def heat_dirichletbc(butcher_tableau):
     stepper = TimeStepper(
         F, butcher_tableau, t, dt, u, Fexp=Fexp, bcs=bc,
         solver_parameters=luparams, mass_parameters=luparams,
-        stage_type="dirkimex"
+        stage_type="dirkimex",
+        constant_jacobian=True,
     )
 
     t_end = 2.0
     while float(t) < t_end:
         print("Current time: ", float(t))
         if float(t) + float(dt) > t_end:
+            stepper.invalidate_jacobian()
             dt.assign(t_end - float(t))
         stepper.advance()
         t.assign(float(t) + float(dt))

--- a/tests/test_pc.py
+++ b/tests/test_pc.py
@@ -261,8 +261,8 @@ def test_stokes_augmented_lagrangian_preconditioner(family, order):
     sparams = {
         "mat_type": "matfree",
         "pmat_type": "aij",
-        "snes_type": "ksponly",
         "ksp_max_it": 15,
+        "ksp_rtol": 1E-5,
         "ksp_view_eigenvalues": None,
         "ksp_converged_reason": None,
         "pc_factor_mat_solver_type": "mumps",

--- a/tests/test_pc.py
+++ b/tests/test_pc.py
@@ -229,8 +229,11 @@ def test_stokes_augmented_lagrangian_preconditioner(family, order):
     p_rhs = -div(uexact)
 
     z = Function(Z)
+
+    # Use a TrialFunction to test the LinearVariationalSolver interface
+    ztrial = TrialFunction(Z)
     ztest = TestFunction(Z)
-    u, p = split(z)
+    u, p = split(ztrial)
     v, q = split(ztest)
 
     scheme = family(order)
@@ -259,7 +262,6 @@ def test_stokes_augmented_lagrangian_preconditioner(family, order):
         "mat_type": "matfree",
         "pmat_type": "aij",
         "snes_type": "ksponly",
-        "snes_lag_jacobian": -2,
         "ksp_max_it": 15,
         "ksp_view_eigenvalues": None,
         "ksp_converged_reason": None,
@@ -275,7 +277,9 @@ def test_stokes_augmented_lagrangian_preconditioner(family, order):
         sparams["pc_type"] = "lu"
 
     stepper = TimeStepper(F, scheme, t, dt, z,
-                          bcs=bcs, Fp=Fp, solver_parameters=sparams)
+                          bcs=bcs, Fp=Fp,
+                          solver_parameters=sparams,
+                          constant_jacobian=True)
 
     ksp = stepper.solver.snes.ksp
     u, p = z.subfunctions

--- a/tests/test_stokes.py
+++ b/tests/test_stokes.py
@@ -1,6 +1,6 @@
 import pytest
 from firedrake import *
-from irksome import Dt, LobattoIIIC, MeshConstant, RadauIIA, TimeStepper
+from irksome import Dt, LobattoIIIC, RadauIIA, TimeStepper
 from irksome import DiscontinuousGalerkinScheme
 from irksome.tools import AI, IA
 
@@ -15,14 +15,12 @@ def StokesTest(N, scheme, **kwargs):
     mh = MeshHierarchy(mesh0, 2)
     mesh = mh[-1]
 
-    Ve = VectorElement("CG", mesh.ufl_cell(), 2)
-    Pe = FiniteElement("CG", mesh.ufl_cell(), 1)
-    Ze = MixedElement([Ve, Pe])
-    Z = FunctionSpace(mesh, Ze)
+    V = VectorFunctionSpace(mesh, "CG", 2)
+    Q = FunctionSpace(mesh, "CG", 1)
+    Z = V * Q
 
-    MC = MeshConstant(mesh)
-    t = MC.Constant(0.0)
-    dt = MC.Constant(1.0/N)
+    t = Constant(0.0)
+    dt = Constant(1.0/N)
     (x, y) = SpatialCoordinate(mesh)
 
     uexact = as_vector([x*t + y**2, -y*t+t*(x**2)])
@@ -32,13 +30,12 @@ def StokesTest(N, scheme, **kwargs):
     p_rhs = -div(uexact)
 
     z = Function(Z)
-    test_z = TestFunction(Z)
-    (u, p) = split(z)
-    (v, q) = split(test_z)
+    (u, p) = TrialFunctions(Z)
+    (v, q) = TestFunctions(Z)
     F = (inner(Dt(u), v)*dx
          + inner(grad(u), grad(v))*dx
          - inner(p, div(v))*dx
-         - inner(q, div(u))*dx
+         - inner(div(u), q)*dx
          - inner(u_rhs, v)*dx
          - inner(p_rhs, q)*dx)
 
@@ -53,7 +50,6 @@ def StokesTest(N, scheme, **kwargs):
     ind_pressure = ",".join([str(2*i+1) for i in range(ns)])
     solver_params = {
         "mat_type": "aij",
-        "snes_type": "ksponly",
         "ksp_type": "fgmres",
         "ksp_max_it": 200,
         "ksp_gmres_restart": 30,
@@ -81,10 +77,13 @@ def StokesTest(N, scheme, **kwargs):
 
     stepper = TimeStepper(F, scheme, t, dt, z,
                           bcs=bcs, solver_parameters=solver_params,
-                          nullspace=nsp, **kwargs)
+                          nullspace=nsp,
+                          constant_jacobian=True,
+                          **kwargs)
 
     while (float(t) < 1.0):
         if (float(t) + float(dt) > 1.0):
+            stepper.invalidate_jacobian()
             dt.assign(1.0 - float(t))
         stepper.advance()
         t.assign(float(t) + float(dt))
@@ -120,8 +119,8 @@ def NSETest(scheme, **kwargs):
     F = (inner(Dt(u), v) * dx
          + 1.0 / Re * inner(grad(u), grad(v)) * dx
          + inner(dot(grad(u), u), v) * dx
-         - p * div(v) * dx
-         + div(u) * q * dx
+         - inner(p, div(v)) * dx
+         + inner(div(u), q) * dx
          )
 
     bcs = [DirichletBC(Z.sub(0), Constant((1, 0)), (4,)),
@@ -164,9 +163,8 @@ def NSETest(scheme, **kwargs):
         },
     }
 
-    MC = MeshConstant(M)
-    t = MC.Constant(0.0)
-    dt = MC.Constant(1.0/N)
+    t = Constant(0.0)
+    dt = Constant(1.0/N)
     stepper = TimeStepper(F, scheme,
                           t, dt, up,
                           bcs=bcs,


### PR DESCRIPTION
Enables `TimeStepper(F, ...)` to take in bilinear forms `F = a(t; w, v) - L(t; v)` and to internally use a `LinearVariationalProblem/Solver`. Also adds the kwarg `constant_jacobian=True`, as an alternative to `snes_lag_jacobian -2` solver option.