### PR TITLE
Support for multidomain problems

### DIFF
--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -9,7 +9,7 @@ from .ufl.estimate_degrees import TimeDegreeEstimator, get_degree_mapping
 from .ufl.deriv import TimeDerivative, expand_time_derivatives
 from .ufl.manipulation import split_time_derivative_terms, remove_time_derivatives
 from .scheme import create_time_quadrature, ufc_line
-from .tools import IA, dot, reshape, replace
+from .tools import IA, dot, reshape, replace, sanitize_form
 from .constant import vecconst
 from .tableaux.ButcherTableaux import CollocationButcherTableau
 from .stage_value import getFormStage
@@ -166,6 +166,7 @@ def getFormDiscGalerkin(F, L, Qdefault, t, dt, u0, stages, bcs=None, deriv_type=
                                  max_quadrature_degree=max_quadrature_degree)
     Fnew = sum(getTermDiscGalerkin(Fcur, L, Q, t, dt, u0, stages, test, deriv_type=deriv_type)
                for Q, Fcur in splitting.items())
+    Fnew = sanitize_form(Fnew)
 
     # Oh, honey, is it the boundary conditions?
     bcsnew = []

--- a/irksome/galerkin_stepper.py
+++ b/irksome/galerkin_stepper.py
@@ -10,7 +10,7 @@ from .ufl.deriv import TimeDerivative, expand_time_derivatives
 from .ufl.estimate_degrees import TimeDegreeEstimator, get_degree_mapping
 from .labeling import split_quadrature, as_form
 from .scheme import create_time_quadrature, ufc_line
-from .tools import AI, IA, dot, fields_to_components, reshape, replace
+from .tools import AI, IA, dot, fields_to_components, reshape, replace, sanitize_form
 from .constant import vecconst
 from .discontinuous_galerkin_stepper import getElement as getTestElement
 from .integrated_lagrange import IntegratedLagrange
@@ -169,6 +169,7 @@ def getFormGalerkin(F, L_trial, L_test, Qdefault, t, dt, u0, stages, bcs=None, b
                                  max_quadrature_degree=max_quadrature_degree)
     Fnew = sum(getTermGalerkin(Fcur, L_trial, L_test, Q, t, dt, u0, stages, test, aux_indices)
                for Q, Fcur in splitting.items())
+    Fnew = sanitize_form(Fnew)
 
     # Oh, honey, is it the boundary conditions?
     V = u0.function_space()

--- a/irksome/nystrom_stepper.py
+++ b/irksome/nystrom_stepper.py
@@ -1,11 +1,11 @@
 from .base_time_stepper import StageCoupledTimeStepper
 from .bcs import BCStageData, bc2space
 from .ufl.deriv import Dt, TimeDerivative, expand_time_derivatives
-from .tools import dot, reshape, replace
+from .tools import dot, reshape, replace, sanitize_form
 from .constant import vecconst
 from firedrake import TestFunction, as_ufl
 import numpy
-from ufl import zero
+from ufl import Form
 
 
 class NystromTableau:
@@ -99,7 +99,7 @@ def getFormNystrom(F, tableau, t, dt, u0, ut0, stages,
     dtu = TimeDerivative(u0)
     dt2u = TimeDerivative(dtu)
 
-    Fnew = zero()
+    Fnew = Form([])
 
     for i in range(num_stages):
         repl = {t: t + c[i] * dt,
@@ -108,6 +108,7 @@ def getFormNystrom(F, tableau, t, dt, u0, ut0, stages,
                 dtu: ut0 + Ak[i] * dt,
                 dt2u: k_np[i]}
         Fnew += replace(F, repl)
+    Fnew = sanitize_form(Fnew)
 
     if bcs is None:
         bcs = []

--- a/irksome/stage_derivative.py
+++ b/irksome/stage_derivative.py
@@ -11,7 +11,7 @@ from FIAT.barycentric_interpolation import LagrangePolynomialSet
 from ufl.constantvalue import as_ufl
 from .tableaux.ButcherTableaux import CollocationButcherTableau
 from .constant import vecconst
-from .tools import AI, dot, replace, reshape, fields_to_components
+from .tools import AI, dot, replace, reshape, fields_to_components, sanitize_form
 from .ufl.deriv import Dt, TimeDerivative, expand_time_derivatives
 from .bcs import EmbeddedBCData, BCStageData, extract_bcs, bc2space, stage2spaces4bc
 from .ufl.manipulation import split_time_derivative_terms
@@ -105,6 +105,7 @@ def getForm(F, butch, t, dt, u0, stages, bcs=None, bc_type=None, splitting=AI, a
                    dtu: dtusub}
 
     Fnew = sum(replace(F, repl[i]) for i in range(num_stages))
+    Fnew = sanitize_form(Fnew)
 
     if bcs is None:
         bcs = []

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -12,7 +12,7 @@ from .bcs import stage2spaces4bc
 from .tableaux.ButcherTableaux import CollocationButcherTableau
 from .ufl.deriv import expand_time_derivatives
 from .ufl.manipulation import split_time_derivative_terms, remove_time_derivatives
-from .tools import AI, dot, reshape, replace
+from .tools import AI, dot, reshape, replace, sanitize_form
 from .constant import vecconst
 from .base_time_stepper import StageCoupledTimeStepper
 
@@ -130,6 +130,7 @@ def getFormStage(F, butch, t, dt, u0, stages, bcs=None, splitting=AI, vandermond
                 v: A1Tv[i] * dt,
                 u0: w_np[i]}
         Fnew += replace(F_remainder, repl)
+    Fnew = sanitize_form(Fnew)
 
     if bcs is None:
         bcs = []

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -5,6 +5,7 @@ import numpy
 from firedrake.fml import LabelledForm, Term
 from firedrake import VectorSpaceBasis, MixedVectorSpaceBasis
 from ufl.algorithms.analysis import extract_type
+from ufl.algorithms import expand_indices
 from ufl import as_tensor
 from ufl import replace as ufl_replace
 from pyop2.types import MixedDat
@@ -105,6 +106,14 @@ def getNullspace(V, Vbig, num_stages, nullspace):
         nspnew = MixedVectorSpaceBasis(Vbig, nspnew)
 
     return nspnew
+
+
+def sanitize_form(form):
+    """Simplify indexed expressions to eliminate unwanted
+       quantities on mismatching domains."""
+    if len(form.ufl_domains()) > 1:
+        form = expand_indices(form)
+    return form
 
 
 def replace(e, mapping):

--- a/tests/test_multidomain.py
+++ b/tests/test_multidomain.py
@@ -1,0 +1,37 @@
+from firedrake import *
+from irksome import GaussLegendre, Dt
+from irksome.stage_derivative import getForm
+import pytest
+
+
+@pytest.mark.parametrize("num_stages", [1, 2])
+def test_multidomain_getForm(num_stages):
+    t = Constant(0)
+    dt = Constant(0.1)
+    mesh1 = UnitSquareMesh(1, 1)
+    mesh2 = Submesh(mesh1, mesh1.topological_dimension-1, 1, label_name="exterior_facets")
+
+    V1 = FunctionSpace(mesh1, "CG", 1)
+    V2 = FunctionSpace(mesh2, "CG", 1)
+    Z = V1 * V2
+
+    z = Function(Z)
+    u1, u2 = split(z)
+    v1, v2 = TrialFunctions(Z)
+
+    dx1 = dx(mesh1)
+    dx2 = dx(mesh2)
+    dx12 = Measure("ds", domain=mesh1, intersect_measures=[dx2])
+
+    F = (inner(Dt(u1), v1) * dx1
+         + inner(Dt(u2), v2) * dx2
+         - inner(u1, v1) * dx1
+         - inner(u2, v2) * dx2
+         + inner(u1-u2, v1-v2) * dx12)
+
+    butch = GaussLegendre(num_stages)
+    Zbig = MixedFunctionSpace([Z]*num_stages)
+    stages = Function(Zbig)
+
+    Fnew, bcs = getForm(F, butch, t, dt, z, stages)
+    assemble(Fnew)

--- a/tests/test_multidomain.py
+++ b/tests/test_multidomain.py
@@ -25,8 +25,8 @@ def test_multidomain_getForm(num_stages):
 
     F = (inner(Dt(u1), v1) * dx1
          + inner(Dt(u2), v2) * dx2
-         - inner(u1, v1) * dx1
-         - inner(u2, v2) * dx2
+         + inner(u1, v1) * dx1
+         + inner(u2, v2) * dx2
          + inner(u1-u2, v1-v2) * dx12)
 
     butch = GaussLegendre(num_stages)


### PR DESCRIPTION
Suppose `u = (u0, u1) in V0 * V1` is the unknown for a mixed formulation where the function spaces `V0` and `V1` are defined on different meshes. At stage `i` we replace `u -> (A*k)[i]`, where `k[i] = (k[0][i], k[1][i])` is the component of the stage vector for stage i.

For a single-domain integral like `inner(u[0], v[0]) * dx(mesh0)`, we run into an issue when we replace `u[0] -> (A*k)[i][0]` inside the integral as `k` is defined on both `mesh0` and `mesh1`.

This PR fixes this by calling `expand_indices` which eventually does the subsitution `u[0] -> (A*k[0])[i]`, so `k[1]` no longer appears inside the `dx(mesh0)` integral.

This seems more like a Firedrake bug, so maybe we should be calling `expand_indices` early enough in the form compiler.