### PR TITLE
Lag label

### DIFF
--- a/irksome/__init__.py
+++ b/irksome/__init__.py
@@ -14,7 +14,8 @@ from .tableaux.multistep_tableaux import (
     AdamsMoulton,
 )
 from .tableaux.pep_explicit_rk import PEPRK
-from .ufl.deriv import Dt, expand_time_derivatives, lag, check_irksome_import_order
+from .ufl.deriv import Dt, expand_time_derivatives, check_irksome_import_order
+from .ufl.lag import lag
 
 check_irksome_import_order()
 

--- a/irksome/__init__.py
+++ b/irksome/__init__.py
@@ -14,7 +14,7 @@ from .tableaux.multistep_tableaux import (
     AdamsMoulton,
 )
 from .tableaux.pep_explicit_rk import PEPRK
-from .ufl.deriv import Dt, expand_time_derivatives, check_irksome_import_order
+from .ufl.deriv import Dt, expand_time_derivatives, lag, check_irksome_import_order
 
 check_irksome_import_order()
 
@@ -44,6 +44,7 @@ __all__ = [
     "expand_time_derivatives",
     "GalerkinCollocationScheme",
     "GaussLegendre",
+    "lag",
     "LobattoIIIA",
     "LobattoIIIC",
     "MeshConstant",

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -111,17 +111,17 @@ def getNullspace(V, Vbig, num_stages, nullspace):
 def replace(e, mapping):
     """A wrapper for ufl.replace that allows numpy arrays and skips
     substitution into sub-expressions wrapped by :func:`~.lag`."""
-    cmapping = {k: as_tensor(v) for k, v in mapping.items()}
     if isinstance(e, LabelledForm):
         enew = LabelledForm(*(Term(replace(term.form, cmapping), term.labels)
                               for term in e.terms))
         return enew
     else:
 
-for var in extract_type(e, Variable):
-    if var.ufl_operands[1] is lag_label:
-        cmapping.setdefault(var, var)
-return ufl_replace(e, cmapping)
+    cmapping = {k: as_tensor(v) for k, v in mapping.items()}
+    for var in extract_type(e, Variable):
+        if var.ufl_operands[1] is lag_label:
+            cmapping.setdefault(var, var)
+    return ufl_replace(e, cmapping)
 
 
 # Utility functions that help us refactor

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -112,7 +112,7 @@ def replace(e, mapping):
     """A wrapper for ufl.replace that allows numpy arrays and skips
     substitution into sub-expressions wrapped by :func:`~.lag`."""
     if isinstance(e, LabelledForm):
-        enew = LabelledForm(*(Term(replace(term.form, cmapping), term.labels)
+        enew = LabelledForm(*(Term(replace(term.form, mapping), term.labels)
                               for term in e.terms))
         return enew
     else:

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -6,7 +6,8 @@ from ufl import as_tensor, replace as ufl_replace
 
 import FIAT
 
-from .ufl.deriv import TimeDerivative, lag_label
+from .ufl.deriv import TimeDerivative
+from .ufl.lag import lag_label
 
 
 def dot(A, B):
@@ -122,7 +123,7 @@ def getNullspace(V, Vbig, num_stages, nullspace):
 
 def replace(e, mapping):
     """A wrapper for ufl.replace that allows numpy arrays and skips
-    substitution into sub-expressions wrapped by :func:`~.lag`."""
+    substitution into sub-expressions wrapped by :func:`~irksome.lag`."""
     cmapping = {k: as_tensor(v) for k, v in mapping.items()}
     for var in extract_type(e, Variable):
         if var.ufl_operands[1] is lag_label:

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -116,7 +116,7 @@ def replace(e, mapping):
         if var.ufl_operands[1] is lag_label:
             cmapping.setdefault(var, var)
     if isinstance(e, LabelledForm):
-        enew = LabelledForm(*(Term(ufl_replace(term.form, cmapping), term.labels)
+        enew = LabelledForm(*(Term(replace(term.form, cmapping), term.labels)
                               for term in e.terms))
         return enew
     else:

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -110,17 +110,17 @@ def getNullspace(V, Vbig, num_stages, nullspace):
 
 def replace(e, mapping):
     """A wrapper for ufl.replace that allows numpy arrays and skips
-    substitution into sub-expressions wrapped by :func:`lag`."""
+    substitution into sub-expressions wrapped by :func:`~.lag`."""
     cmapping = {k: as_tensor(v) for k, v in mapping.items()}
+    for var in extract_type(e, Variable):
+        if var.ufl_operands[1] is lag_label:
+            cmapping.setdefault(var, var)
     if isinstance(e, LabelledForm):
         new_terms = []
-        for term in e.terms:
-            tmap = dict(cmapping)
-            for var in extract_type(term.form, Variable):
-                if var.ufl_operands[1] is lag_label:
-                    tmap.setdefault(var, var)
-            new_terms.append(Term(ufl_replace(term.form, tmap), term.labels))
-        return LabelledForm(*new_terms)
+
+        enew = LabelledForm(*(Term(ufl_replace(term.form, cmapping), term.labels)
+                              for term in e.terms))
+        return enew
 
     for var in extract_type(e, Variable):
         if var.ufl_operands[1] is lag_label:

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -121,11 +121,8 @@ def replace(e, mapping):
         enew = LabelledForm(*(Term(ufl_replace(term.form, cmapping), term.labels)
                               for term in e.terms))
         return enew
-
-    for var in extract_type(e, Variable):
-        if var.ufl_operands[1] is lag_label:
-            cmapping.setdefault(var, var)
-    return ufl_replace(e, cmapping)
+    else:
+        return ufl_replace(e, cmapping)
 
 
 # Utility functions that help us refactor

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -115,7 +115,6 @@ def replace(e, mapping):
         enew = LabelledForm(*(Term(replace(term.form, mapping), term.labels)
                               for term in e.terms))
         return enew
-    else:
 
     cmapping = {k: as_tensor(v) for k, v in mapping.items()}
     for var in extract_type(e, Variable):

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -120,22 +120,12 @@ def getNullspace(V, Vbig, num_stages, nullspace):
 
 
 def replace(e, mapping):
-<<<<<<< lag-label
     """A wrapper for ufl.replace that allows numpy arrays and skips
     substitution into sub-expressions wrapped by :func:`~.lag`."""
-    if isinstance(e, LabelledForm):
-        enew = LabelledForm(*(Term(replace(term.form, mapping), term.labels)
-                              for term in e.terms))
-        return enew
-
     cmapping = {k: as_tensor(v) for k, v in mapping.items()}
     for var in extract_type(e, Variable):
         if var.ufl_operands[1] is lag_label:
             cmapping.setdefault(var, var)
-=======
-    """A wrapper for ufl.replace that allows numpy arrays."""
-    cmapping = {k: as_tensor(v) for k, v in mapping.items()}
->>>>>>> master
     return ufl_replace(e, cmapping)
 
 

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -116,8 +116,6 @@ def replace(e, mapping):
         if var.ufl_operands[1] is lag_label:
             cmapping.setdefault(var, var)
     if isinstance(e, LabelledForm):
-        new_terms = []
-
         enew = LabelledForm(*(Term(ufl_replace(term.form, cmapping), term.labels)
                               for term in e.terms))
         return enew

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -112,15 +112,16 @@ def replace(e, mapping):
     """A wrapper for ufl.replace that allows numpy arrays and skips
     substitution into sub-expressions wrapped by :func:`~.lag`."""
     cmapping = {k: as_tensor(v) for k, v in mapping.items()}
-    for var in extract_type(e, Variable):
-        if var.ufl_operands[1] is lag_label:
-            cmapping.setdefault(var, var)
     if isinstance(e, LabelledForm):
         enew = LabelledForm(*(Term(replace(term.form, cmapping), term.labels)
                               for term in e.terms))
         return enew
     else:
-        return ufl_replace(e, cmapping)
+
+for var in extract_type(e, Variable):
+    if var.ufl_operands[1] is lag_label:
+        cmapping.setdefault(var, var)
+return ufl_replace(e, cmapping)
 
 
 # Utility functions that help us refactor

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -7,10 +7,11 @@ from firedrake import VectorSpaceBasis, MixedVectorSpaceBasis
 from ufl.algorithms.analysis import extract_type
 from ufl import as_tensor
 from ufl import replace as ufl_replace
+from ufl.classes import Variable
 from pyop2.types import MixedDat
 import FIAT
 
-from .ufl.deriv import TimeDerivative
+from .ufl.deriv import TimeDerivative, lag_label
 
 
 def dot(A, B):
@@ -108,14 +109,23 @@ def getNullspace(V, Vbig, num_stages, nullspace):
 
 
 def replace(e, mapping):
-    """A wrapper for ufl.replace that allows numpy arrays."""
+    """A wrapper for ufl.replace that allows numpy arrays and skips
+    substitution into sub-expressions wrapped by :func:`lag`."""
     cmapping = {k: as_tensor(v) for k, v in mapping.items()}
     if isinstance(e, LabelledForm):
-        enew = LabelledForm(*(Term(ufl_replace(term.form, cmapping), term.labels)
-                              for term in e.terms))
-        return enew
-    else:
-        return ufl_replace(e, cmapping)
+        new_terms = []
+        for term in e.terms:
+            tmap = dict(cmapping)
+            for var in extract_type(term.form, Variable):
+                if var.ufl_operands[1] is lag_label:
+                    tmap.setdefault(var, var)
+            new_terms.append(Term(ufl_replace(term.form, tmap), term.labels))
+        return LabelledForm(*new_terms)
+
+    for var in extract_type(e, Variable):
+        if var.ufl_operands[1] is lag_label:
+            cmapping.setdefault(var, var)
+    return ufl_replace(e, cmapping)
 
 
 # Utility functions that help us refactor

--- a/irksome/ufl/deriv.py
+++ b/irksome/ufl/deriv.py
@@ -10,7 +10,7 @@ from ufl.algorithms.apply_derivatives import GenericDerivativeRuleset
 from ufl.algorithms.apply_algebra_lowering import apply_algebra_lowering
 from ufl.form import BaseForm
 from ufl.classes import (Argument, Coefficient, Conj, Curl, ConstantValue, Derivative,
-                         Div, Expr, Grad, Indexed, Label, ReferenceGrad,
+                         Div, Expr, Grad, Indexed, ReferenceGrad,
                          ReferenceValue, SpatialCoordinate, Variable)
 from ufl.corealg.multifunction import MultiFunction
 
@@ -83,17 +83,6 @@ def Dt(f, order=1):
     for k in range(order):
         f = TimeDerivative(f)
     return f
-
-
-# A :class:`ufl.Label` to mark nodes that are only evaluated at the start of
-# the timestep.
-lag_label = Label()
-
-
-def lag(expr):
-    """Mark a sub-expression to be evaluated only at the start of the
-    timestep during the implicit solve."""
-    return Variable(expr, lag_label)
 
 
 class TimeDerivativeRuleset(GenericDerivativeRuleset):

--- a/irksome/ufl/deriv.py
+++ b/irksome/ufl/deriv.py
@@ -10,7 +10,7 @@ from ufl.algorithms.apply_derivatives import GenericDerivativeRuleset
 from ufl.algorithms.apply_algebra_lowering import apply_algebra_lowering
 from ufl.form import BaseForm
 from ufl.classes import (Coefficient, Conj, Curl, ConstantValue, Derivative,
-                         Div, Expr, Grad, Indexed, ReferenceGrad,
+                         Div, Expr, Grad, Indexed, Label, ReferenceGrad,
                          ReferenceValue, SpatialCoordinate, Variable)
 from ufl.corealg.multifunction import MultiFunction
 
@@ -83,6 +83,17 @@ def Dt(f, order=1):
     for k in range(order):
         f = TimeDerivative(f)
     return f
+
+
+# A :class:`ufl.Label` to mark nodes that are only evaluated at the start of
+# the timestep.
+lag_label = Label()
+
+
+def lag(expr):
+    """Mark a sub-expression to be evaluated only at the start of the
+    timestep during the implicit solve."""
+    return Variable(expr, lag_label)
 
 
 class TimeDerivativeRuleset(GenericDerivativeRuleset):

--- a/irksome/ufl/lag.py
+++ b/irksome/ufl/lag.py
@@ -1,0 +1,12 @@
+from ufl.classes import Label, Variable
+
+
+# A :class:`ufl.Label` to mark nodes that are only evaluated at the start of
+# the timestep.
+lag_label = Label()
+
+
+def lag(expr):
+    """Mark a sub-expression to be evaluated only at the start of the
+    timestep during the implicit solve."""
+    return Variable(expr, lag_label)

--- a/tests/test_lag.py
+++ b/tests/test_lag.py
@@ -1,8 +1,7 @@
 import firedrake
 from firedrake import Constant, inner, grad, dx, conditional
 import irksome
-from irksome import Dt
-from irksome.ufl.deriv import lag
+from irksome import Dt, lag
 
 
 def test_stefan_implicit():

--- a/tests/test_lag.py
+++ b/tests/test_lag.py
@@ -1,5 +1,6 @@
+import pytest
 import firedrake
-from firedrake import Constant, inner, grad, dx, conditional
+from firedrake import Constant, inner, grad, dx, conditional, assemble, replace
 import irksome
 from irksome import Dt, lag
 
@@ -13,26 +14,43 @@ def test_stefan_implicit():
 
     u = firedrake.Function(V)
     u.interpolate(1 - 2 * x)
-
-    k_solid = Constant(2.0)
-    k_liquid = Constant(1.0)
-    k = lag(conditional(u < 0, k_solid, k_liquid))
-
-    v = firedrake.TestFunction(V)
-    F = (Dt(u) * v + k * inner(grad(u), grad(v))) * dx
+    u_0 = u.copy(deepcopy=True)
 
     T_1 = Constant(1.0)
     T_2 = Constant(-1.0)
     bcs = [firedrake.DirichletBC(V, T_1, 1), firedrake.DirichletBC(V, T_2, 2)]
 
+    v = firedrake.TestFunction(V)
     t = Constant(0.0)
     dt = Constant(0.1)
+    final_time = 10.0
+    num_steps = int(final_time / float(dt))
     solver_params = {"snes_type": "newtonls", "snes_converged_reason": None}
     params = {"bcs": bcs, "solver_parameters": solver_params}
     method = irksome.BackwardEuler()
+
+    k_solid = Constant(2.0)
+    k_liquid = Constant(1.0)
+
+    # Check that fully implicit form fails
+    k = conditional(u < 0, k_solid, k_liquid)
+    F = (Dt(u) * v + k * inner(grad(u), grad(v))) * dx
+    stepper = irksome.TimeStepper(F, method, t, dt, u, **params)
+    with pytest.raises(firedrake.ConvergenceError):
+        for step in range(num_steps):
+            stepper.advance()
+
+    # Check that the lagged form works
+    u.assign(u_0)
+    F = (Dt(u) * v + lag(k) * inner(grad(u), grad(v))) * dx
     stepper = irksome.TimeStepper(F, method, t, dt, u, **params)
 
-    final_time = 10.0
-    num_steps = int(final_time / float(dt))
     for step in range(num_steps):
         stepper.advance()
+
+    energy = 0.5 * u**2 * dx
+    initial_energy = assemble(replace(energy, {u: u_0}))
+    final_energy = assemble(energy)
+    print(f"Initial energy: {initial_energy}")
+    print(f"Final:          {final_energy}")
+    assert final_energy <= initial_energy

--- a/tests/test_lag.py
+++ b/tests/test_lag.py
@@ -3,8 +3,10 @@ import firedrake
 from firedrake import Constant, inner, grad, dx, conditional
 import irksome
 from irksome import Dt
+from irksome.ufl.deriv import lag
 
 
+@pytest.mark.xfail(strict=True, reason="lag not yet honored by replace")
 def test_stefan_implicit():
     """Test lagging the conductivity on the Stefan problem"""
     nx = 32
@@ -17,7 +19,7 @@ def test_stefan_implicit():
 
     k_solid = Constant(2.0)
     k_liquid = Constant(1.0)
-    k = conditional(u < 0, k_solid, k_liquid)
+    k = lag(conditional(u < 0, k_solid, k_liquid))
 
     v = firedrake.TestFunction(V)
     F = (Dt(u) * v + k * inner(grad(u), grad(v))) * dx
@@ -33,8 +35,7 @@ def test_stefan_implicit():
     method = irksome.BackwardEuler()
     stepper = irksome.TimeStepper(F, method, t, dt, u, **params)
 
-    with pytest.raises(firedrake.ConvergenceError):
-        final_time = 10.0
-        num_steps = int(final_time / float(dt))
-        for step in range(num_steps):
-            stepper.advance()
+    final_time = 10.0
+    num_steps = int(final_time / float(dt))
+    for step in range(num_steps):
+        stepper.advance()

--- a/tests/test_lag.py
+++ b/tests/test_lag.py
@@ -44,7 +44,6 @@ def test_stefan_implicit():
     u.assign(u_0)
     F = (Dt(u) * v + lag(k) * inner(grad(u), grad(v))) * dx
     stepper = irksome.TimeStepper(F, method, t, dt, u, **params)
-    
     energy = 0.5 * u**2 * dx
     initial_energy = assemble(energy)
 

--- a/tests/test_lag.py
+++ b/tests/test_lag.py
@@ -1,4 +1,3 @@
-import pytest
 import firedrake
 from firedrake import Constant, inner, grad, dx, conditional
 import irksome
@@ -6,7 +5,6 @@ from irksome import Dt
 from irksome.ufl.deriv import lag
 
 
-@pytest.mark.xfail(strict=True, reason="lag not yet honored by replace")
 def test_stefan_implicit():
     """Test lagging the conductivity on the Stefan problem"""
     nx = 32

--- a/tests/test_lag.py
+++ b/tests/test_lag.py
@@ -44,12 +44,13 @@ def test_stefan_implicit():
     u.assign(u_0)
     F = (Dt(u) * v + lag(k) * inner(grad(u), grad(v))) * dx
     stepper = irksome.TimeStepper(F, method, t, dt, u, **params)
+    
+    energy = 0.5 * u**2 * dx
+    initial_energy = assemble(energy)
 
     for step in range(num_steps):
         stepper.advance()
 
-    energy = 0.5 * u**2 * dx
-    initial_energy = assemble(replace(energy, {u: u_0}))
     final_energy = assemble(energy)
     print(f"Initial energy: {initial_energy}")
     print(f"Final:          {final_energy}")

--- a/tests/test_lag.py
+++ b/tests/test_lag.py
@@ -1,0 +1,40 @@
+import pytest
+import firedrake
+from firedrake import Constant, inner, grad, dx, conditional
+import irksome
+from irksome import Dt
+
+
+def test_stefan_implicit():
+    """Test lagging the conductivity on the Stefan problem"""
+    nx = 32
+    mesh = firedrake.UnitIntervalMesh(nx)
+    V = firedrake.FunctionSpace(mesh, "CG", 1)
+    x, = firedrake.SpatialCoordinate(mesh)
+
+    u = firedrake.Function(V)
+    u.interpolate(1 - 2 * x)
+
+    k_solid = Constant(2.0)
+    k_liquid = Constant(1.0)
+    k = conditional(u < 0, k_solid, k_liquid)
+
+    v = firedrake.TestFunction(V)
+    F = (Dt(u) * v + k * inner(grad(u), grad(v))) * dx
+
+    T_1 = Constant(1.0)
+    T_2 = Constant(-1.0)
+    bcs = [firedrake.DirichletBC(V, T_1, 1), firedrake.DirichletBC(V, T_2, 2)]
+
+    t = Constant(0.0)
+    dt = Constant(0.1)
+    solver_params = {"snes_type": "newtonls", "snes_converged_reason": None}
+    params = {"bcs": bcs, "solver_parameters": solver_params}
+    method = irksome.BackwardEuler()
+    stepper = irksome.TimeStepper(F, method, t, dt, u, **params)
+
+    with pytest.raises(firedrake.ConvergenceError):
+        final_time = 10.0
+        num_steps = int(final_time / float(dt))
+        for step in range(num_steps):
+            stepper.advance()

--- a/tests/test_lag.py
+++ b/tests/test_lag.py
@@ -1,6 +1,6 @@
 import pytest
 import firedrake
-from firedrake import Constant, inner, grad, dx, conditional, assemble, replace
+from firedrake import Constant, inner, grad, dx, conditional, assemble
 import irksome
 from irksome import Dt, lag
 


### PR DESCRIPTION
Resolves #221. This PR adds a function `lag` which labels a single expression in a form for holding back to the start of a timestep. As @pbrubeck thought, implementing it amounted to modifying `irksome.tools.replace`. I added a test based on lagging the conductivity in the Stefan problem. Without lagging, that fails because of the conditional.

In addition to giving you an escape hatch, you can use lagging to define nonlinear preconditioners. I have a demo of this for the Allen-Cahn equation coded up just using petsc4py which I think is pretty compelling. @JHopeCollins and I are working on getting AuxiliaryOperatorSNES merged into Firedrake: firedrakeproject/firedrake#5119. Once that's merged I can write an Irksome demo showing that off, either in this PR or a separate one.