### PR TITLE
Clean up some tests

### DIFF
--- a/tests/test_dirichletbc.py
+++ b/tests/test_dirichletbc.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 from firedrake import *
 from irksome import LobattoIIIA, GaussLegendre, Dt, MeshConstant, TimeStepper
 
@@ -54,8 +53,7 @@ def test_1d_heat_dirichletbc(butcher_tableau, stage_type):
         F, butcher_tableau, t, dt, u, bcs=bc, solver_parameters=luparams, bc_type="ODE"
     )
 
-    eval_at_pts = PointEvaluator(msh, [x0, x1]).evaluate
-    expected = [float(u_0), float(u_1)]
+    bnd_error = inner(u-uexact, u-uexact) * ds
     t_end = 2.0
     while float(t) < t_end:
         if float(t) + float(dt) > t_end:
@@ -63,5 +61,5 @@ def test_1d_heat_dirichletbc(butcher_tableau, stage_type):
         stepper.advance()
         t.assign(float(t) + float(dt))
         # Check solution and boundary values
-        assert norm(u - uexact) / norm(uexact) < 10.0 ** -5
-        assert np.allclose(eval_at_pts(u), expected)
+        assert errornorm(uexact, u) / norm(uexact) < 1e-5
+        assert abs(assemble(bnd_error)) ** 0.5 < 1e-12

--- a/tests/test_dirk.py
+++ b/tests/test_dirk.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 from firedrake import *
 from irksome import WSODIRK, Alexander, Dt, MeshConstant, TimeStepper
 from ufl import replace
@@ -9,6 +8,7 @@ wsodirks = [WSODIRK(*x) for x in ((4, 3, 2), (4, 3, 3))]
 
 @pytest.mark.parametrize("butcher_tableau", [Alexander()] + wsodirks)
 def test_1d_heat_dirichletbc(butcher_tableau):
+
     # Boundary values
     u_0 = Constant(2.0)
     u_1 = Constant(3.0)
@@ -56,8 +56,7 @@ def test_1d_heat_dirichletbc(butcher_tableau):
         stage_type="dirk"
     )
 
-    eval_at_pts = PointEvaluator(msh, [x0, x1]).evaluate
-    expected = [float(u_0), float(u_1)]
+    bnd_error = inner(u-uexact, u-uexact) * ds
     t_end = 2.0
     while float(t) < t_end:
         if float(t) + float(dt) > t_end:
@@ -65,8 +64,8 @@ def test_1d_heat_dirichletbc(butcher_tableau):
         stepper.advance()
         t.assign(float(t) + float(dt))
         # Check solution and boundary values
-        assert errornorm(uexact, u) / norm(uexact) < 10.0 ** -3
-        assert np.allclose(eval_at_pts(u), expected)
+        assert errornorm(uexact, u) / norm(uexact) < 1e-3
+        assert abs(assemble(bnd_error)) ** 0.5 < 1e-12
 
 
 @pytest.mark.parametrize("butcher_tableau", [Alexander()] + wsodirks)

--- a/tests/test_disc_galerkin.py
+++ b/tests/test_disc_galerkin.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 from firedrake import *
 from irksome import Dt, MeshConstant, TimeStepper, DiscontinuousGalerkinScheme, RadauIIA
 
@@ -7,6 +6,7 @@ from irksome import Dt, MeshConstant, TimeStepper, DiscontinuousGalerkinScheme, 
 @pytest.mark.parametrize("order", [0, 1, 2])
 @pytest.mark.parametrize("basis_type", ["Lagrange", "Bernstein", "spectral", "integral"])
 def test_1d_heat_dirichletbc(order, basis_type):
+
     # Boundary values
     u_0 = Constant(2.0)
     u_1 = Constant(3.0)
@@ -51,8 +51,7 @@ def test_1d_heat_dirichletbc(order, basis_type):
     scheme = DiscontinuousGalerkinScheme(order, basis_type)
     stepper = TimeStepper(F, scheme, t, dt, u, bcs=bcs, solver_parameters=sparams)
 
-    eval_at_pts = PointEvaluator(msh, [x0, x1]).evaluate
-    expected = [float(u_0), float(u_1)]
+    bnd_error = inner(u-uexact, u-uexact) * ds
     t_end = 2.0
     while float(t) < t_end:
         if float(t) + float(dt) > t_end:
@@ -60,8 +59,8 @@ def test_1d_heat_dirichletbc(order, basis_type):
         stepper.advance()
         t.assign(float(t) + float(dt))
         # Check solution and boundary values
-        assert errornorm(uexact, u) / norm(uexact) < 10.0 ** -3
-        assert np.allclose(eval_at_pts(u), expected)
+        assert errornorm(uexact, u) / norm(uexact) < 1e-3
+        assert abs(assemble(bnd_error)) ** 0.5 < 1e-12
 
 
 @pytest.mark.parametrize("order", [0, 1, 2])

--- a/tests/test_equationbc.py
+++ b/tests/test_equationbc.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 from firedrake import *
 from irksome import GaussLegendre, RadauIIA, Dt, MeshConstant, TimeStepper
 
@@ -54,8 +53,7 @@ def test_1d_heat_equationbc(butcher_tableau, stage_type):
         F, butcher_tableau, t, dt, u, bcs=bc, solver_parameters=luparams, bc_type="DAE"
     )
 
-    eval_at_pts = PointEvaluator(msh, [x0, x1]).evaluate
-    expected = [float(u_0), float(u_1)]
+    bnd_error = inner(u-uexact, u-uexact) * ds
     t_end = 2.0
     while float(t) < t_end:
         if float(t) + float(dt) > t_end:
@@ -64,7 +62,7 @@ def test_1d_heat_equationbc(butcher_tableau, stage_type):
         t.assign(float(t) + float(dt))
         # Check solution and boundary values
         assert norm(u - uexact) / norm(uexact) < 1e-5
-        assert np.allclose(eval_at_pts(u), expected)
+        assert abs(assemble(bnd_error)) ** 0.5 < 1e-12
 
 
 @pytest.mark.parametrize("stage_type", ["deriv"])

--- a/tests/test_explicit.py
+++ b/tests/test_explicit.py
@@ -1,5 +1,4 @@
 import pytest
-import numpy as np
 from firedrake import *
 from irksome import PEPRK, Dt, MeshConstant, TimeStepper, SSPButcherTableau
 
@@ -17,6 +16,7 @@ id_list = ["PEP(4,2,5)", "PEP(5,2,6)", "SSP(2,2)", "SSP(2,3)", "SSP(3,3)"]
 # actually sensible!
 @pytest.mark.parametrize("butcher_tableau", bt_list, ids=id_list)
 def test_1d_heat_dirichletbc(butcher_tableau):
+
     # Boundary values
     u_0 = Constant(2.0)
     u_1 = Constant(3.0)
@@ -64,8 +64,7 @@ def test_1d_heat_dirichletbc(butcher_tableau):
         stage_type="explicit"
     )
 
-    eval_at_pts = PointEvaluator(msh, [x0, x1]).evaluate
-    expected = [float(u_0), float(u_1)]
+    bnd_error = inner(u-uexact, u-uexact) * ds
     t_end = 2.0
     while float(t) < t_end:
         if float(t) + float(dt) > t_end:
@@ -73,5 +72,5 @@ def test_1d_heat_dirichletbc(butcher_tableau):
         stepper.advance()
         t.assign(float(t) + float(dt))
         # Check solution and boundary values
-        assert errornorm(uexact, u) / norm(uexact) < 10.0 ** -3
-        assert np.allclose(eval_at_pts(u), expected)
+        assert errornorm(uexact, u) / norm(uexact) < 1e-3
+        assert abs(assemble(bnd_error)) ** 0.5 < 1e-12

--- a/tests/test_galerkin.py
+++ b/tests/test_galerkin.py
@@ -49,8 +49,7 @@ def run_1d_heat_dirichletbc(scheme, **kwargs):
 
     stepper = TimeStepper(F, scheme, t, dt, u, bcs=bcs, solver_parameters=sparams, **kwargs)
 
-    eval_at_pts = PointEvaluator(msh, [x0, x1]).evaluate
-    expected = [float(u_0), float(u_1)]
+    bnd_error = inner(u-uexact, u-uexact) * ds
     t_end = 2.0
     while float(t) < t_end:
         if float(t) + float(dt) > t_end:
@@ -58,8 +57,8 @@ def run_1d_heat_dirichletbc(scheme, **kwargs):
         stepper.advance()
         t += dt
         # Check solution and boundary values
-        assert errornorm(uexact, u) / norm(uexact) < 10.0 ** -3
-        assert np.allclose(eval_at_pts(u), expected)
+        assert errornorm(uexact, u) / norm(uexact) < 1e-3
+        assert abs(assemble(bnd_error)) ** 0.5 < 1e-12
 
 
 @pytest.mark.parametrize("quad_degree", [None, "auto"])

--- a/tests/test_imex.py
+++ b/tests/test_imex.py
@@ -120,8 +120,7 @@ def heat_dirichletbc(butcher_tableau):
         stage_type="dirkimex"
     )
 
-    eval_at_pts = PointEvaluator(msh, [x0, x1]).evaluate
-    expected = [float(u_0), float(u_1)]
+    bnd_error = inner(u-uexact, u-uexact) * ds
     t_end = 2.0
     while float(t) < t_end:
         print("Current time: ", float(t))
@@ -130,8 +129,8 @@ def heat_dirichletbc(butcher_tableau):
         stepper.advance()
         t.assign(float(t) + float(dt))
         # Check solution and boundary values
-        assert errornorm(uexact, u) / norm(uexact) < 10.0 ** -3
-        assert np.allclose(eval_at_pts(u), expected)
+        assert errornorm(uexact, u) / norm(uexact) < 1e-3
+        assert abs(assemble(bnd_error)) ** 0.5 < 1e-12
 
 
 # Note that ARS_DIRK_IMEX(1,1,1), ARS_DIRK_IMEX(2, 2, 2), and ARS_DIRK_IMEX(4,4,3)


### PR DESCRIPTION
Removes PointEvaluator/VertexOnlyMesh dependency to check enforcement of BCs in favour of `assemble(inner(...)*ds)`