### PR TITLE
DOLFINx support for StageDerivativeTimeStepper with BCs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
 
   dolfinx:
     runs-on: [ubuntu-latest]
-    container: ghcr.io/fenics/dolfinx/dolfinx:nightly
+    container: ghcr.io/fenics/dolfinx/dolfinx:stable
     steps:
     - uses: actions/checkout@v6
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,27 @@ jobs:
         run: |
           find . -delete
           firedrake-clean
+
+
+  dolfinx:
+    runs-on: [ubuntu-latest]
+    container: ghcr.io/fenics/dolfinx/dolfinx:nightly
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        # Download Irksome into a subdirectory not called 'irksome' to make sure
+        # that the package installs correctly. Otherwise 'import irksome' may
+        # work even if the installation failed because it is a subdirectory.
+        path: irksome-repo
+
+    - name: Install irksome
+      working-directory: irksome-repo
+      run: |
+        python3 -m pip install .[dolfinx]
+
+    - name: Install pyadjoint as it is used in conftest.py
+      run: python3 -m pip install pyadjoint-ad
+
+    - name: Run dolfinx tests
+      working-directory: irksome-repo/tests
+      run: python3 -m pytest -xvs test_dolfinx.py

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -32,6 +32,9 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.viewcode',
               'sphinxcontrib.bibtex']
 
+# Mock DOLFINx import
+autodoc_mock_imports = ["dolfinx", ]
+
 mathjax_path = 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML'
 
 # Both the class’ and the __init__ method’s docstring are concatenated and

--- a/irksome/backend.py
+++ b/irksome/backend.py
@@ -111,6 +111,9 @@ class Backend(Protocol):
     def get_number_of_fields(V) -> int:
         ...
 
+    def extract_subfunctions(f: ufl.Coefficient) -> Sequence[ufl.Coefficient]:
+        ...
+
 
 def get_backend(backend: str | types.ModuleType) -> Backend:
     """Get backend class from backend name.

--- a/irksome/backend.py
+++ b/irksome/backend.py
@@ -22,12 +22,9 @@ class Backend(Protocol):
         Given a function space for a single time-step, get a duplicate of this space,
         repeated `num_stages` times.
 
-        Args:
-            V: Space for single step
-            num_stages: Number of stages
-
-        Returns:
-            A coefficient in the new function space
+        :param V: Space for single step
+        :param num_stages: Number of stages
+        :returns: A coefficient in the new function space
         """
 
     class Constant:
@@ -112,11 +109,8 @@ class Backend(Protocol):
 def get_backend(backend: str | types.ModuleType) -> Backend:
     """Get backend class from backend name.
 
-    Args:
-        backend: Name of the backend to get
-
-    Returns:
-        Backend class
+    :param backend: Name of the backend to get
+    :returns: Backend class
     """
     if isinstance(backend, types.ModuleType):
         return backend

--- a/irksome/backend.py
+++ b/irksome/backend.py
@@ -105,6 +105,12 @@ class Backend(Protocol):
     def create_bounds_constrained_bc(V, g, sub_domain, bounds, solver_parameters=None) -> DirichletBC:
         ...
 
+    def getNullspace(V, Vbig, num_stages, nullspace):
+        ...
+
+    def get_number_of_fields(V) -> int:
+        ...
+
 
 def get_backend(backend: str | types.ModuleType) -> Backend:
     """Get backend class from backend name.

--- a/irksome/backend.py
+++ b/irksome/backend.py
@@ -108,12 +108,6 @@ class Backend(Protocol):
     def getNullspace(V, Vbig, num_stages, nullspace):
         ...
 
-    def get_number_of_fields(V) -> int:
-        ...
-
-    def extract_subfunctions(f: ufl.Coefficient) -> Sequence[ufl.Coefficient]:
-        ...
-
 
 def get_backend(backend: str | types.ModuleType) -> Backend:
     """Get backend class from backend name.

--- a/irksome/backends/dolfinx.py
+++ b/irksome/backends/dolfinx.py
@@ -140,16 +140,20 @@ try:
             List of (weight, function) tuples
         """
 
-        # Parse the expression
+        # Parse the expression, flattening nested Sums recursively
         if isinstance(expr, ufl.classes.Sum):
             summands = expr.ufl_operands
         else:
             summands = [expr]
         terms = []
         for summand in summands:
-            result = extract_term(summand)
-            if result is not None:
-                terms.append(result)
+            if isinstance(summand, ufl.classes.Sum):
+                # Recursively flatten nested Sum structures
+                terms.extend(extract_linear_combination(summand))
+            else:
+                result = extract_term(summand)
+                if result is not None:
+                    terms.append(result)
         return terms
 
     def function_iadd(func: "dolfinx.fem.Function", expr: ufl.core.expr.Expr) -> None:
@@ -168,10 +172,8 @@ try:
         # Extract the linear combination: [(weight1, func1), (weight2, func2), ...]
         terms = extract_linear_combination(expr)
 
-        # Add each term
+        # Add each term using array operations (works with mixed spaces when dofmaps match)
         for weight, term_func in terms:
-            if not (term_func.ufl_element() == func.ufl_element()) or not np.allclose(term_func.function_space.dofmap.list, func.function_space.dofmap.list):
-                raise ValueError(f"Function {term_func} is not compatible for addition with {func}")
             func.x.array[:] += weight * term_func.x.array[:]
 
     # Patching of DOLFINx objects to mimick firedrake naming and properties.
@@ -230,7 +232,7 @@ try:
 
     class NonlinearProblem(dolfinx.fem.petsc.NonlinearProblem):
         """Overloaded nonlinear problem that pack BCs before solving.
-        
+
         Done eac  Newton iteration or line search step by overriding the
         SNES function and Jacobian assembly routines to pack BCs before assembly.
         """
@@ -308,7 +310,7 @@ try:
         V: dolfinx.fem.FunctionSpace | None = None,
     ):
         """Overloaded DirichletBC so that we can reconstruct BCs with UFL expressions.
-        
+
         value: A UFL expression representing the boundary condition.
         dofs: An array of degree-of-freedom indices in `V` where the BC should be applied.
         V: The function space on which the BC applies. It can be a subspace of a mixed/blocked space.

--- a/irksome/backends/dolfinx.py
+++ b/irksome/backends/dolfinx.py
@@ -264,37 +264,80 @@ try:
                 jit_options=jit_options,
                 entity_maps=entity_maps,
             )
-            _vec, (current_func, args, kargs) = self.solver.getFunction()
+            self._bcs = bcs
 
             def assemble_residual(
-                    _snes: PETSc.SNES,  # type: ignore[name-defined]
-                    x: PETSc.Vec,  # type: ignore[name-defined]
-                    b: PETSc.Vec,  # type: ignore[name-defined]
-                    u: dolfinx.fem.Function | Sequence[dolfinx.fem.Function],
-                    residual: dolfinx.fem.Form | Sequence[dolfinx.fem.Form],
-                    jacobian: dolfinx.fem.Form | Sequence[Sequence[dolfinx.fem.Form]],
-                    bcs: Sequence[dolfinx.fem.DirichletBC],
-                    _blocks: tuple[tuple[int, int, int], ...] | None = None,):
+                _snes: PETSc.SNES,  # type: ignore[name-defined]
+                x: PETSc.Vec,  # type: ignore[name-defined]
+                b: PETSc.Vec,  # type: ignore[name-defined]
+                u: dolfinx.fem.Function | Sequence[dolfinx.fem.Function],
+                residual: dolfinx.fem.Form | Sequence[dolfinx.fem.Form],
+                jacobian: dolfinx.fem.Form | Sequence[Sequence[dolfinx.fem.Form]],
+                bcs: Sequence[dolfinx.fem.DirichletBC],
+                _blocks: tuple[tuple[int, int, int], ...] | None = None,
+            ):
+
                 [bc.pack() for bc in bcs]
-                current_func(_snes, x, b, u, residual, jacobian, bcs, _blocks)
+                # Cover single stage problems where _blocks is None
+                dolfinx.fem.petsc.assemble_residual(
+                    _snes, x, b, u, residual, jacobian, bcs, _blocks
+                )
 
-            self.solver.setFunction(assemble_residual, _vec, args=args, kargs=kargs)
-
-            _jac, _jacP, (current_jac, args, kargs) = self.solver.getJacobian()
+            if isinstance(u, Sequence) and len(u) == 1:
+                assert len(self.F) == 1 and len(self.J) == 1 and len(self.J[0]) == 1
+                kargs = {
+                    "u": u[0],
+                    "residual": self.F[0],
+                    "jacobian": self.J[0][0],
+                    "bcs": self._bcs,
+                    "_blocks": self.b.getAttr("_blocks"),
+                }
+                jac_kargs = {
+                    "u": u[0],
+                    "jacobian": self.J[0][0],
+                    "bcs": self._bcs,
+                    "preconditioner": self._preconditioner,
+                }
+                if self._P_mat is not None:
+                    assert (
+                        len(self._preconditioner) == 1
+                        and len(self._preconditioner[0]) == 1
+                    )
+            else:
+                kargs = {
+                    "u": u,
+                    "residual": self.F,
+                    "jacobian": self.J,
+                    "bcs": self._bcs,
+                    "_blocks": self.b.getAttr("_blocks"),
+                }
+                jac_kargs = {
+                    "u": u,
+                    "jacobian": self.J,
+                    "bcs": self._bcs,
+                    "preconditioner": self._preconditioner,
+                }
+            self.solver.setFunction(assemble_residual, self.b, kargs=kargs)
 
             def assemble_jacobian(
-                    _snes: PETSc.SNES,  # type: ignore[name-defined]
-                    x: PETSc.Vec,  # type: ignore[name-defined]
-                    J: PETSc.Mat,  # type: ignore[name-defined]
-                    P_mat: PETSc.Mat,  # type: ignore[name-defined]
-                    u: Sequence[dolfinx.fem.Function] | dolfinx.fem.Function,
-                    jacobian: dolfinx.fem.Form | Sequence[Sequence[dolfinx.fem.Form]],
-                    preconditioner: dolfinx.fem.Form | Sequence[Sequence[dolfinx.fem.Form]] | None,
-                    bcs: Sequence[dolfinx.fem.DirichletBC],
+                _snes: PETSc.SNES,  # type: ignore[name-defined]
+                x: PETSc.Vec,  # type: ignore[name-defined]
+                J: PETSc.Mat,  # type: ignore[name-defined]
+                P_mat: PETSc.Mat,  # type: ignore[name-defined]
+                u: Sequence[dolfinx.fem.Function] | dolfinx.fem.Function,
+                jacobian: dolfinx.fem.Form | Sequence[Sequence[dolfinx.fem.Form]],
+                preconditioner: dolfinx.fem.Form
+                | Sequence[Sequence[dolfinx.fem.Form]]
+                | None,
+                bcs: Sequence[dolfinx.fem.DirichletBC],
             ):
                 [bc.pack() for bc in bcs]
-                current_jac(_snes, x, J, P_mat, u, jacobian, preconditioner, bcs)
-            self.solver.setJacobian(assemble_jacobian, _jac, _jacP, args=args, kargs=kargs)
+                dolfinx.fem.petsc.assemble_jacobian(
+                    _snes, x, J, P_mat, u, jacobian, preconditioner, bcs
+                )
+            self.solver.setJacobian(
+                assemble_jacobian, self.A, self.P_mat, kargs=jac_kargs
+            )
 
         def solve(self, bounds=None):
             if bounds is not None:

--- a/irksome/backends/dolfinx.py
+++ b/irksome/backends/dolfinx.py
@@ -17,6 +17,7 @@ import typing
 import numpy as np
 import numpy.typing as npt
 
+
 def extract_dtype(expr: ufl.core.expr.Expr) -> npt.DTypeLike:
     """Extract the dtype from an expression.
 
@@ -34,6 +35,7 @@ def extract_dtype(expr: ufl.core.expr.Expr) -> npt.DTypeLike:
         if hasattr(c, "dtype"):
             return c.dtype
     raise ValueError("Could not extract dtype from expression, please ensure that all constants and coefficients have a dtype attribute")
+
 
 def extract_scalar_value(scalar_expr):
     """Extract float from a scalar UFL expression."""
@@ -61,12 +63,13 @@ def extract_scalar_value(scalar_expr):
     else:
         raise ValueError(f"Cannot extract scalar from {type(scalar_expr)}: {scalar_expr}")
 
+
 def extract_function(expr) -> tuple[bool, dolfinx.fem.Function | None]:
     """Recursively extract a Function from nested UFL expressions.
 
     :returns: A tuple (is_real, func) where is_real=True means func is on RealElement (a constant)
 
-    .. note:: 
+    .. note::
         Returns (False, None) for RealElement functions so they get handled
         as scalars by extract_scalar_value, preserving any multipliers.
     """
@@ -87,6 +90,7 @@ def extract_function(expr) -> tuple[bool, dolfinx.fem.Function | None]:
             if func is not None:
                 return (is_real, func)
     return (False, None)
+
 
 def extract_term(term):
     """Extract (weight, function) from a single term."""
@@ -131,6 +135,7 @@ def extract_term(term):
             return (result[0] / denom_val, result[1]) if result else None
     return None
 
+
 def extract_linear_combination(expr: ufl.core.expr.Expr) -> list[tuple[float, "dolfinx.fem.Function"]]:
     """Extract (weight, function) pairs from a UFL linear combination.
 
@@ -157,6 +162,7 @@ def extract_linear_combination(expr: ufl.core.expr.Expr) -> list[tuple[float, "d
                 terms.append(result)
     return terms
 
+
 def function_iadd(func: "dolfinx.fem.Function", expr: ufl.core.expr.Expr) -> None:
     """Add a UFL expression to a DOLFINx Function in-place (func += expr).
 
@@ -167,7 +173,7 @@ def function_iadd(func: "dolfinx.fem.Function", expr: ufl.core.expr.Expr) -> Non
     :param expr: UFL expression (linear combination of Functions)
 
     .. code-block:: python
- 
+
         function_iadd(u, 0.5 * v + 0.3 * w)  # equivalent to u += 0.5*v + 0.3*w
     """
     # Extract the linear combination: [(weight1, func1), (weight2, func2), ...]
@@ -178,18 +184,23 @@ def function_iadd(func: "dolfinx.fem.Function", expr: ufl.core.expr.Expr) -> Non
         func.x.array[:] += weight * term_func.x.array[:]
 
 # Patching of DOLFINx objects to mimick firedrake naming and properties.
+
+
 def function_space_length(self):
     return 1
+
 
 def mixed_space_length(self):
     return len(self.ufl_sub_spaces())
 
+
 def function_subfunctions(self):
     """Get subfunctions for a DOLFINx function, which may be in a mixed space.
-    
+
     This function is called when updating `u0` in time-stepping problems.
     """
     return [self]
+
 
 def function_iadd_method(self, other):
     """In-place addition for DOLFINx functions (self += other).
@@ -206,10 +217,12 @@ def function_iadd_method(self, other):
     function_iadd(self, other)
     return self
 
+
 dolfinx.fem.FunctionSpace.__len__ = function_space_length
 dolfinx.fem.Function.subfunctions = property(function_subfunctions)
 dolfinx.fem.Function.__iadd__ = function_iadd_method
 ufl.MixedFunctionSpace.__len__ = mixed_space_length
+
 
 class ListTensor(ufl.tensors.ListTensor):
     """A list tensor that exposes subfunctions for DOLFINx functions"""
@@ -225,6 +238,7 @@ class ListTensor(ufl.tensors.ListTensor):
     def function_space(self):
         return ufl.MixedFunctionSpace(*[self.ufl_operands[i].ufl_function_space() for i in range(self.ufl_shape[0])])
 
+
 class LinearProblem(dolfinx.fem.petsc.LinearProblem):
     """Overloaded linear problem that pack BCs before solving"""
 
@@ -233,6 +247,7 @@ class LinearProblem(dolfinx.fem.petsc.LinearProblem):
             raise NotImplementedError("Bounds-constrained solves are not implemented for DOLFINx")
         [bc.pack() for bc in self._bcs]
         super().solve()
+
 
 class NonlinearProblem(dolfinx.fem.petsc.NonlinearProblem):
     """Overloaded nonlinear problem that pack BCs before solving.
@@ -354,12 +369,14 @@ class NonlinearProblem(dolfinx.fem.petsc.NonlinearProblem):
     def snes(self) -> PETSc.SNES:  # type: ignore[name-defined]
         return self.solver
 
+
 def get_stage_space(V: ufl.FunctionSpace, num_stages: int) -> ufl.FunctionSpace:
     if num_stages == 1:
         space_list = [V]
     else:
         space_list = [V.clone() for _ in range(num_stages)]
     return ufl.MixedFunctionSpace(*space_list)
+
 
 class DirichletBC(dolfinx.fem.DirichletBC):
     _pack_expression: dolfinx.fem.Expression | None
@@ -368,7 +385,7 @@ class DirichletBC(dolfinx.fem.DirichletBC):
     def __init__(self, g: ufl.core.expr.Expr, dofs: npt.NDArray[np.int32], V: dolfinx.fem.FunctionSpace):
         """
         Create an Irksome compatible DirichletBC from an existing DOLFINx bc.
-        
+
         .. note::
             This is not a user-facing class, but rather an internal class used for BC reconstruction in time-stepping problems.
             Use: :func:`irksome.backends.dolfinx.dirichletbc`.
@@ -502,6 +519,7 @@ class DirichletBC(dolfinx.fem.DirichletBC):
     def reconstruct(self, V, g):
         return DirichletBC(g, self.dof_indices()[0], V=V)
 
+
 def dirichletbc(
     value: ufl.core.expr.Expr,
     dofs: npt.NDArray[np.int32],
@@ -518,8 +536,10 @@ def dirichletbc(
     """
     return DirichletBC(value, dofs, V)
 
+
 def bc2space(bc, V):
     return get_sub(V, bc.function_space.component())
+
 
 def stage2spaces4bc(bc, V, Vbig, i):
     """used to figure out how to apply Dirichlet BC to each stage"""
@@ -527,9 +547,11 @@ def stage2spaces4bc(bc, V, Vbig, i):
     Vbig_i = Vbig.ufl_sub_spaces()[i]
     return get_sub(Vbig_i, comp)
 
+
 def extract_bcs(bcs: typing.Any) -> tuple[typing.Any]:
     """Extract boundary conditions"""
     return bcs
+
 
 def create_variational_problem(F, u, bcs=None, aP=None, **kwargs):
     """Create a variational problem."""
@@ -561,6 +583,7 @@ def create_variational_problem(F, u, bcs=None, aP=None, **kwargs):
         )
     else:
         raise RuntimeError(f"Forms of rank {rank} are not supported in create_variational_problem")
+
 
 def create_variational_solver(
     problem: dolfinx.fem.petsc.LinearProblem | dolfinx.fem.petsc.NonlinearProblem,
@@ -603,11 +626,13 @@ def create_variational_solver(
         problem.A.setNearNullSpace(near_nullspace)
     return problem
 
+
 def get_function_space(u: ufl.Coefficient | ufl.Argument) -> ufl.FunctionSpace:
     if isinstance(u, (ufl.Coefficient, ufl.Argument)):
         return u.ufl_function_space()
     else:
         raise ValueError(f"Cannot get function space for object of type {type(u)}")
+
 
 def get_stages(V: dolfinx.fem.FunctionSpace, num_stages: int) -> ListTensor:
     """
@@ -622,6 +647,7 @@ def get_stages(V: dolfinx.fem.FunctionSpace, num_stages: int) -> ListTensor:
     Vbig = ufl.MixedFunctionSpace(*_Vbig)
     return ListTensor(*[dolfinx.fem.Function(Vi, name=f"stage_{i}") for i, Vi in enumerate(Vbig.ufl_sub_spaces())])
 
+
 class FloatConstantFunction(dolfinx.fem.Function):
     def __float__(self):
         if len(self.x.array) != 1:
@@ -631,6 +657,7 @@ class FloatConstantFunction(dolfinx.fem.Function):
     def assign(self, value):
         self.x.array[0] = self.x.array.dtype.type(value)
         self.x.scatter_forward()
+
 
 class MeshConstant(object):
     def __init__(self, msh):
@@ -656,8 +683,10 @@ class MeshConstant(object):
         v.x.array[:] = val
         return v
 
+
 def get_mesh_constant(MC: MeshConstant | None) -> ufl.core.expr.Expr:
     return MC.Constant if MC is not None else ufl.constantvalue.ComplexValue
+
 
 def norm(
     v: ufl.core.expr.Expr, norm_type: str = "L2", mesh: ufl.Mesh | None = None
@@ -680,6 +709,7 @@ def norm(
     norm_global = form.mesh.comm.allreduce(norm_loc, op=MPI.SUM)
     return norm_global ** (1 / p)
 
+
 def assemble(expr: ufl.core.expr.Expr | float):
     """Assemble a UFL expression in the backend language."""
     if isinstance(expr, float):
@@ -695,13 +725,15 @@ def assemble(expr: ufl.core.expr.Expr | float):
         else:
             raise ValueError(f"Cannot assemble form of rank {form.rank}")
 
+
 def TrialFunction(function_space):
     """Create a trial function in the backend language.
-    
+
     This is required as :func:`ufl.TrialFunctions` returns a tuple of trial functions,
     which we need to convert to a tensor for consistency with the Firedrake backend.
     """
     return ufl.as_tensor(ufl.TrialFunctions(function_space))
+
 
 def Function(V: ufl.FunctionSpace | ufl.MixedFunctionSpace, name=None):
     """Create a function in the backend language."""
@@ -715,6 +747,7 @@ def Function(V: ufl.FunctionSpace | ufl.MixedFunctionSpace, name=None):
     else:
         return dolfinx.fem.Function(V, name=name)
 
+
 def TestFunction(function_space):
     """Create a test function in the backend language.
 
@@ -723,28 +756,33 @@ def TestFunction(function_space):
     """
     return ufl.as_tensor(ufl.TestFunctions(function_space))
 
+
 class Constant(ufl.constantvalue.ScalarValue):
     # NOTE: If dolfinx ever get's meshless constants we should change this
     def assign(self, value):
         self._value = value
 
+
 class EquationBCSplit:
     def __init__(self, *args, **kwargs):
         raise NotImplementedError("DOLFINx does not support EquationBCSplit")
+
 
 class EquationBC:
     def __init__(self, *args, **kwargs):
         raise NotImplementedError("DOLFINx does not support EquationBC")
 
+
 def invalidate_jacobian(solver: dolfinx.fem.petsc.LinearProblem):
     """Invalidate the Jacobian matrix in the backend language."""
     pass
-    # raise RuntimeError("DOLFINx does not support Jacobian invalidation")
+
 
 def create_bounds_constrained_bc(V, g, sub_domain, bounds, solver_parameters=None):
     raise NotImplementedError(
         "Bounds-constrained BCs are not implemented for DOLFINx"
     )
+
 
 def getNullspace(V, Vbig, num_stages, nullspace):
     """
@@ -777,5 +815,6 @@ def getNullspace(V, Vbig, num_stages, nullspace):
             vectors=new_vecs, comm=nullspace.getComm()
         )
     return nspnew
+
 
 derivative = ufl.derivative

--- a/irksome/backends/dolfinx.py
+++ b/irksome/backends/dolfinx.py
@@ -40,6 +40,9 @@ try:
         def subfunctions(self):
             return [self.ufl_operands[i] for i in range(len(self))]
 
+        def function_space(self):
+            return ufl.MixedFunctionSpace(*[self.ufl_operands[i].ufl_function_space() for i in range(len(self))])
+
     class LinearProblem(dolfinx.fem.petsc.LinearProblem):
 
         def solve(self, bounds=None):
@@ -335,15 +338,11 @@ try:
             opts.delValue(f"{solver_prefix}{k}")
         return problem
 
-    def get_function_space(
-        u: list[ufl.Coefficient | ufl.Argument] | ufl.Coefficient,
-    ) -> ufl.FunctionSpace:
+    def get_function_space(u: ufl.Coefficient | ufl.Argument) -> ufl.FunctionSpace:
         if isinstance(u, (ufl.Coefficient, ufl.Argument)):
             return u.ufl_function_space()
         else:
-            return ufl.MixedFunctionSpace(
-                *[u[i].ufl_function_space() for i in range(u.ufl_shape[0])]
-            )
+            raise ValueError(f"Cannot get function space for object of type {type(u)}")
 
     def get_stages(V: dolfinx.fem.FunctionSpace, num_stages: int) -> ListTensor:
         """

--- a/irksome/backends/dolfinx.py
+++ b/irksome/backends/dolfinx.py
@@ -1,50 +1,227 @@
 """DOLFINx backend for Irksome"""
 
 from collections.abc import Sequence
-
 from irksome.tools import get_sub
 
 try:
     from mpi4py import MPI
     from petsc4py import PETSc
     import dolfinx.fem.petsc
-    from dolfinx.typing import Scalar
 
     import ufl
     import typing
     import numpy as np
     import numpy.typing as npt
 
+    def extract_dtype(expr: ufl.core.expr.Expr) -> npt.DTypeLike:
+        """Extract the dtype from an expression.
+
+        Looks for any constants or coefficients and returning their dtype.
+        This is necessary for determining which DOLFINx DirichletBC constructor
+        to use when packing UFL expressions into DOLFINx Expressions for use in
+        BC reconstruction.
+        """
+        consts = ufl.algorithms.analysis.extract_constants(expr)
+        for c in consts:
+            if hasattr(c, "dtype"):
+                return c.dtype
+        coeffs = ufl.algorithms.extract_coefficients(expr)
+        for c in coeffs:
+            if hasattr(c, "dtype"):
+                return c.dtype
+        raise ValueError("Could not extract dtype from expression, please ensure that all constants and coefficients have a dtype attribute")
+
+    def extract_scalar_value(scalar_expr):
+        """Extract float from a scalar UFL expression."""
+        if isinstance(scalar_expr, (ufl.classes.IntValue, ufl.classes.FloatValue)):
+            return float(scalar_expr)
+        elif isinstance(scalar_expr, dolfinx.fem.Function):
+            # Check if it's a RealElement (constant stored as Function)
+            if scalar_expr.function_space.ufl_element().is_real and scalar_expr.ufl_shape == ():
+                return float(scalar_expr.x.array[0])
+            else:
+                raise ValueError(f"Cannot extract scalar from spatial Function: {scalar_expr}")
+        elif isinstance(scalar_expr, dolfinx.fem.Constant) and scalar_expr.ufl_shape == ():
+            val = scalar_expr.value
+            return float(val) if hasattr(val, '__float__') else float(val.item())
+        elif isinstance(scalar_expr, ufl.classes.ScalarValue):
+            return float(scalar_expr._value)
+        elif isinstance(scalar_expr, ufl.classes.Product):
+            result = 1.0
+            for op in scalar_expr.ufl_operands:
+                result *= extract_scalar_value(op)
+            return result
+        elif isinstance(scalar_expr, ufl.classes.Division):
+            num, den = scalar_expr.ufl_operands
+            return extract_scalar_value(num) / extract_scalar_value(den)
+        else:
+            raise ValueError(f"Cannot extract scalar from {type(scalar_expr)}: {scalar_expr}")
+
+    def extract_function(expr) -> tuple[bool, dolfinx.fem.Function | None]:
+        """Recursively extract a Function from nested UFL expressions.
+
+        Returns:
+            (is_real, func) where is_real=True means func is on RealElement (a constant)
+
+        Note: Returns (False, None) for RealElement functions so they get handled
+        as scalars by extract_scalar_value, preserving any multipliers.
+        """
+        if isinstance(expr, dolfinx.fem.Function):
+            is_real = expr.function_space.ufl_element().is_real
+            if is_real:
+                # Don't return RealElement functions - let them be handled as scalars
+                return (False, None)
+            return (False, expr)
+        elif isinstance(expr, (ufl.classes.Indexed, ufl.classes.ComponentTensor)):
+            # Indexed or ComponentTensor wraps the actual function
+            # Get the operand and recurse
+            return extract_function(expr.ufl_operands[0])
+        elif hasattr(expr, 'ufl_operands'):
+            # Try each operand
+            for op in expr.ufl_operands:
+                is_real, func = extract_function(op)
+                if func is not None:
+                    return (is_real, func)
+        return (False, None)
+
+    def extract_term(term):
+        """Extract (weight, function) from a single term."""
+        if isinstance(term, dolfinx.fem.Function):
+            is_real = term.ufl_element().is_real
+            if is_real:
+                return None  # RealElement is a constant, not a spatial function
+            return (1.0, term)
+        elif isinstance(term, ufl.classes.ComponentTensor):
+            # ComponentTensor(Product(Indexed(func), scalar), index)
+            # Extract from the inner product
+            inner_expr = term.ufl_operands[0]
+            return extract_term(inner_expr)
+        elif isinstance(term, ufl.classes.Indexed):
+            # Indexed(func, index) - just extract the function
+            is_real, func = extract_function(term)
+            if func is None:
+                return None
+            return (1.0, func)
+        elif isinstance(term, ufl.classes.Product):
+            weight = 1.0
+            func = None
+            for op in term.ufl_operands:
+                is_real, extracted_func = extract_function(op)
+                if extracted_func is not None:
+                    # It's a spatial function (RealElement functions return None)
+                    func = extracted_func
+                else:
+                    # Not a function, or is a RealElement - extract as scalar
+                    weight *= extract_scalar_value(op)
+            return (weight, func) if func is not None else None
+        elif isinstance(term, ufl.classes.Division):
+            num, den = term.ufl_operands
+            denom_val = extract_scalar_value(den)
+            if isinstance(num, dolfinx.fem.Function):
+                is_real = num.function_space.ufl_element().family() == "Real"
+                if is_real:
+                    return None
+                return (1.0 / denom_val, num)
+            elif isinstance(num, ufl.classes.Product):
+                result = extract_term(num)
+                return (result[0] / denom_val, result[1]) if result else None
+        return None
+
+    def extract_linear_combination(expr: ufl.core.expr.Expr) -> list[tuple[float, "dolfinx.fem.Function"]]:
+        """Extract (weight, function) pairs from a UFL linear combination.
+
+        Analyzes expressions like: 0.5*u + 0.3*v + 0.2*w
+        Returns: [(0.5, u), (0.3, v), (0.2, w)]
+
+        Args:
+            expr: UFL expression (Sum, Product, or single Function)
+
+        Returns:
+            List of (weight, function) tuples
+        """
+
+        # Parse the expression
+        if isinstance(expr, ufl.classes.Sum):
+            summands = expr.ufl_operands
+        else:
+            summands = [expr]
+        terms = []
+        for summand in summands:
+            result = extract_term(summand)
+            if result is not None:
+                terms.append(result)
+        return terms
+
+    def function_iadd(func: "dolfinx.fem.Function", expr: ufl.core.expr.Expr) -> None:
+        """Add a UFL expression to a DOLFINx Function in-place (func += expr).
+
+        Extracts the linear combination structure and adds terms directly using
+        PETSc vector operations. Works with mixed spaces and subfunction views.
+
+        Args:
+            func: DOLFINx Function or subfunction view to update in-place
+            expr: UFL expression (linear combination of Functions)
+
+        Example:
+            function_iadd(u, 0.5 * v + 0.3 * w)  # equivalent to u += 0.5*v + 0.3*w
+        """
+        # Extract the linear combination: [(weight1, func1), (weight2, func2), ...]
+        terms = extract_linear_combination(expr)
+
+        # Add each term
+        for weight, term_func in terms:
+            if not (term_func.ufl_element() == func.ufl_element()) or not np.allclose(term_func.function_space.dofmap.list, func.function_space.dofmap.list):
+                raise ValueError(f"Function {term_func} is not compatible for addition with {func}")
+            func.x.array[:] += weight * term_func.x.array[:]
+
     # Patching of DOLFINx objects to mimick firedrake naming and properties.
     def function_space_length(self):
-        num_sub_elements = self.ufl_element().num_sub_elements
-        return 1 if num_sub_elements == 0 else num_sub_elements
+        return 1
 
     def mixed_space_length(self):
         return len(self.ufl_sub_spaces())
 
     def subfunctions(self):
         """Get subfunctions for a DOLFINx function, which may be in a mixed space."""
-        if self.function_space.ufl_element().num_sub_elements == 0:
-            return [self]
-        else:
-            return [self.sub(i) for i in range(self.function_space().ufl_element().num_sub_elements)]
+        return [self]
+
+    def function_iadd_method(self, other):
+        """In-place addition for DOLFINx functions (self += other).
+
+        This method is monkey-patched onto :py:class:`dolfinx.fem.Function` to enable
+        Firedrake-style arithmetic operations.
+
+        Args:
+            self: The function to be modified
+            other: The expression to add. Can be a UFL expression, Function, Constant, or scalar.
+
+        Returns:
+            self (for chaining)
+        """
+        # Delegate to the standalone function_iadd which handles all the complexity
+        function_iadd(self, other)
+        return self
 
     dolfinx.fem.FunctionSpace.__len__ = function_space_length
     dolfinx.fem.Function.subfunctions = property(subfunctions)
+    dolfinx.fem.Function.__iadd__ = function_iadd_method
     ufl.MixedFunctionSpace.__len__ = mixed_space_length
 
     class ListTensor(ufl.tensors.ListTensor):
         """A list tensor that exposes subfunctions for DOLFINx functions"""
         @property
         def subfunctions(self):
-            return [self.ufl_operands[i] for i in range(len(self))]
+            sub_funcs = []
+            for i in range(self.ufl_shape[0]):
+                func = self.ufl_operands[i]
+                sub_funcs.append(func)
+            return sub_funcs
 
         def function_space(self):
-            return ufl.MixedFunctionSpace(*[self.ufl_operands[i].ufl_function_space() for i in range(len(self))])
+            return ufl.MixedFunctionSpace(*[self.ufl_operands[i].ufl_function_space() for i in range(self.ufl_shape[0])])
 
     class LinearProblem(dolfinx.fem.petsc.LinearProblem):
-
+        """Overloaded linear problem that pack BCs before solving"""
         def solve(self, bounds=None):
             if bounds is not None:
                 raise NotImplementedError("Bounds-constrained solves are not implemented for DOLFINx")
@@ -52,7 +229,11 @@ try:
             super().solve()
 
     class NonlinearProblem(dolfinx.fem.petsc.NonlinearProblem):
-
+        """Overloaded nonlinear problem that pack BCs before solving.
+        
+        Done eac  Newton iteration or line search step by overriding the
+        SNES function and Jacobian assembly routines to pack BCs before assembly.
+        """
         def __init__(
             self,
             F: ufl.form.Form | Sequence[ufl.form.Form],
@@ -94,6 +275,7 @@ try:
                     _blocks: tuple[tuple[int, int, int], ...] | None = None,):
                 [bc.pack() for bc in bcs]
                 current_func(_snes, x, b, u, residual, jacobian, bcs, _blocks)
+
             self.solver.setFunction(assemble_residual, _vec, args=args, kargs=kargs)
 
             _jac, _jacP, (current_jac, args, kargs) = self.solver.getJacobian()
@@ -122,18 +304,16 @@ try:
             return self.solver
 
     def dirichletbc(
-        value: dolfinx.fem.Function
-        | dolfinx.fem.Constant
-        | npt.NDArray[Scalar]
-        | float
-        | complex,
-        dofs: npt.NDArray[np.int32],
+        value: ufl.core.expr.Expr, dofs: npt.NDArray[np.int32],
         V: dolfinx.fem.FunctionSpace | None = None,
     ):
-        """Overloaded DirichletBC so that we can reconstruct BCs with UFL expressions"""
-        bc = dolfinx.fem.dirichletbc(value, dofs, V)
-        bc._ufl_space = V if V is not None else value.ufl_function_space()
-        return bc
+        """Overloaded DirichletBC so that we can reconstruct BCs with UFL expressions.
+        
+        value: A UFL expression representing the boundary condition.
+        dofs: An array of degree-of-freedom indices in `V` where the BC should be applied.
+        V: The function space on which the BC applies. It can be a subspace of a mixed/blocked space.
+        """
+        return DirichletBC(value, dofs, V)
 
     def get_stage_space(V: ufl.FunctionSpace, num_stages: int) -> ufl.FunctionSpace:
         if num_stages == 1:
@@ -144,74 +324,77 @@ try:
 
     class DirichletBC(dolfinx.fem.DirichletBC):
         _pack_expression: dolfinx.fem.Expression | None
+        _ufl_expr: ufl.core.expr.Expr | None  # Store original UFL expression
 
-        def __init__(self, bc: dolfinx.fem.DirichletBC, V=None, new_value=None):
+        def __init__(self, g: ufl.core.expr.Expr, dofs: npt.NDArray[np.int32], V: dolfinx.fem.FunctionSpace):
             """
             Create an Irksome compatible DirichletBC from an existing DOLFINx bc, created by `irksome.backends.dolfinx.dirichletbc`.
 
             Args:
-                bc: A DOLFINx DirichletBC object
-                V: A function space V to reconstruct the BC on.
-                new_value: A new value to reconstruct the BC with.
-
+                g: The boundary condition expression
+                dofs: An array of degree-of-freedom indices in V
+                V: The space to construct the BC on.
             """
 
             # Attach UFL function space (to be able to reconstruct functions and constants on the same UFL domain)
-            if not hasattr(bc, "_ufl_space"):
-                if V is not None:
-                    bc._ufl_space = V
-                else:
-                    raise RuntimeError(
-                        "Dirichlet condition must be constructed with `irksome.backends.dolfinx.dirichletbc` in order to be reconstructable with UFL expressions"
+            self._ufl_space = V.ufl_function_space()
+
+            # Store original UFL expression for time-varying BCs
+            if not isinstance(g, (dolfinx.fem.Function, dolfinx.fem.Constant, int, float, complex)):
+                self._ufl_expr = g  # Save the symbolic expression
+            else:
+                self._ufl_expr = None
+            self._ufl_space = V.ufl_function_space()
+
+            # If reconstructing with a sub space, we need to get the subspace dof indices
+            # If working with a subspace of a single stage, we need to create the (parent_dof, sub_dof) mapping
+            if V.component() != []:
+                V_sub, sub_to_parent = V.collapse()
+                if len(sub_to_parent) != 1:
+                    raise NotImplementedError(
+                        "Mixed topology is not supported for reconstructing BCs with UFL expressions"
                     )
-            self._ufl_space = bc._ufl_space
-
-            # Get dof indices of existing BC
-            dof_indices = bc.dof_indices()[0].copy()
-
-            # If reconstructing use V as the new space rather than the BC space
-            bc_space = bc.function_space if V is None else V
+                else:
+                    sub_to_parent = sub_to_parent[0]
+                    parent_to_sub = np.full(
+                        V.dofmap.index_map.size_local
+                        * V.dofmap.index_map_bs,
+                        -1,
+                        dtype=np.int32,
+                    )
+                    parent_to_sub[sub_to_parent] = np.arange(len(sub_to_parent))
+                    sub_dofs = parent_to_sub[dofs]
+                    dofs = (dofs, sub_dofs)
 
             # If we are not reconstructing the BC with a new value, we can reuse existing C++ objects
-            if new_value is None:
-                val = bc.g
+            self._pack_expression = None
+
+            # If we are reconstructing the BC with a new value, we need to check if the new value is a DOLFINx function or Constant.
+            # If True, we do not need to do anything for reconstruction.
+            if isinstance(g, (dolfinx.fem.Function, dolfinx.fem.Constant)):
+                val = g
                 self._pack_expression = None
             else:
-                # If we are reconstructing the BC with a new value, we need to check if the new value is a DOLFINx function or Constant.
-                # If True, we do not need to do anything for reconstruction.
-                if isinstance(new_value, (dolfinx.fem.Function, dolfinx.fem.Constant)):
-                    val = new_value
-                    self._pack_expression = None
+                # If not, we need to take the ufl.core.expr.Expr and pack it into a DOLFINx Expression
+                if V.component() != []:
+                    val = dolfinx.fem.Function(V_sub, name=f"bc_{str(g)}")._cpp_object
                 else:
-                    # If not, we need to take the ufl.core.expr.Expr and pack it into a DOLFINx Expression
-                    if bc_space.component() != []:
-                        # If working with a subspace of a single stage, we need to create the (parent_dof, sub_dof) mapping
-                        V_sub, sub_to_parent = bc_space.collapse()
-                        if len(sub_to_parent) != 1:
-                            raise NotImplementedError(
-                                "Mixed topology is not supported for reconstructing BCs with UFL expressions"
-                            )
-                        else:
-                            sub_to_parent = sub_to_parent[0]
-                            parent_to_sub = np.full(
-                                bc_space.dofmap.index_map.size_local
-                                * bc_space.dofmap.index_map_bs,
-                                -1,
-                                dtype=np.int32,
-                            )
-                            parent_to_sub[sub_to_parent] = np.arange(len(sub_to_parent))
+                    val = dolfinx.fem.Function(V, name=f"bc_{str(g)}")._cpp_object
+                self._pack_expression = dolfinx.fem.Expression(g, V.element.interpolation_points)
 
-                            dof_indices = (dof_indices, parent_to_sub[dof_indices])
-                            val = dolfinx.fem.Function(V_sub, name=f"bc_{str(new_value)}")._cpp_object
-                    else:
-                        val = dolfinx.fem.Function(bc_space, name=f"bc_{str(new_value)}")._cpp_object
-                    self._pack_expression = dolfinx.fem.Expression(
-                        new_value, bc.function_space.element.interpolation_points()
-                    )
+            # Get correct C++ implementation based on dtype of expression
+            dtype = extract_dtype(g)
+            if np.issubdtype(dtype, np.float32):
+                bctype = dolfinx.cpp.fem.DirichletBC_float32
+            elif np.issubdtype(dtype, np.float64):
+                bctype = dolfinx.cpp.fem.DirichletBC_float64
+            elif np.issubdtype(dtype, np.complex64):
+                bctype = dolfinx.cpp.fem.DirichletBC_complex64
+            elif np.issubdtype(dtype, np.complex128):
+                bctype = dolfinx.cpp.fem.DirichletBC_complex128
+            else:
+                raise NotImplementedError(f"Type {dtype} not supported.")
 
-            # Reconstruct the C++ object
-            # Note: We compare against bc._cpp_object.function_space, NOT the class type.
-            cpp_class = type(bc._cpp_object)
             if (
                 isinstance(
                     val,
@@ -222,16 +405,16 @@ try:
                         dolfinx.cpp.fem.Function_float64,
                     ),
                 )
-                and val.function_space == bc_space._cpp_object
+                and val.function_space == V._cpp_object
             ):
-                new_cpp_object = cpp_class(val, dof_indices)
+                new_cpp_object = bctype(val, dofs)
             else:
                 # Depending on your FEniCSx version, the C++ constructor might strictly
                 # expect the C++ FunctionSpace instead of the Python FunctionSpace wrapper.
                 try:
-                    new_cpp_object = cpp_class(val, dof_indices, bc_space)
+                    new_cpp_object = bctype(val, dofs, V._cpp_object)
                 except TypeError:
-                    new_cpp_object = cpp_class(val, dof_indices, bc_space._cpp_object)
+                    new_cpp_object = bctype(val._cpp_object, dofs, V._cpp_object)
 
             # 4. Initialize the parent dolfinx.fem.DirichletBC wrapper with the newly minted C++ object
             super().__init__(new_cpp_object)
@@ -245,7 +428,11 @@ try:
 
         @property
         def _original_arg(self):
+            # If we stored the original UFL expression, return it for time substitution
+            if hasattr(self, '_ufl_expr') and self._ufl_expr is not None:
+                return self._ufl_expr
 
+            # Otherwise return the wrapped Function/Constant
             if isinstance(
                 self._orig_g,
                 (
@@ -255,7 +442,7 @@ try:
                     dolfinx.cpp.fem.Function_float64,
                 ),
             ):
-                return dolfinx.fem.Function(self._ufl_space, self._orig_g.x, name=f"orig_{self._orig_g.name:s}")
+                return dolfinx.fem.Function(self._ufl_space, dolfinx.la.Vector(self._orig_g.x), name=f"orig_{self._orig_g.name:s}")
             elif isinstance(
                 self._orig_g,
                 (
@@ -271,7 +458,7 @@ try:
             return self._orig_g
 
         def reconstruct(self, V, g):
-            return DirichletBC(self, new_value=g, V=V)
+            return DirichletBC(g, self.dof_indices()[0], V=V)
 
     def bc2space(bc, V):
         return get_sub(V, bc.function_space.component())
@@ -284,10 +471,7 @@ try:
 
     def extract_bcs(bcs: typing.Any) -> tuple[typing.Any]:
         """Extract boundary conditions"""
-        new_bcs = []
-        for bc in bcs:
-            new_bcs.append(DirichletBC(bc))
-        return new_bcs
+        return bcs
 
     def create_variational_problem(F, u, bcs=None, aP=None, **kwargs):
         """Create a variational problem."""
@@ -401,7 +585,7 @@ try:
     ) -> float:
         """Compute the norm of a function in the backend language."""
         if mesh is not None:
-            dx = ufl.Mesure("dx", domain=mesh)
+            dx = ufl.Measure("dx", domain=mesh)
         else:
             dx = ufl.dx
         p = 2
@@ -414,7 +598,8 @@ try:
         else:
             raise NotImplementedError(f"Norm type {norm_type} not implemented")
         norm_loc = dolfinx.fem.assemble_scalar(form)
-        return form.mesh.comm.Allreduce(MPI.IN_PLACE, norm_loc, op=MPI.SUM) ** (1 / p)
+        norm_global = form.mesh.comm.allreduce(norm_loc, op=MPI.SUM)
+        return norm_global ** (1 / p)
 
     def assemble(expr: ufl.core.expr.Expr | float):
         """Assemble a UFL expression in the backend language."""

--- a/irksome/backends/dolfinx.py
+++ b/irksome/backends/dolfinx.py
@@ -432,7 +432,7 @@ try:
                 raise ValueError(f"Cannot assemble form of rank {form.rank}")
 
     derivative = ufl.derivative
-    TrialFunction = ufl.TrialFunctions
+    TrialFunction = lambda function_space: ufl.as_tensor(ufl.TrialFunctions(function_space))
 
     def Function(V: ufl.FunctionSpace | ufl.MixedFunctionSpace, name=None):
         """Create a function in the backend language."""
@@ -441,7 +441,7 @@ try:
         else:
             return dolfinx.fem.Function(V, name=name)
 
-    TestFunction = ufl.TestFunctions
+    TestFunction = lambda function_space: ufl.as_tensor(ufl.TestFunctions(function_space))
 
     class Constant(ufl.constantvalue.ScalarValue):
         # NOTE: If dolfinx ever get's meshless constants we should change this

--- a/irksome/backends/dolfinx.py
+++ b/irksome/backends/dolfinx.py
@@ -686,6 +686,7 @@ try:
                 raise ValueError(f"Cannot assemble form of rank {form.rank}")
 
     derivative = ufl.derivative
+
     def TrialFunction(function_space):
         """Create a trial function in the backend language."""
         return ufl.as_tensor(ufl.TrialFunction(function_space))
@@ -743,7 +744,22 @@ try:
         if nullspace is None:
             nspnew = None
         else:
-            raise NotImplementedError("Nullspace computation is not implemented for DOLFINx")
+            old_vecs = nullspace.getVecs()
+            tmp_func = dolfinx.fem.Function(V)
+            new_vecs = [
+                dolfinx.fem.petsc.create_vector(Vbig.ufl_sub_spaces())
+                for _ in range(len(old_vecs))
+            ]
+            for i in range(len(old_vecs)):
+                # Copy the old nullspace vector into the first stage of the new nullspace vector
+                old_vecs[i].copy(tmp_func.x.petsc_vec)
+                tmp_func.x.scatter_forward()
+                dolfinx.fem.petsc.assign(
+                    [tmp_func for j in range(num_stages)], new_vecs[i]
+                )
+            nspnew = PETSc.NullSpace().create(
+                vectors=new_vecs, comm=nullspace.getComm()
+            )
         return nspnew
 
 except ModuleNotFoundError:

--- a/irksome/backends/dolfinx.py
+++ b/irksome/backends/dolfinx.py
@@ -686,16 +686,25 @@ try:
                 raise ValueError(f"Cannot assemble form of rank {form.rank}")
 
     derivative = ufl.derivative
-    TrialFunction = lambda function_space: ufl.as_tensor(ufl.TrialFunctions(function_space))
+    def TrialFunction(function_space):
+        """Create a trial function in the backend language."""
+        return ufl.as_tensor(ufl.TrialFunction(function_space))
 
     def Function(V: ufl.FunctionSpace | ufl.MixedFunctionSpace, name=None):
         """Create a function in the backend language."""
         if isinstance(V, ufl.MixedFunctionSpace):
-            return ListTensor(*[dolfinx.fem.Function(Vi, name=f"{name}_{i}") for i, Vi in enumerate(V.ufl_sub_spaces())])
+            return ListTensor(
+                *[
+                    dolfinx.fem.Function(Vi, name=f"{name}_{i}")
+                    for i, Vi in enumerate(V.ufl_sub_spaces())
+                ]
+            )
         else:
             return dolfinx.fem.Function(V, name=name)
 
-    TestFunction = lambda function_space: ufl.as_tensor(ufl.TestFunctions(function_space))
+    def TestFunction(function_space):
+        """Create a test function in the backend language."""
+        return ufl.as_tensor(ufl.TestFunctions(function_space))
 
     class Constant(ufl.constantvalue.ScalarValue):
         # NOTE: If dolfinx ever get's meshless constants we should change this

--- a/irksome/backends/dolfinx.py
+++ b/irksome/backends/dolfinx.py
@@ -620,6 +620,7 @@ try:
 
         def assign(self, value):
             self.x.array[0] = self.x.array.dtype.type(value)
+            self.x.scatter_forward()
 
     class MeshConstant(object):
         def __init__(self, msh):

--- a/irksome/backends/dolfinx.py
+++ b/irksome/backends/dolfinx.py
@@ -1,36 +1,266 @@
 """DOLFINx backend for Irksome"""
 
+from collections.abc import Sequence
+
+
+from irksome.tools import get_sub
+
 try:
     from mpi4py import MPI
     from petsc4py import PETSc
-    import basix.ufl
     import dolfinx.fem.petsc
+    from dolfinx.typing import Scalar
+
     import ufl
     import typing
     import numpy as np
+    import numpy.typing as npt
+
+    class LinearProblem(dolfinx.fem.petsc.LinearProblem):
+
+        def solve(self):
+            [bc.pack() for bc in self._bcs]
+            super().solve()
+
+    class NonlinearProblem(dolfinx.fem.petsc.NonlinearProblem):
+
+        def __init__(
+            self,
+            F: ufl.form.Form | Sequence[ufl.form.Form],
+            u: dolfinx.fem.Function | Sequence[dolfinx.fem.Function],
+            *,
+            petsc_options_prefix: str,
+            bcs: Sequence[dolfinx.fem.DirichletBC] | None = None,
+            J: ufl.form.Form | Sequence[Sequence[ufl.form.Form]] | None = None,
+            P: ufl.form.Form | Sequence[Sequence[ufl.form.Form]] | None = None,
+            kind: str | Sequence[Sequence[str]] | None = None,
+            petsc_options: dict | None = None,
+            form_compiler_options: dict | None = None,
+            jit_options: dict | None = None,
+            entity_maps: Sequence[dolfinx.mesh.EntityMap] | None = None,
+        ):
+            super().__init__(
+                F,
+                u,
+                petsc_options_prefix=petsc_options_prefix,
+                bcs=bcs,
+                J=J,
+                P=P,
+                kind=kind,
+                petsc_options=petsc_options,
+                form_compiler_options=form_compiler_options,
+                jit_options=jit_options,
+                entity_maps=entity_maps,
+            )
+            _vec, (current_func, args, kargs) = self.solver.getFunction()
+
+            def assemble_residual(
+                    _snes: PETSc.SNES,  # type: ignore[name-defined]
+                    x: PETSc.Vec,  # type: ignore[name-defined]
+                    b: PETSc.Vec,  # type: ignore[name-defined]
+                    u: dolfinx.fem.Function | Sequence[dolfinx.fem.Function],
+                    residual: dolfinx.fem.Form | Sequence[dolfinx.fem.Form],
+                    jacobian: dolfinx.fem.Form | Sequence[Sequence[dolfinx.fem.Form]],
+                    bcs: Sequence[dolfinx.fem.DirichletBC],
+                    _blocks: tuple[tuple[int, int, int], ...] | None = None,):
+                [bc.pack() for bc in bcs]
+                current_func(_snes, x, b, u, residual, jacobian, bcs, _blocks)
+            self.solver.setFunction(assemble_residual, _vec, args=args, kargs=kargs)
+
+            _jac, _jacP, (current_jac, args, kargs) = self.solver.getJacobian()
+
+            def assemble_jacobian(
+                    _snes: PETSc.SNES,  # type: ignore[name-defined]
+                    x: PETSc.Vec,  # type: ignore[name-defined]
+                    J: PETSc.Mat,  # type: ignore[name-defined]
+                    P_mat: PETSc.Mat,  # type: ignore[name-defined]
+                    u: Sequence[dolfinx.fem.Function] | dolfinx.fem.Function,
+                    jacobian: dolfinx.fem.Form | Sequence[Sequence[dolfinx.fem.Form]],
+                    preconditioner: dolfinx.fem.Form | Sequence[Sequence[dolfinx.fem.Form]] | None,
+                    bcs: Sequence[dolfinx.fem.DirichletBC],
+            ):
+                [bc.pack() for bc in bcs]
+                current_jac(_snes, x, J, P_mat, u, jacobian, preconditioner, bcs)
+            self.solver.setJacobian(assemble_jacobian, _jac, _jacP, args=args, kargs=kargs)
+
+    def dirichletbc(
+        value: dolfinx.fem.Function
+        | dolfinx.fem.Constant
+        | npt.NDArray[Scalar]
+        | float
+        | complex,
+        dofs: npt.NDArray[np.int32],
+        V: dolfinx.fem.FunctionSpace | None = None,
+    ):
+        """Overloaded DirichletBC so that we can reconstruct BCs with UFL expressions"""
+        bc = dolfinx.fem.dirichletbc(value, dofs, V)
+        bc._ufl_space = V if V is not None else value.ufl_function_space()
+        return bc
 
     def get_stage_space(V: ufl.FunctionSpace, num_stages: int) -> ufl.FunctionSpace:
         if num_stages == 1:
-            me = V.ufl_elemet()
+            space_list = [V]
         else:
-            el = V.ufl_element()
-            if el.num_sub_elements > 0:
-                me = basix.ufl.mixed_element(
-                    np.tile(el.sub_elements, num_stages).tolist()
-                )
+            space_list = [V.clone() for _ in range(num_stages)]
+        return ufl.MixedFunctionSpace(*space_list)
+
+    class DirichletBC(dolfinx.fem.DirichletBC):
+        _pack_expression: dolfinx.fem.Expression | None
+
+        def __init__(self, bc: dolfinx.fem.DirichletBC, V=None, new_value=None):
+            """
+            Create an Irksome compatible DirichletBC from an existing DOLFINx bc, created by `irksome.backends.dolfinx.dirichletbc`.
+
+            Args:
+                bc: A DOLFINx DirichletBC object
+                V: A function space V to reconstruct the BC on.
+                new_value: A new value to reconstruct the BC with.
+
+            """
+
+            # Attach UFL function space (to be able to reconstruct functions and constants on the same UFL domain)
+            if not hasattr(bc, "_ufl_space"):
+                if V is not None:
+                    bc._ufl_space = V
+                else:
+                    raise RuntimeError(
+                        "Dirichlet condition must be constructed with `irksome.backends.dolfinx.dirichletbc` in order to be reconstructable with UFL expressions"
+                    )
+            self._ufl_space = bc._ufl_space
+
+            # Get dof indices of existing BC
+            dof_indices = bc.dof_indices()[0].copy()
+
+            # If reconstructing use V as the new space rather than the BC space
+            bc_space = bc.function_space if V is None else V
+
+            # If we are not reconstructing the BC with a new value, we can reuse existing C++ objects
+            if new_value is None:
+                val = bc.g
+                self._pack_expression = None
             else:
-                me = basix.ufl.blocked_element(el, shape=(num_stages,))
-        return dolfinx.fem.functionspace(V.mesh, me)
+                # If we are reconstructing the BC with a new value, we need to check if the new value is a DOLFINx function or Constant.
+                # If True, we do not need to do anything for reconstruction.
+                if isinstance(new_value, (dolfinx.fem.Function, dolfinx.fem.Constant)):
+                    val = new_value
+                    self._pack_expression = None
+                else:
+                    # If not, we need to take the ufl.core.expr.Expr and pack it into a DOLFINx Expression
+                    if bc_space.component() != []:
+                        # If working with a subspace of a single stage, we need to create the (parent_dof, sub_dof) mapping
+                        V_sub, sub_to_parent = bc_space.collapse()
+                        if len(sub_to_parent) != 1:
+                            raise NotImplementedError(
+                                "Mixed topology is not supported for reconstructing BCs with UFL expressions"
+                            )
+                        else:
+                            sub_to_parent = sub_to_parent[0]
+                            parent_to_sub = np.full(
+                                bc_space.dofmap.index_map.size_local
+                                * bc_space.dofmap.index_map_bs,
+                                -1,
+                                dtype=np.int32,
+                            )
+                            parent_to_sub[sub_to_parent] = np.arange(len(sub_to_parent))
+
+                            dof_indices = (dof_indices, parent_to_sub[dof_indices])
+                            val = dolfinx.fem.Function(V_sub, name=f"bc_{str(new_value)}")._cpp_object
+                    else:
+                        val = dolfinx.fem.Function(bc_space, name=f"bc_{str(new_value)}")._cpp_object
+                    self._pack_expression = dolfinx.fem.Expression(
+                        new_value, bc.function_space.element.interpolation_points()
+                    )
+
+            # Reconstruct the C++ object
+            # Note: We compare against bc._cpp_object.function_space, NOT the class type.
+            cpp_class = type(bc._cpp_object)
+            if (
+                isinstance(
+                    val,
+                    (
+                        dolfinx.cpp.fem.Function_complex128,
+                        dolfinx.cpp.fem.Function_complex64,
+                        dolfinx.cpp.fem.Function_float32,
+                        dolfinx.cpp.fem.Function_float64,
+                    ),
+                )
+                and val.function_space == bc_space._cpp_object
+            ):
+                new_cpp_object = cpp_class(val, dof_indices)
+            else:
+                # Depending on your FEniCSx version, the C++ constructor might strictly
+                # expect the C++ FunctionSpace instead of the Python FunctionSpace wrapper.
+                try:
+                    new_cpp_object = cpp_class(val, dof_indices, bc_space)
+                except TypeError:
+                    new_cpp_object = cpp_class(val, dof_indices, bc_space._cpp_object)
+
+            # 4. Initialize the parent dolfinx.fem.DirichletBC wrapper with the newly minted C++ object
+            super().__init__(new_cpp_object)
+
+            # 5. Store your custom properties
+            self._orig_g = val
+
+        def pack(self):
+            if self._pack_expression is not None:
+                self.g.interpolate_expr(self._pack_expression._cpp_object, None, None)
+
+        @property
+        def _original_arg(self):
+
+            if isinstance(
+                self._orig_g,
+                (
+                    dolfinx.cpp.fem.Function_complex128,
+                    dolfinx.cpp.fem.Function_complex64,
+                    dolfinx.cpp.fem.Function_float32,
+                    dolfinx.cpp.fem.Function_float64,
+                ),
+            ):
+                return dolfinx.fem.Function(self._ufl_space, self._orig_g.x, name=f"orig_{self._orig_g.name:s}")
+            elif isinstance(
+                self._orig_g,
+                (
+                    dolfinx.cpp.fem.Constant_complex64,
+                    dolfinx.cpp.fem.Constant_complex128,
+                    dolfinx.cpp.fem.Constant_float32,
+                    dolfinx.cpp.fem.Constant_float64,
+                ),
+            ):
+                return dolfinx.fem.Constant(
+                    self._ufl_space.ufl_domain(), self._orig_g.value
+                )
+            return self._orig_g
+
+        def reconstruct(self, V, g):
+            return DirichletBC(self, new_value=g, V=V)
+
+    def bc2space(bc, V):
+        return get_sub(V, bc.function_space.component())
+
+    def stage2spaces4bc(bc, V, Vbig, i):
+        """used to figure out how to apply Dirichlet BC to each stage"""
+        comp = bc.function_space.component()
+        Vbig_i = Vbig.ufl_sub_spaces()[i]
+        return get_sub(Vbig_i, comp)
 
     def extract_bcs(bcs: typing.Any) -> tuple[typing.Any]:
         """Extract boundary conditions"""
-        return bcs
+        new_bcs = []
+        for bc in bcs:
+            new_bcs.append(DirichletBC(bc))
+        return new_bcs
 
     def create_variational_problem(F, u, bcs=None, aP=None, **kwargs):
         """Create a variational problem."""
-        if len(F.arguments()) == 2:
+        rank = len(np.unique([arg.number() for arg in F.arguments()]))
+        if isinstance(u, ufl.tensors.ListTensor):
+            u = u.ufl_operands
+        if rank == 2:
             a, L = ufl.system(F)
-            return dolfinx.fem.petsc.LinearProblem(
+            a = ufl.extract_blocks(a)
+            L = ufl.extract_blocks(L)
+            return LinearProblem(
                 a,
                 L,
                 u,
@@ -39,14 +269,17 @@ try:
                 P=aP,
                 **kwargs,
             )
-        else:
-            return dolfinx.fem.petsc.NonlinearProblem(
+        elif rank == 1:
+            F = ufl.extract_blocks(F)
+            return NonlinearProblem(
                 F,
                 u,
                 petsc_options_prefix="IrkSomeNonlinearSolver",
                 bcs=bcs,
                 petsc_options=kwargs.get("solver_parameters"),
             )
+        else:
+            raise RuntimeError(f"Forms of rank {rank} are not supported in create_variational_problem")
 
     def create_variational_solver(
         problem: dolfinx.fem.petsc.LinearProblem | dolfinx.fem.petsc.NonlinearProblem,
@@ -56,8 +289,7 @@ try:
         solver_parameters = kwargs.get("solver_parameters", {})
         solver = problem.solver
         solver_prefix = problem.solver.getOptionsPrefix()
-        opts = PETSc.Options(
-        )
+        opts = PETSc.Options()
         opts.prefixPush(solver_prefix)
         for k, v in solver_parameters.items():
             opts.setValue(k, v)
@@ -68,8 +300,15 @@ try:
             opts.delValue(f"{solver_prefix}{k}")
         return problem
 
-    def get_function_space(u: ufl.Coefficient) -> ufl.FunctionSpace:
-        return u.ufl_function_space()
+    def get_function_space(
+        u: list[ufl.Coefficient | ufl.Argument] | ufl.Coefficient,
+    ) -> ufl.FunctionSpace:
+        if isinstance(u, (ufl.Coefficient, ufl.Argument)):
+            return u.ufl_function_space()
+        else:
+            return ufl.MixedFunctionSpace(
+                *[u[i].ufl_function_space() for i in range(u.ufl_shape[0])]
+            )
 
     def get_stages(V: dolfinx.fem.FunctionSpace, num_stages: int) -> ufl.Coefficient:
         """
@@ -83,12 +322,9 @@ try:
         Returns:
             A coefficient in the new function space
         """
-        if V.num_sub_spaces == 0:
-            el = basix.ufl.mixed_element([V.ufl_element()] * num_stages)
-        else:
-            el = basix.ufl.mixed_element(V.ufl_element().sub_elements * num_stages)
-        Vbig = dolfinx.fem.functionspace(V.mesh, el)
-        return dolfinx.fem.Function(Vbig)
+        _Vbig = [V.clone() for _ in range(num_stages)]
+        Vbig = ufl.MixedFunctionSpace(*_Vbig)
+        return ufl.as_vector([dolfinx.fem.Function(Vi) for Vi in Vbig.ufl_sub_spaces()])
 
     class MeshConstant(object):
         def __init__(self, msh):
@@ -116,9 +352,6 @@ try:
 
     def get_mesh_constant(MC: MeshConstant | None) -> ufl.core.expr.Expr:
         return MC.Constant if MC is not None else ufl.constantvalue.ComplexValue
-
-    class DirichletBC(dolfinx.fem.DirichletBC):
-        pass
 
     def norm(
         v: ufl.core.expr.Expr, norm_type: str = "L2", mesh: ufl.Mesh | None = None
@@ -156,9 +389,9 @@ try:
                 raise ValueError(f"Cannot assemble form of rank {form.rank}")
 
     derivative = ufl.derivative
-    TrialFunction = ufl.TrialFunction
+    TrialFunction = ufl.TrialFunctions
     Function = dolfinx.fem.Function
-    TestFunction = ufl.TestFunction
+    TestFunction = ufl.TestFunctions
 
     class Constant(ufl.constantvalue.ScalarValue):
         # NOTE: If dolfinx ever get's meshless constants we should change this
@@ -178,7 +411,34 @@ try:
         raise RuntimeError("DOLFINx does not support Jacobian invalidation")
 
     def create_bounds_constrained_bc(V, g, sub_domain, bounds, solver_parameters=None):
-        raise NotImplementedError("Bounds-constrained BCs are not implemented for DOLFINx")
+        raise NotImplementedError(
+            "Bounds-constrained BCs are not implemented for DOLFINx"
+        )
+
+    def getNullspace(V, Vbig, num_stages, nullspace):
+        """
+        Computes the nullspace for a multi-stage method.
+
+        :arg V: The :class:`ufl.FunctionSpace` on which the original time-dependent PDE is posed.
+        :arg Vbig: The multi-stage :class:`ufl.MixedFunctionSpace` for the stage problem
+        :arg num_stages: The number of stages in the RK method
+        :arg nullspace: The nullspace for the original problem.
+
+        On output, we produce a PETSc nullspace defining the nullspace for the multistage problem.
+        """
+        if nullspace is None:
+            nspnew = None
+        else:
+            raise NotImplementedError("Nullspace computation is not implemented for DOLFINx")
+        return nspnew
+
+    def get_number_of_fields(V) -> int:
+        if isinstance(V, ufl.MixedFunctionSpace):
+            return V.num_sub_spaces()
+        elif isinstance(V, ufl.FunctionSpace):
+            return 1
+        else:
+            raise ValueError(f"Unsupported function space type {type(V)} for get_number_of_fields")
 
 except ModuleNotFoundError:
     pass

--- a/irksome/backends/dolfinx.py
+++ b/irksome/backends/dolfinx.py
@@ -402,7 +402,7 @@ try:
                 else:
                     sub_to_parent = sub_to_parent[0]
                     parent_to_sub = np.full(
-                        V.dofmap.index_map.size_local
+                        (V.dofmap.index_map.size_local + V.dofmap.index_map.num_ghosts)
                         * V.dofmap.index_map_bs,
                         -1,
                         dtype=np.int32,

--- a/irksome/backends/dolfinx.py
+++ b/irksome/backends/dolfinx.py
@@ -76,7 +76,7 @@ try:
             # Indexed or ComponentTensor wraps the actual function
             # Get the operand and recurse
             return extract_function(expr.ufl_operands[0])
-        elif hasattr(expr, 'ufl_operands'):
+        elif hasattr(expr, "ufl_operands"):
             # Try each operand
             for op in expr.ufl_operands:
                 is_real, func = extract_function(op)

--- a/irksome/backends/dolfinx.py
+++ b/irksome/backends/dolfinx.py
@@ -521,6 +521,7 @@ try:
     def create_variational_problem(F, u, bcs=None, aP=None, **kwargs):
         """Create a variational problem."""
         rank = len(np.unique([arg.number() for arg in F.arguments()]))
+        prefix = kwargs.get("petsc_options_prefix", "IrkSomeSolver")
         if isinstance(u, ListTensor):
             u = u.subfunctions
         if rank == 2:
@@ -532,7 +533,7 @@ try:
                 L,
                 u,
                 bcs=bcs,
-                petsc_options_prefix="IrkSomeLinearSolver",
+                petsc_options_prefix=prefix,
                 P=aP,
                 **kwargs,
             )
@@ -541,7 +542,7 @@ try:
             return NonlinearProblem(
                 F,
                 u,
-                petsc_options_prefix="IrkSomeNonlinearSolver",
+                petsc_options_prefix=prefix,
                 bcs=bcs,
                 petsc_options=kwargs.get("solver_parameters"),
             )
@@ -555,16 +556,38 @@ try:
         """Create a variational solver that uses PETSc SNES or KSP."""
         solver_parameters = kwargs.get("solver_parameters", {})
         solver = problem.solver
-        solver_prefix = problem.solver.getOptionsPrefix()
+
+        # Update solver prefix
+        solver_prefix = solver_parameters.get(
+            "petsc_options_prefix", problem.solver.getOptionsPrefix()
+        )
+        problem._petsc_options_prefix = solver_prefix
+        problem.solver.setOptionsPrefix(solver_prefix)
+        problem.A.setOptionsPrefix(f"{solver_prefix}A_")
+        problem.b.setOptionsPrefix(f"{solver_prefix}b_")
+        problem.x.setOptionsPrefix(f"{solver_prefix}x_")
+        if problem.P_mat is not None:
+            problem.P_mat.setOptionsPrefix(f"{solver_prefix}P_mat_")
+        # Push new options with prefix, filtering out irksome-internal keys
+        petsc_opts = {
+            k: v for k, v in solver_parameters.items() if k != "petsc_options_prefix"
+        }
         opts = PETSc.Options()
         opts.prefixPush(solver_prefix)
-        for k, v in solver_parameters.items():
+        for k, v in petsc_opts.items():
             opts.setValue(k, v)
         solver.setFromOptions()
         opts.prefixPop()
         # For some strange reason delValue doesn't respect prefixes
-        for k, v in solver_parameters.items():
+        for k in petsc_opts:
             opts.delValue(f"{solver_prefix}{k}")
+
+        nullspace = kwargs.get("nullspace", None)
+        near_nullspace = kwargs.get("near_nullspace", None)
+        if nullspace is not None:
+            problem.A.setNullSpace(nullspace)
+        if near_nullspace is not None:
+            problem.A.setNearNullSpace(near_nullspace)
         return problem
 
     def get_function_space(u: ufl.Coefficient | ufl.Argument) -> ufl.FunctionSpace:

--- a/irksome/backends/dolfinx.py
+++ b/irksome/backends/dolfinx.py
@@ -1,5 +1,6 @@
 """DOLFINx backend for Irksome"""
 
+from __future__ import annotations
 from collections.abc import Sequence
 from irksome.tools import get_sub
 

--- a/irksome/backends/dolfinx.py
+++ b/irksome/backends/dolfinx.py
@@ -3,764 +3,779 @@
 from collections.abc import Sequence
 from irksome.tools import get_sub
 
+from mpi4py import MPI
+from petsc4py import PETSc
+
 try:
-    from mpi4py import MPI
-    from petsc4py import PETSc
     import dolfinx.fem.petsc
+except ModuleNotFoundError:
+    raise ImportError(
+        "DOLFINx is not installed. Please install DOLFINx to use the DOLFINx backend of Irksome."
+    )
+import ufl
+import typing
+import numpy as np
+import numpy.typing as npt
 
-    import ufl
-    import typing
-    import numpy as np
-    import numpy.typing as npt
+def extract_dtype(expr: ufl.core.expr.Expr) -> npt.DTypeLike:
+    """Extract the dtype from an expression.
 
-    def extract_dtype(expr: ufl.core.expr.Expr) -> npt.DTypeLike:
-        """Extract the dtype from an expression.
+    Looks for any constants or coefficients and returning their dtype.
+    This is necessary for determining which DOLFINx DirichletBC constructor
+    to use when packing UFL expressions into DOLFINx Expressions for use in
+    BC reconstruction.
+    """
+    consts = ufl.algorithms.analysis.extract_constants(expr)
+    for c in consts:
+        if hasattr(c, "dtype"):
+            return c.dtype
+    coeffs = ufl.algorithms.extract_coefficients(expr)
+    for c in coeffs:
+        if hasattr(c, "dtype"):
+            return c.dtype
+    raise ValueError("Could not extract dtype from expression, please ensure that all constants and coefficients have a dtype attribute")
 
-        Looks for any constants or coefficients and returning their dtype.
-        This is necessary for determining which DOLFINx DirichletBC constructor
-        to use when packing UFL expressions into DOLFINx Expressions for use in
-        BC reconstruction.
-        """
-        consts = ufl.algorithms.analysis.extract_constants(expr)
-        for c in consts:
-            if hasattr(c, "dtype"):
-                return c.dtype
-        coeffs = ufl.algorithms.extract_coefficients(expr)
-        for c in coeffs:
-            if hasattr(c, "dtype"):
-                return c.dtype
-        raise ValueError("Could not extract dtype from expression, please ensure that all constants and coefficients have a dtype attribute")
-
-    def extract_scalar_value(scalar_expr):
-        """Extract float from a scalar UFL expression."""
-        if isinstance(scalar_expr, (ufl.classes.IntValue, ufl.classes.FloatValue)):
-            return float(scalar_expr)
-        elif isinstance(scalar_expr, dolfinx.fem.Function):
-            # Check if it's a RealElement (constant stored as Function)
-            if scalar_expr.function_space.ufl_element().is_real and scalar_expr.ufl_shape == ():
-                return float(scalar_expr.x.array[0])
-            else:
-                raise ValueError(f"Cannot extract scalar from spatial Function: {scalar_expr}")
-        elif isinstance(scalar_expr, dolfinx.fem.Constant) and scalar_expr.ufl_shape == ():
-            val = scalar_expr.value
-            return float(val) if hasattr(val, '__float__') else float(val.item())
-        elif isinstance(scalar_expr, ufl.classes.ScalarValue):
-            return float(scalar_expr._value)
-        elif isinstance(scalar_expr, ufl.classes.Product):
-            result = 1.0
-            for op in scalar_expr.ufl_operands:
-                result *= extract_scalar_value(op)
-            return result
-        elif isinstance(scalar_expr, ufl.classes.Division):
-            num, den = scalar_expr.ufl_operands
-            return extract_scalar_value(num) / extract_scalar_value(den)
+def extract_scalar_value(scalar_expr):
+    """Extract float from a scalar UFL expression."""
+    if isinstance(scalar_expr, (ufl.classes.IntValue, ufl.classes.FloatValue)):
+        return float(scalar_expr)
+    elif isinstance(scalar_expr, dolfinx.fem.Function):
+        # Check if it's a RealElement (constant stored as Function)
+        if scalar_expr.function_space.ufl_element().is_real and scalar_expr.ufl_shape == ():
+            return float(scalar_expr.x.array[0])
         else:
-            raise ValueError(f"Cannot extract scalar from {type(scalar_expr)}: {scalar_expr}")
+            raise ValueError(f"Cannot extract scalar from spatial Function: {scalar_expr}")
+    elif isinstance(scalar_expr, dolfinx.fem.Constant) and scalar_expr.ufl_shape == ():
+        val = scalar_expr.value
+        return float(val) if hasattr(val, "__float__") else float(val.item())
+    elif isinstance(scalar_expr, ufl.classes.ScalarValue):
+        return float(scalar_expr._value)
+    elif isinstance(scalar_expr, ufl.classes.Product):
+        result = 1.0
+        for op in scalar_expr.ufl_operands:
+            result *= extract_scalar_value(op)
+        return result
+    elif isinstance(scalar_expr, ufl.classes.Division):
+        num, den = scalar_expr.ufl_operands
+        return extract_scalar_value(num) / extract_scalar_value(den)
+    else:
+        raise ValueError(f"Cannot extract scalar from {type(scalar_expr)}: {scalar_expr}")
 
-    def extract_function(expr) -> tuple[bool, dolfinx.fem.Function | None]:
-        """Recursively extract a Function from nested UFL expressions.
+def extract_function(expr) -> tuple[bool, dolfinx.fem.Function | None]:
+    """Recursively extract a Function from nested UFL expressions.
 
-        Returns:
-            (is_real, func) where is_real=True means func is on RealElement (a constant)
+    :returns: A tuple (is_real, func) where is_real=True means func is on RealElement (a constant)
 
-        Note: Returns (False, None) for RealElement functions so they get handled
+    .. note:: 
+        Returns (False, None) for RealElement functions so they get handled
         as scalars by extract_scalar_value, preserving any multipliers.
-        """
-        if isinstance(expr, dolfinx.fem.Function):
-            is_real = expr.function_space.ufl_element().is_real
-            if is_real:
-                # Don't return RealElement functions - let them be handled as scalars
-                return (False, None)
-            return (False, expr)
-        elif isinstance(expr, (ufl.classes.Indexed, ufl.classes.ComponentTensor)):
-            # Indexed or ComponentTensor wraps the actual function
-            # Get the operand and recurse
-            return extract_function(expr.ufl_operands[0])
-        elif hasattr(expr, "ufl_operands"):
-            # Try each operand
-            for op in expr.ufl_operands:
-                is_real, func = extract_function(op)
-                if func is not None:
-                    return (is_real, func)
-        return (False, None)
+    """
+    if isinstance(expr, dolfinx.fem.Function):
+        is_real = expr.function_space.ufl_element().is_real
+        if is_real:
+            # Don't return RealElement functions - let them be handled as scalars
+            return (False, None)
+        return (False, expr)
+    elif isinstance(expr, (ufl.classes.Indexed, ufl.classes.ComponentTensor)):
+        # Indexed or ComponentTensor wraps the actual function
+        # Get the operand and recurse
+        return extract_function(expr.ufl_operands[0])
+    elif hasattr(expr, "ufl_operands"):
+        # Try each operand
+        for op in expr.ufl_operands:
+            is_real, func = extract_function(op)
+            if func is not None:
+                return (is_real, func)
+    return (False, None)
 
-    def extract_term(term):
-        """Extract (weight, function) from a single term."""
-        if isinstance(term, dolfinx.fem.Function):
-            is_real = term.ufl_element().is_real
+def extract_term(term):
+    """Extract (weight, function) from a single term."""
+    if isinstance(term, dolfinx.fem.Function):
+        is_real = term.ufl_element().is_real
+        if is_real:
+            return None  # RealElement is a constant, not a spatial function
+        return (1.0, term)
+    elif isinstance(term, ufl.classes.ComponentTensor):
+        # ComponentTensor(Product(Indexed(func), scalar), index)
+        # Extract from the inner product
+        inner_expr = term.ufl_operands[0]
+        return extract_term(inner_expr)
+    elif isinstance(term, ufl.classes.Indexed):
+        # Indexed(func, index) - just extract the function
+        is_real, func = extract_function(term)
+        if func is None:
+            return None
+        return (1.0, func)
+    elif isinstance(term, ufl.classes.Product):
+        weight = 1.0
+        func = None
+        for op in term.ufl_operands:
+            is_real, extracted_func = extract_function(op)
+            if extracted_func is not None:
+                # It's a spatial function (RealElement functions return None)
+                func = extracted_func
+            else:
+                # Not a function, or is a RealElement - extract as scalar
+                weight *= extract_scalar_value(op)
+        return (weight, func) if func is not None else None
+    elif isinstance(term, ufl.classes.Division):
+        num, den = term.ufl_operands
+        denom_val = extract_scalar_value(den)
+        if isinstance(num, dolfinx.fem.Function):
+            is_real = num.function_space.ufl_element().family() == "Real"
             if is_real:
-                return None  # RealElement is a constant, not a spatial function
-            return (1.0, term)
-        elif isinstance(term, ufl.classes.ComponentTensor):
-            # ComponentTensor(Product(Indexed(func), scalar), index)
-            # Extract from the inner product
-            inner_expr = term.ufl_operands[0]
-            return extract_term(inner_expr)
-        elif isinstance(term, ufl.classes.Indexed):
-            # Indexed(func, index) - just extract the function
-            is_real, func = extract_function(term)
-            if func is None:
                 return None
-            return (1.0, func)
-        elif isinstance(term, ufl.classes.Product):
-            weight = 1.0
-            func = None
-            for op in term.ufl_operands:
-                is_real, extracted_func = extract_function(op)
-                if extracted_func is not None:
-                    # It's a spatial function (RealElement functions return None)
-                    func = extracted_func
-                else:
-                    # Not a function, or is a RealElement - extract as scalar
-                    weight *= extract_scalar_value(op)
-            return (weight, func) if func is not None else None
-        elif isinstance(term, ufl.classes.Division):
-            num, den = term.ufl_operands
-            denom_val = extract_scalar_value(den)
-            if isinstance(num, dolfinx.fem.Function):
-                is_real = num.function_space.ufl_element().family() == "Real"
-                if is_real:
-                    return None
-                return (1.0 / denom_val, num)
-            elif isinstance(num, ufl.classes.Product):
-                result = extract_term(num)
-                return (result[0] / denom_val, result[1]) if result else None
-        return None
+            return (1.0 / denom_val, num)
+        elif isinstance(num, ufl.classes.Product):
+            result = extract_term(num)
+            return (result[0] / denom_val, result[1]) if result else None
+    return None
 
-    def extract_linear_combination(expr: ufl.core.expr.Expr) -> list[tuple[float, "dolfinx.fem.Function"]]:
-        """Extract (weight, function) pairs from a UFL linear combination.
+def extract_linear_combination(expr: ufl.core.expr.Expr) -> list[tuple[float, "dolfinx.fem.Function"]]:
+    """Extract (weight, function) pairs from a UFL linear combination.
 
-        Analyzes expressions like: 0.5*u + 0.3*v + 0.2*w
-        Returns: [(0.5, u), (0.3, v), (0.2, w)]
+    Analyzes expressions like: 0.5*u + 0.3*v + 0.2*w
+    Returns: [(0.5, u), (0.3, v), (0.2, w)]
 
-        Args:
-            expr: UFL expression (Sum, Product, or single Function)
+    :param expr: UFL expression (Sum, Product, or single Function)
+    :returns: List of (weight, function) tuples
+    """
 
-        Returns:
-            List of (weight, function) tuples
-        """
-
-        # Parse the expression, flattening nested Sums recursively
-        if isinstance(expr, ufl.classes.Sum):
-            summands = expr.ufl_operands
+    # Parse the expression, flattening nested Sums recursively
+    if isinstance(expr, ufl.classes.Sum):
+        summands = expr.ufl_operands
+    else:
+        summands = [expr]
+    terms = []
+    for summand in summands:
+        if isinstance(summand, ufl.classes.Sum):
+            # Recursively flatten nested Sum structures
+            terms.extend(extract_linear_combination(summand))
         else:
-            summands = [expr]
-        terms = []
-        for summand in summands:
-            if isinstance(summand, ufl.classes.Sum):
-                # Recursively flatten nested Sum structures
-                terms.extend(extract_linear_combination(summand))
-            else:
-                result = extract_term(summand)
-                if result is not None:
-                    terms.append(result)
-        return terms
+            result = extract_term(summand)
+            if result is not None:
+                terms.append(result)
+    return terms
 
-    def function_iadd(func: "dolfinx.fem.Function", expr: ufl.core.expr.Expr) -> None:
-        """Add a UFL expression to a DOLFINx Function in-place (func += expr).
+def function_iadd(func: "dolfinx.fem.Function", expr: ufl.core.expr.Expr) -> None:
+    """Add a UFL expression to a DOLFINx Function in-place (func += expr).
 
-        Extracts the linear combination structure and adds terms directly using
-        PETSc vector operations. Works with mixed spaces and subfunction views.
+    Extracts the linear combination structure and adds terms directly using
+    PETSc vector operations. Works with mixed spaces and subfunction views.
 
-        Args:
-            func: DOLFINx Function or subfunction view to update in-place
-            expr: UFL expression (linear combination of Functions)
+    :param func: DOLFINx Function or subfunction view to update in-place
+    :param expr: UFL expression (linear combination of Functions)
 
-        Example:
-            function_iadd(u, 0.5 * v + 0.3 * w)  # equivalent to u += 0.5*v + 0.3*w
-        """
-        # Extract the linear combination: [(weight1, func1), (weight2, func2), ...]
-        terms = extract_linear_combination(expr)
+    .. code-block:: python
+ 
+        function_iadd(u, 0.5 * v + 0.3 * w)  # equivalent to u += 0.5*v + 0.3*w
+    """
+    # Extract the linear combination: [(weight1, func1), (weight2, func2), ...]
+    terms = extract_linear_combination(expr)
 
-        # Add each term using array operations (works with mixed spaces when dofmaps match)
-        for weight, term_func in terms:
-            func.x.array[:] += weight * term_func.x.array[:]
+    # Add each term using array operations (works with mixed spaces when dofmaps match)
+    for weight, term_func in terms:
+        func.x.array[:] += weight * term_func.x.array[:]
 
-    # Patching of DOLFINx objects to mimick firedrake naming and properties.
-    def function_space_length(self):
-        return 1
+# Patching of DOLFINx objects to mimick firedrake naming and properties.
+def function_space_length(self):
+    return 1
 
-    def mixed_space_length(self):
-        return len(self.ufl_sub_spaces())
+def mixed_space_length(self):
+    return len(self.ufl_sub_spaces())
 
+def function_subfunctions(self):
+    """Get subfunctions for a DOLFINx function, which may be in a mixed space.
+    
+    This function is called when updating `u0` in time-stepping problems.
+    """
+    return [self]
+
+def function_iadd_method(self, other):
+    """In-place addition for DOLFINx functions (self += other).
+
+    This method is monkey-patched onto :py:class:`dolfinx.fem.Function` to enable
+    Firedrake-style arithmetic operations.
+
+    :param self: The function to be modified
+    :param other: The expression to add. Can be a UFL expression, Function, Constant, or scalar.
+
+    :returns: self (for chaining)
+    """
+    # Delegate to the standalone function_iadd which handles all the complexity
+    function_iadd(self, other)
+    return self
+
+dolfinx.fem.FunctionSpace.__len__ = function_space_length
+dolfinx.fem.Function.subfunctions = property(function_subfunctions)
+dolfinx.fem.Function.__iadd__ = function_iadd_method
+ufl.MixedFunctionSpace.__len__ = mixed_space_length
+
+class ListTensor(ufl.tensors.ListTensor):
+    """A list tensor that exposes subfunctions for DOLFINx functions"""
+
+    @property
     def subfunctions(self):
-        """Get subfunctions for a DOLFINx function, which may be in a mixed space."""
-        return [self]
+        sub_funcs = []
+        for i in range(self.ufl_shape[0]):
+            func = self.ufl_operands[i]
+            sub_funcs.append(func)
+        return sub_funcs
 
-    def function_iadd_method(self, other):
-        """In-place addition for DOLFINx functions (self += other).
+    def function_space(self):
+        return ufl.MixedFunctionSpace(*[self.ufl_operands[i].ufl_function_space() for i in range(self.ufl_shape[0])])
 
-        This method is monkey-patched onto :py:class:`dolfinx.fem.Function` to enable
-        Firedrake-style arithmetic operations.
+class LinearProblem(dolfinx.fem.petsc.LinearProblem):
+    """Overloaded linear problem that pack BCs before solving"""
 
-        Args:
-            self: The function to be modified
-            other: The expression to add. Can be a UFL expression, Function, Constant, or scalar.
+    def solve(self, bounds=None):
+        if bounds is not None:
+            raise NotImplementedError("Bounds-constrained solves are not implemented for DOLFINx")
+        [bc.pack() for bc in self._bcs]
+        super().solve()
 
-        Returns:
-            self (for chaining)
-        """
-        # Delegate to the standalone function_iadd which handles all the complexity
-        function_iadd(self, other)
-        return self
+class NonlinearProblem(dolfinx.fem.petsc.NonlinearProblem):
+    """Overloaded nonlinear problem that pack BCs before solving.
 
-    dolfinx.fem.FunctionSpace.__len__ = function_space_length
-    dolfinx.fem.Function.subfunctions = property(subfunctions)
-    dolfinx.fem.Function.__iadd__ = function_iadd_method
-    ufl.MixedFunctionSpace.__len__ = mixed_space_length
+    Does each  Newton iteration or line search step by overriding the
+    SNES function and Jacobian assembly routines to pack BCs before assembly.
+    """
 
-    class ListTensor(ufl.tensors.ListTensor):
-        """A list tensor that exposes subfunctions for DOLFINx functions"""
-        @property
-        def subfunctions(self):
-            sub_funcs = []
-            for i in range(self.ufl_shape[0]):
-                func = self.ufl_operands[i]
-                sub_funcs.append(func)
-            return sub_funcs
-
-        def function_space(self):
-            return ufl.MixedFunctionSpace(*[self.ufl_operands[i].ufl_function_space() for i in range(self.ufl_shape[0])])
-
-    class LinearProblem(dolfinx.fem.petsc.LinearProblem):
-        """Overloaded linear problem that pack BCs before solving"""
-        def solve(self, bounds=None):
-            if bounds is not None:
-                raise NotImplementedError("Bounds-constrained solves are not implemented for DOLFINx")
-            [bc.pack() for bc in self._bcs]
-            super().solve()
-
-    class NonlinearProblem(dolfinx.fem.petsc.NonlinearProblem):
-        """Overloaded nonlinear problem that pack BCs before solving.
-
-        Done eac  Newton iteration or line search step by overriding the
-        SNES function and Jacobian assembly routines to pack BCs before assembly.
-        """
-        def __init__(
-            self,
-            F: ufl.form.Form | Sequence[ufl.form.Form],
-            u: dolfinx.fem.Function | Sequence[dolfinx.fem.Function],
-            *,
-            petsc_options_prefix: str,
-            bcs: Sequence[dolfinx.fem.DirichletBC] | None = None,
-            J: ufl.form.Form | Sequence[Sequence[ufl.form.Form]] | None = None,
-            P: ufl.form.Form | Sequence[Sequence[ufl.form.Form]] | None = None,
-            kind: str | Sequence[Sequence[str]] | None = None,
-            petsc_options: dict | None = None,
-            form_compiler_options: dict | None = None,
-            jit_options: dict | None = None,
-            entity_maps: Sequence[dolfinx.mesh.EntityMap] | None = None,
-        ):
-            super().__init__(
-                F,
-                u,
-                petsc_options_prefix=petsc_options_prefix,
-                bcs=bcs,
-                J=J,
-                P=P,
-                kind=kind,
-                petsc_options=petsc_options,
-                form_compiler_options=form_compiler_options,
-                jit_options=jit_options,
-                entity_maps=entity_maps,
-            )
-            self._bcs = bcs
-
-            def assemble_residual(
-                _snes: PETSc.SNES,  # type: ignore[name-defined]
-                x: PETSc.Vec,  # type: ignore[name-defined]
-                b: PETSc.Vec,  # type: ignore[name-defined]
-                u: dolfinx.fem.Function | Sequence[dolfinx.fem.Function],
-                residual: dolfinx.fem.Form | Sequence[dolfinx.fem.Form],
-                jacobian: dolfinx.fem.Form | Sequence[Sequence[dolfinx.fem.Form]],
-                bcs: Sequence[dolfinx.fem.DirichletBC],
-                _blocks: tuple[tuple[int, int, int], ...] | None = None,
-            ):
-
-                [bc.pack() for bc in bcs]
-                # Cover single stage problems where _blocks is None
-                dolfinx.fem.petsc.assemble_residual(
-                    _snes, x, b, u, residual, jacobian, bcs, _blocks
-                )
-
-            if isinstance(u, Sequence) and len(u) == 1:
-                assert len(self.F) == 1 and len(self.J) == 1 and len(self.J[0]) == 1
-                kargs = {
-                    "u": u[0],
-                    "residual": self.F[0],
-                    "jacobian": self.J[0][0],
-                    "bcs": self._bcs,
-                    "_blocks": self.b.getAttr("_blocks"),
-                }
-                jac_kargs = {
-                    "u": u[0],
-                    "jacobian": self.J[0][0],
-                    "bcs": self._bcs,
-                    "preconditioner": self._preconditioner,
-                }
-                if self._P_mat is not None:
-                    assert (
-                        len(self._preconditioner) == 1
-                        and len(self._preconditioner[0]) == 1
-                    )
-            else:
-                kargs = {
-                    "u": u,
-                    "residual": self.F,
-                    "jacobian": self.J,
-                    "bcs": self._bcs,
-                    "_blocks": self.b.getAttr("_blocks"),
-                }
-                jac_kargs = {
-                    "u": u,
-                    "jacobian": self.J,
-                    "bcs": self._bcs,
-                    "preconditioner": self._preconditioner,
-                }
-            self.solver.setFunction(assemble_residual, self.b, kargs=kargs)
-
-            def assemble_jacobian(
-                _snes: PETSc.SNES,  # type: ignore[name-defined]
-                x: PETSc.Vec,  # type: ignore[name-defined]
-                J: PETSc.Mat,  # type: ignore[name-defined]
-                P_mat: PETSc.Mat,  # type: ignore[name-defined]
-                u: Sequence[dolfinx.fem.Function] | dolfinx.fem.Function,
-                jacobian: dolfinx.fem.Form | Sequence[Sequence[dolfinx.fem.Form]],
-                preconditioner: dolfinx.fem.Form
-                | Sequence[Sequence[dolfinx.fem.Form]]
-                | None,
-                bcs: Sequence[dolfinx.fem.DirichletBC],
-            ):
-                [bc.pack() for bc in bcs]
-                dolfinx.fem.petsc.assemble_jacobian(
-                    _snes, x, J, P_mat, u, jacobian, preconditioner, bcs
-                )
-            self.solver.setJacobian(
-                assemble_jacobian, self.A, self.P_mat, kargs=jac_kargs
-            )
-
-        def solve(self, bounds=None):
-            if bounds is not None:
-                raise NotImplementedError("Bounds-constrained solves are not implemented for DOLFINx")
-            super().solve()
-
-        @property
-        def snes(self) -> PETSc.SNES:  # type: ignore[name-defined]
-            return self.solver
-
-    def dirichletbc(
-        value: ufl.core.expr.Expr, dofs: npt.NDArray[np.int32],
-        V: dolfinx.fem.FunctionSpace | None = None,
+    def __init__(
+        self,
+        F: ufl.form.Form | Sequence[ufl.form.Form],
+        u: dolfinx.fem.Function | Sequence[dolfinx.fem.Function],
+        *,
+        petsc_options_prefix: str,
+        bcs: Sequence[dolfinx.fem.DirichletBC] | None = None,
+        J: ufl.form.Form | Sequence[Sequence[ufl.form.Form]] | None = None,
+        P: ufl.form.Form | Sequence[Sequence[ufl.form.Form]] | None = None,
+        kind: str | Sequence[Sequence[str]] | None = None,
+        petsc_options: dict | None = None,
+        form_compiler_options: dict | None = None,
+        jit_options: dict | None = None,
+        entity_maps: Sequence[dolfinx.mesh.EntityMap] | None = None,
     ):
-        """Overloaded DirichletBC so that we can reconstruct BCs with UFL expressions.
+        super().__init__(
+            F,
+            u,
+            petsc_options_prefix=petsc_options_prefix,
+            bcs=bcs,
+            J=J,
+            P=P,
+            kind=kind,
+            petsc_options=petsc_options,
+            form_compiler_options=form_compiler_options,
+            jit_options=jit_options,
+            entity_maps=entity_maps,
+        )
+        self._bcs = bcs
 
-        value: A UFL expression representing the boundary condition.
-        dofs: An array of degree-of-freedom indices in `V` where the BC should be applied.
-        V: The function space on which the BC applies. It can be a subspace of a mixed/blocked space.
-        """
-        return DirichletBC(value, dofs, V)
+        def assemble_residual(
+            _snes: PETSc.SNES,  # type: ignore[name-defined]
+            x: PETSc.Vec,  # type: ignore[name-defined]
+            b: PETSc.Vec,  # type: ignore[name-defined]
+            u: dolfinx.fem.Function | Sequence[dolfinx.fem.Function],
+            residual: dolfinx.fem.Form | Sequence[dolfinx.fem.Form],
+            jacobian: dolfinx.fem.Form | Sequence[Sequence[dolfinx.fem.Form]],
+            bcs: Sequence[dolfinx.fem.DirichletBC],
+            _blocks: tuple[tuple[int, int, int], ...] | None = None,
+        ):
 
-    def get_stage_space(V: ufl.FunctionSpace, num_stages: int) -> ufl.FunctionSpace:
-        if num_stages == 1:
-            space_list = [V]
-        else:
-            space_list = [V.clone() for _ in range(num_stages)]
-        return ufl.MixedFunctionSpace(*space_list)
+            [bc.pack() for bc in bcs]
+            # Cover single stage problems where _blocks is None
+            dolfinx.fem.petsc.assemble_residual(
+                _snes, x, b, u, residual, jacobian, bcs, _blocks
+            )
 
-    class DirichletBC(dolfinx.fem.DirichletBC):
-        _pack_expression: dolfinx.fem.Expression | None
-        _ufl_expr: ufl.core.expr.Expr | None  # Store original UFL expression
-
-        def __init__(self, g: ufl.core.expr.Expr, dofs: npt.NDArray[np.int32], V: dolfinx.fem.FunctionSpace):
-            """
-            Create an Irksome compatible DirichletBC from an existing DOLFINx bc, created by `irksome.backends.dolfinx.dirichletbc`.
-
-            Args:
-                g: The boundary condition expression
-                dofs: An array of degree-of-freedom indices in V
-                V: The space to construct the BC on.
-            """
-
-            # Attach UFL function space (to be able to reconstruct functions and constants on the same UFL domain)
-            self._ufl_space = V.ufl_function_space()
-
-            # Store original UFL expression for time-varying BCs
-            if not isinstance(g, (dolfinx.fem.Function, dolfinx.fem.Constant, int, float, complex)):
-                self._ufl_expr = g  # Save the symbolic expression
-            else:
-                self._ufl_expr = None
-            self._ufl_space = V.ufl_function_space()
-
-            # If reconstructing with a sub space, we need to get the subspace dof indices
-            # If working with a subspace of a single stage, we need to create the (parent_dof, sub_dof) mapping
-            if V.component() != []:
-                V_sub, sub_to_parent = V.collapse()
-                if len(sub_to_parent) != 1:
-                    raise NotImplementedError(
-                        "Mixed topology is not supported for reconstructing BCs with UFL expressions"
-                    )
-                else:
-                    sub_to_parent = sub_to_parent[0]
-                    parent_to_sub = np.full(
-                        (V.dofmap.index_map.size_local + V.dofmap.index_map.num_ghosts)
-                        * V.dofmap.index_map_bs,
-                        -1,
-                        dtype=np.int32,
-                    )
-                    parent_to_sub[sub_to_parent] = np.arange(len(sub_to_parent))
-                    sub_dofs = parent_to_sub[dofs]
-                    dofs = (dofs, sub_dofs)
-
-            # If we are not reconstructing the BC with a new value, we can reuse existing C++ objects
-            self._pack_expression = None
-
-            # If we are reconstructing the BC with a new value, we need to check if the new value is a DOLFINx function or Constant.
-            # If True, we do not need to do anything for reconstruction.
-            if isinstance(g, (dolfinx.fem.Function, dolfinx.fem.Constant)):
-                val = g
-                self._pack_expression = None
-            else:
-                # If not, we need to take the ufl.core.expr.Expr and pack it into a DOLFINx Expression
-                if V.component() != []:
-                    val = dolfinx.fem.Function(V_sub, name=f"bc_{str(g)}")._cpp_object
-                else:
-                    val = dolfinx.fem.Function(V, name=f"bc_{str(g)}")._cpp_object
-                self._pack_expression = dolfinx.fem.Expression(g, V.element.interpolation_points)
-
-            # Get correct C++ implementation based on dtype of expression
-            dtype = extract_dtype(g)
-            if np.issubdtype(dtype, np.float32):
-                bctype = dolfinx.cpp.fem.DirichletBC_float32
-            elif np.issubdtype(dtype, np.float64):
-                bctype = dolfinx.cpp.fem.DirichletBC_float64
-            elif np.issubdtype(dtype, np.complex64):
-                bctype = dolfinx.cpp.fem.DirichletBC_complex64
-            elif np.issubdtype(dtype, np.complex128):
-                bctype = dolfinx.cpp.fem.DirichletBC_complex128
-            else:
-                raise NotImplementedError(f"Type {dtype} not supported.")
-
-            if (
-                isinstance(
-                    val,
-                    (
-                        dolfinx.cpp.fem.Function_complex128,
-                        dolfinx.cpp.fem.Function_complex64,
-                        dolfinx.cpp.fem.Function_float32,
-                        dolfinx.cpp.fem.Function_float64,
-                    ),
+        if isinstance(u, Sequence) and len(u) == 1:
+            assert len(self.F) == 1 and len(self.J) == 1 and len(self.J[0]) == 1
+            kargs = {
+                "u": u[0],
+                "residual": self.F[0],
+                "jacobian": self.J[0][0],
+                "bcs": self._bcs,
+                "_blocks": self.b.getAttr("_blocks"),
+            }
+            jac_kargs = {
+                "u": u[0],
+                "jacobian": self.J[0][0],
+                "bcs": self._bcs,
+                "preconditioner": self._preconditioner,
+            }
+            if self._P_mat is not None:
+                assert (
+                    len(self._preconditioner) == 1
+                    and len(self._preconditioner[0]) == 1
                 )
-                and val.function_space == V._cpp_object
-            ):
-                new_cpp_object = bctype(val, dofs)
+        else:
+            kargs = {
+                "u": u,
+                "residual": self.F,
+                "jacobian": self.J,
+                "bcs": self._bcs,
+                "_blocks": self.b.getAttr("_blocks"),
+            }
+            jac_kargs = {
+                "u": u,
+                "jacobian": self.J,
+                "bcs": self._bcs,
+                "preconditioner": self._preconditioner,
+            }
+        self.solver.setFunction(assemble_residual, self.b, kargs=kargs)
+
+        def assemble_jacobian(
+            _snes: PETSc.SNES,  # type: ignore[name-defined]
+            x: PETSc.Vec,  # type: ignore[name-defined]
+            J: PETSc.Mat,  # type: ignore[name-defined]
+            P_mat: PETSc.Mat,  # type: ignore[name-defined]
+            u: Sequence[dolfinx.fem.Function] | dolfinx.fem.Function,
+            jacobian: dolfinx.fem.Form | Sequence[Sequence[dolfinx.fem.Form]],
+            preconditioner: dolfinx.fem.Form
+            | Sequence[Sequence[dolfinx.fem.Form]]
+            | None,
+            bcs: Sequence[dolfinx.fem.DirichletBC],
+        ):
+            [bc.pack() for bc in bcs]
+            dolfinx.fem.petsc.assemble_jacobian(
+                _snes, x, J, P_mat, u, jacobian, preconditioner, bcs
+            )
+
+        self.solver.setJacobian(
+            assemble_jacobian, self.A, self.P_mat, kargs=jac_kargs
+        )
+
+    def solve(self, bounds=None):
+        if bounds is not None:
+            raise NotImplementedError("Bounds-constrained solves are not implemented for DOLFINx")
+        super().solve()
+
+    @property
+    def snes(self) -> PETSc.SNES:  # type: ignore[name-defined]
+        return self.solver
+
+def get_stage_space(V: ufl.FunctionSpace, num_stages: int) -> ufl.FunctionSpace:
+    if num_stages == 1:
+        space_list = [V]
+    else:
+        space_list = [V.clone() for _ in range(num_stages)]
+    return ufl.MixedFunctionSpace(*space_list)
+
+class DirichletBC(dolfinx.fem.DirichletBC):
+    _pack_expression: dolfinx.fem.Expression | None
+    _ufl_expr: ufl.core.expr.Expr | None  # Store original UFL expression
+
+    def __init__(self, g: ufl.core.expr.Expr, dofs: npt.NDArray[np.int32], V: dolfinx.fem.FunctionSpace):
+        """
+        Create an Irksome compatible DirichletBC from an existing DOLFINx bc.
+        
+        .. note::
+            This is not a user-facing class, but rather an internal class used for BC reconstruction in time-stepping problems.
+            Use: :func:`irksome.backends.dolfinx.dirichletbc`.
+
+        :param g: The boundary condition expression
+        :param dofs: An array of degree-of-freedom indices in V
+        :param V: The space to construct the BC on.
+        """
+
+        # Attach UFL function space (to be able to reconstruct functions and constants on the same UFL domain)
+        self._ufl_space = V.ufl_function_space()
+
+        # Store original UFL expression for time-varying BCs
+        if not isinstance(g, (dolfinx.fem.Function, dolfinx.fem.Constant, int, float, complex)):
+            self._ufl_expr = g  # Save the symbolic expression
+        else:
+            self._ufl_expr = None
+        self._ufl_space = V.ufl_function_space()
+
+        # If reconstructing with a sub space, we need to get the subspace dof indices
+        # If working with a subspace of a single stage, we need to create the (parent_dof, sub_dof) mapping
+        if V.component() != []:
+            V_sub, sub_to_parent = V.collapse()
+            if len(sub_to_parent) != 1:
+                raise NotImplementedError(
+                    "Mixed topology is not supported for reconstructing BCs with UFL expressions"
+                )
             else:
-                # Depending on your FEniCSx version, the C++ constructor might strictly
-                # expect the C++ FunctionSpace instead of the Python FunctionSpace wrapper.
-                try:
-                    new_cpp_object = bctype(val, dofs, V._cpp_object)
-                except TypeError:
-                    new_cpp_object = bctype(val._cpp_object, dofs, V._cpp_object)
+                sub_to_parent = sub_to_parent[0]
+                parent_to_sub = np.full(
+                    (V.dofmap.index_map.size_local + V.dofmap.index_map.num_ghosts)
+                    * V.dofmap.index_map_bs,
+                    -1,
+                    dtype=np.int32,
+                )
+                parent_to_sub[sub_to_parent] = np.arange(len(sub_to_parent))
+                sub_dofs = parent_to_sub[dofs]
+                dofs = (dofs, sub_dofs)
 
-            # 4. Initialize the parent dolfinx.fem.DirichletBC wrapper with the newly minted C++ object
-            super().__init__(new_cpp_object)
+        # If we are not reconstructing the BC with a new value, we can reuse existing C++ objects
+        self._pack_expression = None
 
-            # 5. Store your custom properties
-            self._orig_g = val
+        # If we are reconstructing the BC with a new value, we need to check if the new value is a DOLFINx function or Constant.
+        # If True, we do not need to do anything for reconstruction.
+        if isinstance(g, (dolfinx.fem.Function, dolfinx.fem.Constant)):
+            val = g
+            self._pack_expression = None
+        else:
+            # If not, we need to take the ufl.core.expr.Expr and pack it into a DOLFINx Expression
+            if V.component() != []:
+                val = dolfinx.fem.Function(V_sub, name=f"bc_{str(g)}")._cpp_object
+            else:
+                val = dolfinx.fem.Function(V, name=f"bc_{str(g)}")._cpp_object
+            self._pack_expression = dolfinx.fem.Expression(g, V.element.interpolation_points)
 
-        def pack(self):
-            if self._pack_expression is not None:
-                self.g.interpolate_expr(self._pack_expression._cpp_object, None, None)
+        # Get correct C++ implementation based on dtype of expression
+        dtype = extract_dtype(g)
+        if np.issubdtype(dtype, np.float32):
+            bctype = dolfinx.cpp.fem.DirichletBC_float32
+        elif np.issubdtype(dtype, np.float64):
+            bctype = dolfinx.cpp.fem.DirichletBC_float64
+        elif np.issubdtype(dtype, np.complex64):
+            bctype = dolfinx.cpp.fem.DirichletBC_complex64
+        elif np.issubdtype(dtype, np.complex128):
+            bctype = dolfinx.cpp.fem.DirichletBC_complex128
+        else:
+            raise NotImplementedError(f"Type {dtype} not supported.")
 
-        @property
-        def _original_arg(self):
-            # If we stored the original UFL expression, return it for time substitution
-            if hasattr(self, '_ufl_expr') and self._ufl_expr is not None:
-                return self._ufl_expr
-
-            # Otherwise return the wrapped Function/Constant
-            if isinstance(
-                self._orig_g,
+        if (
+            isinstance(
+                val,
                 (
                     dolfinx.cpp.fem.Function_complex128,
                     dolfinx.cpp.fem.Function_complex64,
                     dolfinx.cpp.fem.Function_float32,
                     dolfinx.cpp.fem.Function_float64,
                 ),
-            ):
-                return dolfinx.fem.Function(self._ufl_space, dolfinx.la.Vector(self._orig_g.x), name=f"orig_{self._orig_g.name:s}")
-            elif isinstance(
-                self._orig_g,
-                (
-                    dolfinx.cpp.fem.Constant_complex64,
-                    dolfinx.cpp.fem.Constant_complex128,
-                    dolfinx.cpp.fem.Constant_float32,
-                    dolfinx.cpp.fem.Constant_float64,
-                ),
-            ):
-                return dolfinx.fem.Constant(
-                    self._ufl_space.ufl_domain(), self._orig_g.value
-                )
-            return self._orig_g
-
-        def reconstruct(self, V, g):
-            return DirichletBC(g, self.dof_indices()[0], V=V)
-
-    def bc2space(bc, V):
-        return get_sub(V, bc.function_space.component())
-
-    def stage2spaces4bc(bc, V, Vbig, i):
-        """used to figure out how to apply Dirichlet BC to each stage"""
-        comp = bc.function_space.component()
-        Vbig_i = Vbig.ufl_sub_spaces()[i]
-        return get_sub(Vbig_i, comp)
-
-    def extract_bcs(bcs: typing.Any) -> tuple[typing.Any]:
-        """Extract boundary conditions"""
-        return bcs
-
-    def create_variational_problem(F, u, bcs=None, aP=None, **kwargs):
-        """Create a variational problem."""
-        rank = len(np.unique([arg.number() for arg in F.arguments()]))
-        prefix = kwargs.get("petsc_options_prefix", "IrkSomeSolver")
-        if isinstance(u, ListTensor):
-            u = u.subfunctions
-        if rank == 2:
-            a, L = ufl.system(F)
-            a = ufl.extract_blocks(a)
-            L = ufl.extract_blocks(L)
-            return LinearProblem(
-                a,
-                L,
-                u,
-                bcs=bcs,
-                petsc_options_prefix=prefix,
-                P=aP,
-                **kwargs,
             )
-        elif rank == 1:
-            F = ufl.extract_blocks(F)
-            return NonlinearProblem(
-                F,
-                u,
-                petsc_options_prefix=prefix,
-                bcs=bcs,
-                petsc_options=kwargs.get("solver_parameters"),
-            )
+            and val.function_space == V._cpp_object
+        ):
+            new_cpp_object = bctype(val, dofs)
         else:
-            raise RuntimeError(f"Forms of rank {rank} are not supported in create_variational_problem")
-
-    def create_variational_solver(
-        problem: dolfinx.fem.petsc.LinearProblem | dolfinx.fem.petsc.NonlinearProblem,
-        **kwargs,
-    ):
-        """Create a variational solver that uses PETSc SNES or KSP."""
-        solver_parameters = kwargs.get("solver_parameters", {})
-        solver = problem.solver
-
-        # Update solver prefix
-        solver_prefix = solver_parameters.get(
-            "petsc_options_prefix", problem.solver.getOptionsPrefix()
-        )
-        problem._petsc_options_prefix = solver_prefix
-        problem.solver.setOptionsPrefix(solver_prefix)
-        problem.A.setOptionsPrefix(f"{solver_prefix}A_")
-        problem.b.setOptionsPrefix(f"{solver_prefix}b_")
-        problem.x.setOptionsPrefix(f"{solver_prefix}x_")
-        if problem.P_mat is not None:
-            problem.P_mat.setOptionsPrefix(f"{solver_prefix}P_mat_")
-        # Push new options with prefix, filtering out irksome-internal keys
-        petsc_opts = {
-            k: v for k, v in solver_parameters.items() if k != "petsc_options_prefix"
-        }
-        opts = PETSc.Options()
-        opts.prefixPush(solver_prefix)
-        for k, v in petsc_opts.items():
-            opts.setValue(k, v)
-        solver.setFromOptions()
-        opts.prefixPop()
-        # For some strange reason delValue doesn't respect prefixes
-        for k in petsc_opts:
-            opts.delValue(f"{solver_prefix}{k}")
-
-        nullspace = kwargs.get("nullspace", None)
-        near_nullspace = kwargs.get("near_nullspace", None)
-        if nullspace is not None:
-            problem.A.setNullSpace(nullspace)
-        if near_nullspace is not None:
-            problem.A.setNearNullSpace(near_nullspace)
-        return problem
-
-    def get_function_space(u: ufl.Coefficient | ufl.Argument) -> ufl.FunctionSpace:
-        if isinstance(u, (ufl.Coefficient, ufl.Argument)):
-            return u.ufl_function_space()
-        else:
-            raise ValueError(f"Cannot get function space for object of type {type(u)}")
-
-    def get_stages(V: dolfinx.fem.FunctionSpace, num_stages: int) -> ListTensor:
-        """
-        Given a function space for a single time-step, get a duplicate of this space,
-        repeated `num_stages` times.
-
-        Args:
-            V: Space for single step
-            num_stages: Number of stages
-
-        Returns:
-            A coefficient in the new function space
-        """
-        _Vbig = [V.clone() for _ in range(num_stages)]
-        Vbig = ufl.MixedFunctionSpace(*_Vbig)
-        return ListTensor(*[dolfinx.fem.Function(Vi, name=f"stage_{i}") for i, Vi in enumerate(Vbig.ufl_sub_spaces())])
-
-    class FloatConstantFunction(dolfinx.fem.Function):
-        def __float__(self):
-            if len(self.x.array) != 1:
-                raise ValueError("Can only convert a FloatConstantFunction to float if it has exactly one degree of freedom")
-            return float(self.x.array[0])
-
-        def assign(self, value):
-            self.x.array[0] = self.x.array.dtype.type(value)
-            self.x.scatter_forward()
-
-    class MeshConstant(object):
-        def __init__(self, msh):
-            self.msh = msh
+            # Depending on your FEniCSx version, the C++ constructor might strictly
+            # expect the C++ FunctionSpace instead of the Python FunctionSpace wrapper.
             try:
-                import basix.ufl
-
-                r_el = basix.ufl.real_element(
-                    msh.basix_cell(), value_shape=(), dtype=dolfinx.default_scalar_type
-                )
-                self.V = dolfinx.fem.functionspace(msh, r_el)
+                new_cpp_object = bctype(val, dofs, V._cpp_object)
             except TypeError:
-                try:
-                    import scifem
-                except ModuleNotFoundError:
-                    raise RuntimeError(
-                        "DOLFINx with real element support or Scifem is required to make mesh-constants"
-                    )
-                self.V = scifem.create_real_functionspace(msh, ())
+                new_cpp_object = bctype(val._cpp_object, dofs, V._cpp_object)
 
-        def Constant(self, val=0.0) -> ufl.Coefficient:
-            v = FloatConstantFunction(self.V)
-            v.x.array[:] = val
-            return v
+        # 4. Initialize the parent dolfinx.fem.DirichletBC wrapper with the newly minted C++ object
+        super().__init__(new_cpp_object)
 
-    def get_mesh_constant(MC: MeshConstant | None) -> ufl.core.expr.Expr:
-        return MC.Constant if MC is not None else ufl.constantvalue.ComplexValue
+        # 5. Store your custom properties
+        self._orig_g = val
 
-    def norm(
-        v: ufl.core.expr.Expr, norm_type: str = "L2", mesh: ufl.Mesh | None = None
-    ) -> float:
-        """Compute the norm of a function in the backend language."""
-        if mesh is not None:
-            dx = ufl.Measure("dx", domain=mesh)
-        else:
-            dx = ufl.dx
-        p = 2
-        if norm_type.startswith("L"):
-            p = int(norm_type[1:])
-            if p < 1:
-                raise ValueError(f"Invalid norm type {norm_type}")
-            expr = ufl.inner(v, v) ** (p / 2)
-            form = dolfinx.fem.form(expr * dx)
-        else:
-            raise NotImplementedError(f"Norm type {norm_type} not implemented")
-        norm_loc = dolfinx.fem.assemble_scalar(form)
-        norm_global = form.mesh.comm.allreduce(norm_loc, op=MPI.SUM)
-        return norm_global ** (1 / p)
+    def pack(self):
+        if self._pack_expression is not None:
+            self.g.interpolate_expr(self._pack_expression._cpp_object, None, None)
 
-    def assemble(expr: ufl.core.expr.Expr | float):
-        """Assemble a UFL expression in the backend language."""
-        if isinstance(expr, float):
-            return float
-        else:
-            form = dolfinx.fem.form(expr)
-            if form.rank == 0:
-                return dolfinx.fem.assemble_scalar(form)
-            elif form.rank == 1:
-                return dolfinx.fem.assemble_vector(form)
-            elif form.rank == 2:
-                return dolfinx.fem.assemble_matrix(form)
-            else:
-                raise ValueError(f"Cannot assemble form of rank {form.rank}")
+    @property
+    def _original_arg(self):
+        # If we stored the original UFL expression, return it for time substitution
+        if hasattr(self, "_ufl_expr") and self._ufl_expr is not None:
+            return self._ufl_expr
 
-    derivative = ufl.derivative
-
-    def TrialFunction(function_space):
-        """Create a trial function in the backend language."""
-        return ufl.as_tensor(ufl.TrialFunction(function_space))
-
-    def Function(V: ufl.FunctionSpace | ufl.MixedFunctionSpace, name=None):
-        """Create a function in the backend language."""
-        if isinstance(V, ufl.MixedFunctionSpace):
-            return ListTensor(
-                *[
-                    dolfinx.fem.Function(Vi, name=f"{name}_{i}")
-                    for i, Vi in enumerate(V.ufl_sub_spaces())
-                ]
+        # Otherwise return the wrapped Function/Constant
+        if isinstance(
+            self._orig_g,
+            (
+                dolfinx.cpp.fem.Function_complex128,
+                dolfinx.cpp.fem.Function_complex64,
+                dolfinx.cpp.fem.Function_float32,
+                dolfinx.cpp.fem.Function_float64,
+            ),
+        ):
+            return dolfinx.fem.Function(self._ufl_space, dolfinx.la.Vector(self._orig_g.x), name=f"orig_{self._orig_g.name:s}")
+        elif isinstance(
+            self._orig_g,
+            (
+                dolfinx.cpp.fem.Constant_complex64,
+                dolfinx.cpp.fem.Constant_complex128,
+                dolfinx.cpp.fem.Constant_float32,
+                dolfinx.cpp.fem.Constant_float64,
+            ),
+        ):
+            return dolfinx.fem.Constant(
+                self._ufl_space.ufl_domain(), self._orig_g.value
             )
-        else:
-            return dolfinx.fem.Function(V, name=name)
+        return self._orig_g
 
-    def TestFunction(function_space):
-        """Create a test function in the backend language."""
-        return ufl.as_tensor(ufl.TestFunctions(function_space))
+    def reconstruct(self, V, g):
+        return DirichletBC(g, self.dof_indices()[0], V=V)
 
-    class Constant(ufl.constantvalue.ScalarValue):
-        # NOTE: If dolfinx ever get's meshless constants we should change this
-        def assign(self, value):
-            self._value = value
+def dirichletbc(
+    value: ufl.core.expr.Expr,
+    dofs: npt.NDArray[np.int32],
+    V: dolfinx.fem.FunctionSpace | None = None,
+) -> DirichletBC:
+    """Overloaded DirichletBC so that we can reconstruct BCs with UFL expressions.
 
-    class EquationBCSplit:
-        def __init__(self, *args, **kwargs):
-            raise NotImplementedError("DOLFINx does not support EquationBCSplit")
+    .. note::
+        This class is user-facing.
 
-    class EquationBC:
-        def __init__(self, *args, **kwargs):
-            raise NotImplementedError("DOLFINx does not support EquationBC")
+    :param value: A UFL expression representing the boundary condition.
+    :param dofs: An array of degree-of-freedom indices in `V` where the BC should be applied.
+    :param V: The function space on which the BC applies. It can be a subspace of a mixed/blocked space.
+    """
+    return DirichletBC(value, dofs, V)
 
-    def invalidate_jacobian(solver: dolfinx.fem.petsc.LinearProblem):
-        """Invalidate the Jacobian matrix in the backend language."""
-        pass
-        # raise RuntimeError("DOLFINx does not support Jacobian invalidation")
+def bc2space(bc, V):
+    return get_sub(V, bc.function_space.component())
 
-    def create_bounds_constrained_bc(V, g, sub_domain, bounds, solver_parameters=None):
-        raise NotImplementedError(
-            "Bounds-constrained BCs are not implemented for DOLFINx"
+def stage2spaces4bc(bc, V, Vbig, i):
+    """used to figure out how to apply Dirichlet BC to each stage"""
+    comp = bc.function_space.component()
+    Vbig_i = Vbig.ufl_sub_spaces()[i]
+    return get_sub(Vbig_i, comp)
+
+def extract_bcs(bcs: typing.Any) -> tuple[typing.Any]:
+    """Extract boundary conditions"""
+    return bcs
+
+def create_variational_problem(F, u, bcs=None, aP=None, **kwargs):
+    """Create a variational problem."""
+    rank = len(np.unique([arg.number() for arg in F.arguments()]))
+    prefix = kwargs.get("petsc_options_prefix", "IrkSomeSolver")
+    if isinstance(u, ListTensor):
+        u = u.subfunctions
+    if rank == 2:
+        a, L = ufl.system(F)
+        a = ufl.extract_blocks(a)
+        L = ufl.extract_blocks(L)
+        return LinearProblem(
+            a,
+            L,
+            u,
+            bcs=bcs,
+            petsc_options_prefix=prefix,
+            P=aP,
+            **kwargs,
         )
+    elif rank == 1:
+        F = ufl.extract_blocks(F)
+        return NonlinearProblem(
+            F,
+            u,
+            petsc_options_prefix=prefix,
+            bcs=bcs,
+            petsc_options=kwargs.get("solver_parameters"),
+        )
+    else:
+        raise RuntimeError(f"Forms of rank {rank} are not supported in create_variational_problem")
 
-    def getNullspace(V, Vbig, num_stages, nullspace):
-        """
-        Computes the nullspace for a multi-stage method.
+def create_variational_solver(
+    problem: dolfinx.fem.petsc.LinearProblem | dolfinx.fem.petsc.NonlinearProblem,
+    **kwargs,
+):
+    """Create a variational solver that uses PETSc SNES or KSP."""
+    solver_parameters = kwargs.get("solver_parameters", {})
+    solver = problem.solver
 
-        :arg V: The :class:`ufl.FunctionSpace` on which the original time-dependent PDE is posed.
-        :arg Vbig: The multi-stage :class:`ufl.MixedFunctionSpace` for the stage problem
-        :arg num_stages: The number of stages in the RK method
-        :arg nullspace: The nullspace for the original problem.
+    # Update solver prefix
+    solver_prefix = solver_parameters.get(
+        "petsc_options_prefix", problem.solver.getOptionsPrefix()
+    )
+    problem._petsc_options_prefix = solver_prefix
+    problem.solver.setOptionsPrefix(solver_prefix)
+    problem.A.setOptionsPrefix(f"{solver_prefix}A_")
+    problem.b.setOptionsPrefix(f"{solver_prefix}b_")
+    problem.x.setOptionsPrefix(f"{solver_prefix}x_")
+    if problem.P_mat is not None:
+        problem.P_mat.setOptionsPrefix(f"{solver_prefix}P_mat_")
+    # Push new options with prefix, filtering out irksome-internal keys
+    petsc_opts = {
+        k: v for k, v in solver_parameters.items() if k != "petsc_options_prefix"
+    }
+    opts = PETSc.Options()
+    opts.prefixPush(solver_prefix)
+    for k, v in petsc_opts.items():
+        opts.setValue(k, v)
+    solver.setFromOptions()
+    opts.prefixPop()
+    # For some strange reason delValue doesn't respect prefixes
+    for k in petsc_opts:
+        opts.delValue(f"{solver_prefix}{k}")
 
-        On output, we produce a PETSc nullspace defining the nullspace for the multistage problem.
-        """
-        if nullspace is None:
-            nspnew = None
-        else:
-            old_vecs = nullspace.getVecs()
-            tmp_func = dolfinx.fem.Function(V)
-            new_vecs = [
-                dolfinx.fem.petsc.create_vector(Vbig.ufl_sub_spaces())
-                for _ in range(len(old_vecs))
-            ]
-            for i in range(len(old_vecs)):
-                # Copy the old nullspace vector into the first stage of the new nullspace vector
-                old_vecs[i].copy(tmp_func.x.petsc_vec)
-                tmp_func.x.scatter_forward()
-                dolfinx.fem.petsc.assign(
-                    [tmp_func for j in range(num_stages)], new_vecs[i]
-                )
-            nspnew = PETSc.NullSpace().create(
-                vectors=new_vecs, comm=nullspace.getComm()
+    nullspace = kwargs.get("nullspace", None)
+    near_nullspace = kwargs.get("near_nullspace", None)
+    if nullspace is not None:
+        problem.A.setNullSpace(nullspace)
+    if near_nullspace is not None:
+        problem.A.setNearNullSpace(near_nullspace)
+    return problem
+
+def get_function_space(u: ufl.Coefficient | ufl.Argument) -> ufl.FunctionSpace:
+    if isinstance(u, (ufl.Coefficient, ufl.Argument)):
+        return u.ufl_function_space()
+    else:
+        raise ValueError(f"Cannot get function space for object of type {type(u)}")
+
+def get_stages(V: dolfinx.fem.FunctionSpace, num_stages: int) -> ListTensor:
+    """
+    Given a function space for a single time-step, get a duplicate of this space,
+    repeated `num_stages` times.
+
+    :param V: Space for single step
+    :param num_stages: Number of stages
+    :returns: A coefficient in the new function space
+    """
+    _Vbig = [V.clone() for _ in range(num_stages)]
+    Vbig = ufl.MixedFunctionSpace(*_Vbig)
+    return ListTensor(*[dolfinx.fem.Function(Vi, name=f"stage_{i}") for i, Vi in enumerate(Vbig.ufl_sub_spaces())])
+
+class FloatConstantFunction(dolfinx.fem.Function):
+    def __float__(self):
+        if len(self.x.array) != 1:
+            raise ValueError("Can only convert a FloatConstantFunction to float if it has exactly one degree of freedom")
+        return float(self.x.array[0])
+
+    def assign(self, value):
+        self.x.array[0] = self.x.array.dtype.type(value)
+        self.x.scatter_forward()
+
+class MeshConstant(object):
+    def __init__(self, msh):
+        self.msh = msh
+        try:
+            import basix.ufl
+
+            r_el = basix.ufl.real_element(
+                msh.basix_cell(), value_shape=(), dtype=dolfinx.default_scalar_type
             )
-        return nspnew
+            self.V = dolfinx.fem.functionspace(msh, r_el)
+        except TypeError:
+            try:
+                import scifem
+            except ModuleNotFoundError:
+                raise RuntimeError(
+                    "DOLFINx with real element support or Scifem is required to make mesh-constants"
+                )
+            self.V = scifem.create_real_functionspace(msh, ())
 
-except ModuleNotFoundError:
+    def Constant(self, val=0.0) -> ufl.Coefficient:
+        v = FloatConstantFunction(self.V)
+        v.x.array[:] = val
+        return v
+
+def get_mesh_constant(MC: MeshConstant | None) -> ufl.core.expr.Expr:
+    return MC.Constant if MC is not None else ufl.constantvalue.ComplexValue
+
+def norm(
+    v: ufl.core.expr.Expr, norm_type: str = "L2", mesh: ufl.Mesh | None = None
+) -> float:
+    """Compute the norm of a function in the backend language."""
+    if mesh is not None:
+        dx = ufl.Measure("dx", domain=mesh)
+    else:
+        dx = ufl.dx
+    p = 2
+    if norm_type.startswith("L"):
+        p = int(norm_type[1:])
+        if p < 1:
+            raise ValueError(f"Invalid norm type {norm_type}")
+        expr = ufl.inner(v, v) ** (p / 2)
+        form = dolfinx.fem.form(expr * dx)
+    else:
+        raise NotImplementedError(f"Norm type {norm_type} not implemented")
+    norm_loc = dolfinx.fem.assemble_scalar(form)
+    norm_global = form.mesh.comm.allreduce(norm_loc, op=MPI.SUM)
+    return norm_global ** (1 / p)
+
+def assemble(expr: ufl.core.expr.Expr | float):
+    """Assemble a UFL expression in the backend language."""
+    if isinstance(expr, float):
+        return float
+    else:
+        form = dolfinx.fem.form(expr)
+        if form.rank == 0:
+            return dolfinx.fem.assemble_scalar(form)
+        elif form.rank == 1:
+            return dolfinx.fem.assemble_vector(form)
+        elif form.rank == 2:
+            return dolfinx.fem.assemble_matrix(form)
+        else:
+            raise ValueError(f"Cannot assemble form of rank {form.rank}")
+
+def TrialFunction(function_space):
+    """Create a trial function in the backend language.
+    
+    This is required as :func:`ufl.TrialFunctions` returns a tuple of trial functions,
+    which we need to convert to a tensor for consistency with the Firedrake backend.
+    """
+    return ufl.as_tensor(ufl.TrialFunctions(function_space))
+
+def Function(V: ufl.FunctionSpace | ufl.MixedFunctionSpace, name=None):
+    """Create a function in the backend language."""
+    if isinstance(V, ufl.MixedFunctionSpace):
+        return ListTensor(
+            *[
+                dolfinx.fem.Function(Vi, name=f"{name}_{i}")
+                for i, Vi in enumerate(V.ufl_sub_spaces())
+            ]
+        )
+    else:
+        return dolfinx.fem.Function(V, name=name)
+
+def TestFunction(function_space):
+    """Create a test function in the backend language.
+
+    This is required as :func:`ufl.TestFunctions` returns a tuple of test functions,
+    which we need to convert to a tensor for consistency with the Firedrake backend.
+    """
+    return ufl.as_tensor(ufl.TestFunctions(function_space))
+
+class Constant(ufl.constantvalue.ScalarValue):
+    # NOTE: If dolfinx ever get's meshless constants we should change this
+    def assign(self, value):
+        self._value = value
+
+class EquationBCSplit:
+    def __init__(self, *args, **kwargs):
+        raise NotImplementedError("DOLFINx does not support EquationBCSplit")
+
+class EquationBC:
+    def __init__(self, *args, **kwargs):
+        raise NotImplementedError("DOLFINx does not support EquationBC")
+
+def invalidate_jacobian(solver: dolfinx.fem.petsc.LinearProblem):
+    """Invalidate the Jacobian matrix in the backend language."""
     pass
+    # raise RuntimeError("DOLFINx does not support Jacobian invalidation")
+
+def create_bounds_constrained_bc(V, g, sub_domain, bounds, solver_parameters=None):
+    raise NotImplementedError(
+        "Bounds-constrained BCs are not implemented for DOLFINx"
+    )
+
+def getNullspace(V, Vbig, num_stages, nullspace):
+    """
+    Computes the nullspace for a multi-stage method.
+
+    :param V: The :class:`ufl.FunctionSpace` on which the original time-dependent PDE is posed.
+    :param Vbig: The multi-stage :class:`ufl.MixedFunctionSpace` for the stage problem
+    :param num_stages: The number of stages in the RK method
+    :param nullspace: The nullspace for the original problem.
+
+    On output, we produce a PETSc nullspace defining the nullspace for the multistage problem.
+    """
+    if nullspace is None:
+        nspnew = None
+    else:
+        old_vecs = nullspace.getVecs()
+        tmp_func = dolfinx.fem.Function(V)
+        new_vecs = [
+            dolfinx.fem.petsc.create_vector(Vbig.ufl_sub_spaces())
+            for _ in range(len(old_vecs))
+        ]
+        for i in range(len(old_vecs)):
+            # Copy the old nullspace vector into all stages of the new nullspace vector
+            old_vecs[i].copy(tmp_func.x.petsc_vec)
+            tmp_func.x.scatter_forward()
+            dolfinx.fem.petsc.assign(
+                [tmp_func for _ in range(num_stages)], new_vecs[i]
+            )
+        nspnew = PETSc.NullSpace().create(
+            vectors=new_vecs, comm=nullspace.getComm()
+        )
+    return nspnew
+
+derivative = ufl.derivative

--- a/irksome/backends/dolfinx.py
+++ b/irksome/backends/dolfinx.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 
-
+import itertools
 from irksome.tools import get_sub
 
 try:
@@ -18,7 +18,9 @@ try:
 
     class LinearProblem(dolfinx.fem.petsc.LinearProblem):
 
-        def solve(self):
+        def solve(self, bounds=None):
+            if bounds is not None:
+                raise NotImplementedError("Bounds-constrained solves are not implemented for DOLFINx")
             [bc.pack() for bc in self._bcs]
             super().solve()
 
@@ -82,6 +84,15 @@ try:
                 [bc.pack() for bc in bcs]
                 current_jac(_snes, x, J, P_mat, u, jacobian, preconditioner, bcs)
             self.solver.setJacobian(assemble_jacobian, _jac, _jacP, args=args, kargs=kargs)
+
+        def solve(self, bounds=None):
+            if bounds is not None:
+                raise NotImplementedError("Bounds-constrained solves are not implemented for DOLFINx")
+            super().solve()
+
+        @property
+        def snes(self) -> PETSc.SNES:  # type: ignore[name-defined]
+            return self.solver
 
     def dirichletbc(
         value: dolfinx.fem.Function
@@ -326,6 +337,15 @@ try:
         Vbig = ufl.MixedFunctionSpace(*_Vbig)
         return ufl.as_vector([dolfinx.fem.Function(Vi) for Vi in Vbig.ufl_sub_spaces()])
 
+    class FloatConstantFunction(dolfinx.fem.Function):
+        def __float__(self):
+            if len(self.x.array) != 1:
+                raise ValueError("Can only convert a FloatConstantFunction to float if it has exactly one degree of freedom")
+            return float(self.x.array[0])
+
+        def assign(self, value):
+            self.x.array[0] = self.x.array.dtype.type(value)
+
     class MeshConstant(object):
         def __init__(self, msh):
             self.msh = msh
@@ -346,8 +366,8 @@ try:
                 self.V = scifem.create_real_functionspace(msh, ())
 
         def Constant(self, val=0.0) -> ufl.Coefficient:
-            v = dolfinx.fem.Function(self.V)
-            v.value = val
+            v = FloatConstantFunction(self.V)
+            v.x.array[:] = val
             return v
 
     def get_mesh_constant(MC: MeshConstant | None) -> ufl.core.expr.Expr:
@@ -408,7 +428,8 @@ try:
 
     def invalidate_jacobian(solver: dolfinx.fem.petsc.LinearProblem):
         """Invalidate the Jacobian matrix in the backend language."""
-        raise RuntimeError("DOLFINx does not support Jacobian invalidation")
+        pass
+        # raise RuntimeError("DOLFINx does not support Jacobian invalidation")
 
     def create_bounds_constrained_bc(V, g, sub_domain, bounds, solver_parameters=None):
         raise NotImplementedError(
@@ -440,5 +461,14 @@ try:
         else:
             raise ValueError(f"Unsupported function space type {type(V)} for get_number_of_fields")
 
+    def extract_subfunctions(f: ufl.Coefficient | list[ufl.Coefficient]) -> Sequence[ufl.Coefficient]:
+        if isinstance(f, ufl.Coefficient):
+            num_sub_elements = f.ufl_element().num_sub_elements
+            if num_sub_elements == 0:
+                return [f]
+            else:
+                return [f.sub(i) for i in range(num_sub_elements)]
+        else:
+            return list(itertools.chain.from_iterable(extract_subfunctions(f.ufl_operands[i]) for i in range(len(f))))
 except ModuleNotFoundError:
     pass

--- a/irksome/backends/dolfinx.py
+++ b/irksome/backends/dolfinx.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Sequence
 
-import itertools
 from irksome.tools import get_sub
 
 try:
@@ -15,6 +14,31 @@ try:
     import typing
     import numpy as np
     import numpy.typing as npt
+
+    # Patching of DOLFINx objects to mimick firedrake naming and properties.
+    def function_space_length(self):
+        num_sub_elements = self.ufl_element().num_sub_elements
+        return 1 if num_sub_elements == 0 else num_sub_elements
+
+    def mixed_space_length(self):
+        return len(self.ufl_sub_spaces())
+
+    def subfunctions(self):
+        """Get subfunctions for a DOLFINx function, which may be in a mixed space."""
+        if self.function_space.ufl_element().num_sub_elements == 0:
+            return [self]
+        else:
+            return [self.sub(i) for i in range(self.function_space().ufl_element().num_sub_elements)]
+
+    dolfinx.fem.FunctionSpace.__len__ = function_space_length
+    dolfinx.fem.Function.subfunctions = property(subfunctions)
+    ufl.MixedFunctionSpace.__len__ = mixed_space_length
+
+    class ListTensor(ufl.tensors.ListTensor):
+        """A list tensor that exposes subfunctions for DOLFINx functions"""
+        @property
+        def subfunctions(self):
+            return [self.ufl_operands[i] for i in range(len(self))]
 
     class LinearProblem(dolfinx.fem.petsc.LinearProblem):
 
@@ -265,8 +289,8 @@ try:
     def create_variational_problem(F, u, bcs=None, aP=None, **kwargs):
         """Create a variational problem."""
         rank = len(np.unique([arg.number() for arg in F.arguments()]))
-        if isinstance(u, ufl.tensors.ListTensor):
-            u = u.ufl_operands
+        if isinstance(u, ListTensor):
+            u = u.subfunctions
         if rank == 2:
             a, L = ufl.system(F)
             a = ufl.extract_blocks(a)
@@ -321,7 +345,7 @@ try:
                 *[u[i].ufl_function_space() for i in range(u.ufl_shape[0])]
             )
 
-    def get_stages(V: dolfinx.fem.FunctionSpace, num_stages: int) -> ufl.Coefficient:
+    def get_stages(V: dolfinx.fem.FunctionSpace, num_stages: int) -> ListTensor:
         """
         Given a function space for a single time-step, get a duplicate of this space,
         repeated `num_stages` times.
@@ -335,7 +359,7 @@ try:
         """
         _Vbig = [V.clone() for _ in range(num_stages)]
         Vbig = ufl.MixedFunctionSpace(*_Vbig)
-        return ufl.as_vector([dolfinx.fem.Function(Vi) for Vi in Vbig.ufl_sub_spaces()])
+        return ListTensor(*[dolfinx.fem.Function(Vi, name=f"stage_{i}") for i, Vi in enumerate(Vbig.ufl_sub_spaces())])
 
     class FloatConstantFunction(dolfinx.fem.Function):
         def __float__(self):
@@ -410,7 +434,14 @@ try:
 
     derivative = ufl.derivative
     TrialFunction = ufl.TrialFunctions
-    Function = dolfinx.fem.Function
+
+    def Function(V: ufl.FunctionSpace | ufl.MixedFunctionSpace, name=None):
+        """Create a function in the backend language."""
+        if isinstance(V, ufl.MixedFunctionSpace):
+            return ListTensor(*[dolfinx.fem.Function(Vi, name=f"{name}_{i}") for i, Vi in enumerate(V.ufl_sub_spaces())])
+        else:
+            return dolfinx.fem.Function(V, name=name)
+
     TestFunction = ufl.TestFunctions
 
     class Constant(ufl.constantvalue.ScalarValue):
@@ -453,22 +484,5 @@ try:
             raise NotImplementedError("Nullspace computation is not implemented for DOLFINx")
         return nspnew
 
-    def get_number_of_fields(V) -> int:
-        if isinstance(V, ufl.MixedFunctionSpace):
-            return V.num_sub_spaces()
-        elif isinstance(V, ufl.FunctionSpace):
-            return 1
-        else:
-            raise ValueError(f"Unsupported function space type {type(V)} for get_number_of_fields")
-
-    def extract_subfunctions(f: ufl.Coefficient | list[ufl.Coefficient]) -> Sequence[ufl.Coefficient]:
-        if isinstance(f, ufl.Coefficient):
-            num_sub_elements = f.ufl_element().num_sub_elements
-            if num_sub_elements == 0:
-                return [f]
-            else:
-                return [f.sub(i) for i in range(num_sub_elements)]
-        else:
-            return list(itertools.chain.from_iterable(extract_subfunctions(f.ufl_operands[i]) for i in range(len(f))))
 except ModuleNotFoundError:
     pass

--- a/irksome/backends/firedrake.py
+++ b/irksome/backends/firedrake.py
@@ -3,7 +3,6 @@
 import firedrake
 import ufl
 import typing
-from collections.abc import Sequence
 from functools import reduce
 from operator import mul
 from irksome.tools import get_sub
@@ -191,11 +190,3 @@ def getNullspace(V, Vbig, num_stages, nullspace):
         nspnew = MixedVectorSpaceBasis(Vbig, nspnew)
 
     return nspnew
-
-
-def get_number_of_fields(V) -> int:
-    return len(V)
-
-
-def extract_subfunctions(f: ufl.Coefficient) -> Sequence[ufl.Coefficient]:
-    return f.subfunctions

--- a/irksome/backends/firedrake.py
+++ b/irksome/backends/firedrake.py
@@ -3,9 +3,10 @@
 import firedrake
 import ufl
 import typing
+from collections.abc import Sequence
 from functools import reduce
 from operator import mul
-from irksome.bcs import get_sub
+from irksome.tools import get_sub
 
 assemble = firedrake.assemble
 derivative = firedrake.derivative
@@ -194,3 +195,7 @@ def getNullspace(V, Vbig, num_stages, nullspace):
 
 def get_number_of_fields(V) -> int:
     return len(V)
+
+
+def extract_subfunctions(f: ufl.Coefficient) -> Sequence[ufl.Coefficient]:
+    return f.subfunctions

--- a/irksome/backends/firedrake.py
+++ b/irksome/backends/firedrake.py
@@ -5,7 +5,7 @@ import ufl
 import typing
 from functools import reduce
 from operator import mul
-
+from irksome.bcs import get_sub
 
 assemble = firedrake.assemble
 derivative = firedrake.derivative
@@ -135,5 +135,62 @@ class BoundsConstrainedDirichletBC(firedrake.DirichletBC):
         return type(self)(V, g, sub_domain, self.bounds, self.solver_parameters)
 
 
+def bc2space(bc, V):
+    return get_sub(V, bc._indices)
+
+
+def stage2spaces4bc(bc, V, Vbig, i):
+    """used to figure out how to apply Dirichlet BC to each stage"""
+    field = 0 if len(V) == 1 else bc.function_space_index()
+    comp = (bc.function_space().component,)
+    return get_sub(Vbig[field + len(V) * i], comp)
+
+
 def create_bounds_constrained_bc(V, g, sub_domain, bounds, solver_parameters=None):
     return BoundsConstrainedDirichletBC(V, g, sub_domain, bounds, solver_parameters=solver_parameters)
+
+
+def getNullspace(V, Vbig, num_stages, nullspace):
+    """
+    Computes the nullspace for a multi-stage method.
+
+    :arg V: The :class:`firedrake.FunctionSpace` on which the original time-dependent PDE is posed.
+    :arg Vbig: The multi-stage :class:`firedrake.FunctionSpace` for the stage problem
+    :arg num_stages: The number of stages in the RK method
+    :arg nullspace: The nullspace for the original problem.
+
+    On output, we produce a :class:`firedrake.MixedVectorSpaceBasis` defining the nullspace
+    for the multistage problem.
+    """
+    from firedrake import VectorSpaceBasis, MixedVectorSpaceBasis
+
+    num_fields = len(V)
+    if nullspace is None:
+        nspnew = None
+    else:
+        if isinstance(nullspace, (MixedVectorSpaceBasis, VectorSpaceBasis)):
+            nullspace = [(field, basis) for field, basis in enumerate(nullspace)
+                         if isinstance(basis, VectorSpaceBasis)]
+        try:
+            nullspace.sort()
+        except AttributeError:
+            raise AttributeError("Nullspace entries must be of form (idx, VSP), where idx is a non-negative integer")
+        if (nullspace[-1][0] > num_fields) or (nullspace[0][0] < 0):
+            raise ValueError("At least one index for nullspaces is out of range")
+        nspnew = []
+        nsp_comp = len(nullspace)
+        for i in range(num_stages):
+            count = 0
+            for j in range(num_fields):
+                if count < nsp_comp and j == nullspace[count][0]:
+                    nspnew.append(nullspace[count][1])
+                    count += 1
+                else:
+                    nspnew.append(Vbig.sub(j + num_fields * i))
+        nspnew = MixedVectorSpaceBasis(Vbig, nspnew)
+
+    return nspnew
+
+
+def get_number_of_fields(V) -> int:
+    return len(V)

--- a/irksome/backends/firedrake.py
+++ b/irksome/backends/firedrake.py
@@ -38,12 +38,10 @@ def get_stages(V: firedrake.FunctionSpace, num_stages: int) -> firedrake.Functio
     Given a function space for a single time-step, get a duplicate of this space,
     repeated `num_stages` times.
 
-    Args:
-        V: Space for single step
-        num_stages: Number of stages
+    :param V: Space for single step
+    :param num_stages: Number of stages
 
-    Returns:
-        A coefficient in the new function space
+    :returns: A coefficient in the new function space
     """
     Vbig = get_stage_space(V, num_stages)
     return firedrake.Function(Vbig)
@@ -154,10 +152,10 @@ def getNullspace(V, Vbig, num_stages, nullspace):
     """
     Computes the nullspace for a multi-stage method.
 
-    :arg V: The :class:`firedrake.FunctionSpace` on which the original time-dependent PDE is posed.
-    :arg Vbig: The multi-stage :class:`firedrake.FunctionSpace` for the stage problem
-    :arg num_stages: The number of stages in the RK method
-    :arg nullspace: The nullspace for the original problem.
+    :param V: The :class:`firedrake.FunctionSpace` on which the original time-dependent PDE is posed.
+    :param Vbig: The multi-stage :class:`firedrake.FunctionSpace` for the stage problem
+    :param num_stages: The number of stages in the RK method
+    :param nullspace: The nullspace for the original problem.
 
     On output, we produce a :class:`firedrake.MixedVectorSpaceBasis` defining the nullspace
     for the multistage problem.

--- a/irksome/base_time_stepper.py
+++ b/irksome/base_time_stepper.py
@@ -119,7 +119,7 @@ class StageCoupledTimeStepper(BaseTimeStepper):
         self.stages = stages
 
         V = self._backend.get_function_space(u0)
-        Vbig = self._backend.get_function_space(stages)
+        Vbig = stages.function_space()
 
         F_linear = len(as_form(F).arguments()) == 2
         stages_F = self._backend.TrialFunction(Vbig) if F_linear else stages
@@ -206,7 +206,7 @@ class StageCoupledTimeStepper(BaseTimeStepper):
                 sub = self._backend.Function(Vbig, val=flatten_dats(dats))
 
         elif bounds_type == "last_stage":
-            V = self.u0.function_space()
+            V = self._backend.get_function_space(self.u0)
             if lower is not None:
                 ninfty = self._backend.Function(V).assign(PETSc.NINFINITY)
                 dats = [ninfty.dat] * (self.num_stages-1)

--- a/irksome/base_time_stepper.py
+++ b/irksome/base_time_stepper.py
@@ -1,7 +1,7 @@
 from abc import abstractmethod
 
 from petsc4py import PETSc
-from .tools import AI, getNullspace, flatten_dats, split_stages
+from .tools import AI, flatten_dats, split_stages
 try:
     from .labeling import as_form
 except ImportError:
@@ -118,8 +118,8 @@ class StageCoupledTimeStepper(BaseTimeStepper):
         stages = self.get_stages()
         self.stages = stages
 
-        V = u0.function_space()
-        Vbig = stages.function_space()
+        V = self._backend.get_function_space(u0)
+        Vbig = self._backend.get_function_space(stages)
 
         F_linear = len(as_form(F).arguments()) == 2
         stages_F = self._backend.TrialFunction(Vbig) if F_linear else stages
@@ -132,9 +132,9 @@ class StageCoupledTimeStepper(BaseTimeStepper):
             Fpbig, _ = self.get_form_and_bcs(stages_Fp, F=Fp, bcs=())
             Jpbig = ufl.lhs(Fpbig) if Fp_linear else self._backend.derivative(Fpbig, stages_Fp)
 
-        nullspace = getNullspace(V, Vbig, num_stages, nullspace)
-        transpose_nullspace = getNullspace(V, Vbig, num_stages, transpose_nullspace)
-        near_nullspace = getNullspace(V, Vbig, num_stages, near_nullspace)
+        nullspace = self._backend.getNullspace(V, Vbig, num_stages, nullspace)
+        transpose_nullspace = self._backend.getNullspace(V, Vbig, num_stages, transpose_nullspace)
+        near_nullspace = self._backend.getNullspace(V, Vbig, num_stages, near_nullspace)
 
         self.bigBCs = bigBCs
 

--- a/irksome/bcs.py
+++ b/irksome/bcs.py
@@ -1,48 +1,32 @@
 from .backend import get_backend
-from ufl import as_ufl, replace
+import ufl
 
 
-def get_sub(u, indices):
-    for i in indices:
-        if i is not None:
-            u = u.sub(i)
-    return u
-
-
-def bc2space(bc, V):
-    return get_sub(V, bc._indices)
-
-
-def stage2spaces4bc(bc, V, Vbig, i):
-    """used to figure out how to apply Dirichlet BC to each stage"""
-    field = 0 if len(V) == 1 else bc.function_space_index()
-    comp = (bc.function_space().component,)
-    return get_sub(Vbig[field + len(V) * i], comp)
-
-
-def BCStageData(bc, gcur, u0, stages, i):
+def BCStageData(bc, gcur, u0, stages, i, backend="firedrake"):
+    backend_cls = get_backend(backend)
     if bc._original_arg == 0:
         gcur = 0
-    V = u0.function_space()
-    Vbig = stages.function_space()
-    Vbigi = stage2spaces4bc(bc, V, Vbig, i)
+    V = backend_cls.get_function_space(u0)
+    Vbig = backend_cls.get_function_space(stages)
+    Vbigi = backend_cls.stage2spaces4bc(bc, V, Vbig, i)
     return bc.reconstruct(V=Vbigi, g=gcur)
 
 
-def EmbeddedBCData(bc, butcher_tableau, t, dt, u0, stages):
-    Vbc = bc2space(bc, u0.function_space())
+def EmbeddedBCData(bc, butcher_tableau, t, dt, u0, stages, backend="firedrake"):
+    backend_cls = get_backend(backend)
+    Vbc = backend_cls.bc2space(bc, backend_cls.get_function_space(u0))
     gorig = bc._original_arg
     if gorig == 0:
         g = gorig
     else:
-        V = u0.function_space()
+        V = backend_cls.get_function_space(u0)
         field = 0 if len(V) == 1 else bc.function_space_index()
         comp = (bc.function_space().component,)
         ws = stages.subfunctions[field::len(V)]
         btilde = butcher_tableau.btilde
         num_stages = butcher_tableau.num_stages
-        g = replace(as_ufl(gorig), {t: t + dt}) - gorig
-        g -= sum(get_sub(ws[j], comp) * (btilde[j] * dt) for j in range(num_stages))
+        g = ufl.replace(ufl.as_ufl(gorig), {t: t + dt}) - gorig
+        g -= sum(backend_cls.get_sub(ws[j], comp) * (btilde[j] * dt) for j in range(num_stages))
     return bc.reconstruct(V=Vbc, g=g)
 
 

--- a/irksome/bcs.py
+++ b/irksome/bcs.py
@@ -8,7 +8,7 @@ def BCStageData(bc, gcur, u0, stages, i, backend="firedrake"):
     if bc._original_arg == 0:
         gcur = 0
     V = backend_cls.get_function_space(u0)
-    Vbig = backend_cls.get_function_space(stages)
+    Vbig = stages.function_space()
     Vbigi = backend_cls.stage2spaces4bc(bc, V, Vbig, i)
     return bc.reconstruct(V=Vbigi, g=gcur)
 

--- a/irksome/bcs.py
+++ b/irksome/bcs.py
@@ -23,7 +23,7 @@ def EmbeddedBCData(bc, butcher_tableau, t, dt, u0, stages, backend="firedrake"):
         V = backend_cls.get_function_space(u0)
         field = 0 if len(V) == 1 else bc.function_space_index()
         comp = (bc.function_space().component,)
-        ws = backend_cls.extract_subfunctions(stages)[field::len(V)]
+        ws = stages.subfunctions[field::len(V)]
         btilde = butcher_tableau.btilde
         num_stages = butcher_tableau.num_stages
         g = ufl.replace(ufl.as_ufl(gorig), {t: t + dt}) - gorig

--- a/irksome/bcs.py
+++ b/irksome/bcs.py
@@ -1,5 +1,6 @@
 from .backend import get_backend
 import ufl
+from irksome.tools import get_sub
 
 
 def BCStageData(bc, gcur, u0, stages, i, backend="firedrake"):
@@ -22,11 +23,11 @@ def EmbeddedBCData(bc, butcher_tableau, t, dt, u0, stages, backend="firedrake"):
         V = backend_cls.get_function_space(u0)
         field = 0 if len(V) == 1 else bc.function_space_index()
         comp = (bc.function_space().component,)
-        ws = stages.subfunctions[field::len(V)]
+        ws = backend_cls.extract_subfunctions(stages)[field::len(V)]
         btilde = butcher_tableau.btilde
         num_stages = butcher_tableau.num_stages
         g = ufl.replace(ufl.as_ufl(gorig), {t: t + dt}) - gorig
-        g -= sum(backend_cls.get_sub(ws[j], comp) * (btilde[j] * dt) for j in range(num_stages))
+        g -= sum(get_sub(ws[j], comp) * (btilde[j] * dt) for j in range(num_stages))
     return bc.reconstruct(V=Vbc, g=g)
 
 

--- a/irksome/dirk_stepper.py
+++ b/irksome/dirk_stepper.py
@@ -110,7 +110,7 @@ class DIRKTimeStepper:
         self.t = t
         self.dt = dt
         self.orig_bcs = bcs
-        self.num_fields = self._backend.get_number_of_fields(self._backend.get_function_space(u0))
+        self.num_fields = len(self._backend.get_function_space(u0))
         self.ks = [backend_cls.Function(V) for _ in range(num_stages)]
 
         # "k" is a generic function for which we will solve the

--- a/irksome/dirk_stepper.py
+++ b/irksome/dirk_stepper.py
@@ -105,12 +105,12 @@ class DIRKTimeStepper:
         self.AA = vecconst(butcher_tableau.A, backend=backend)
         self.BB = vecconst(butcher_tableau.b, backend=backend)
 
-        self.V = V = u0.function_space()
+        self.V = V = self._backend.get_function_space(u0)
         self.u0 = u0
         self.t = t
         self.dt = dt
         self.orig_bcs = bcs
-        self.num_fields = len(self._backend.get_function_space(u0))
+        self.num_fields = len(V)
         self.ks = [backend_cls.Function(V) for _ in range(num_stages)]
 
         # "k" is a generic function for which we will solve the

--- a/irksome/dirk_stepper.py
+++ b/irksome/dirk_stepper.py
@@ -2,7 +2,6 @@ import numpy
 from ufl import as_ufl, lhs
 
 from .constant import vecconst, MeshConstant
-from .bcs import bc2space
 from .ufl.deriv import TimeDerivative, expand_time_derivatives
 from .tools import extract_timedep_arguments, replace
 from .backend import get_backend
@@ -56,8 +55,8 @@ def getFormDIRK(F, ks, butch, t, dt, u0, bcs=None, kgac=None, backend="firedrake
             bcnew.append(bc)
         else:
             bcarg_stage = replace(as_ufl(bcarg), {t: t+c*dt})
-            gdat = bcarg_stage - bc2space(bc, u0)
-            gdat -= sum(bc2space(bc, ks[i]) * (a_vals[i] * dt) for i in range(num_stages))
+            gdat = bcarg_stage - backend_cls.bc2space(bc, u0)
+            gdat -= sum(backend_cls.bc2space(bc, ks[i]) * (a_vals[i] * dt) for i in range(num_stages))
             gdat /= d_val * dt
             bcnew.append(bc.reconstruct(g=gdat))
 
@@ -103,15 +102,15 @@ class DIRKTimeStepper:
         if butcher_tableau.is_explicit:
             self.AAb = self.AAb[1:]
             self.CCone = self.CCone[1:]
-        self.AA = vecconst(butcher_tableau.A)
-        self.BB = vecconst(butcher_tableau.b)
+        self.AA = vecconst(butcher_tableau.A, backend=backend)
+        self.BB = vecconst(butcher_tableau.b, backend=backend)
 
         self.V = V = u0.function_space()
         self.u0 = u0
         self.t = t
         self.dt = dt
         self.orig_bcs = bcs
-        self.num_fields = len(u0.function_space())
+        self.num_fields = self._backend.get_number_of_fields(self._backend.get_function_space(u0))
         self.ks = [backend_cls.Function(V) for _ in range(num_stages)]
 
         # "k" is a generic function for which we will solve the

--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -136,9 +136,9 @@ def getFormDiscGalerkin(F, L, Qdefault, t, dt, u0, stages, bcs=None, deriv_type=
     :arg u0: a :class:`Function` referring to the state of
          the PDE system at time `t`
     :arg stages: a :class:`Function` representing the stages to be solved for.
-    :kwarg bcs: optionally, a :class:`DirichletBC` object (or iterable thereof)
-         containing (possibly time-dependent) boundary conditions imposed
-         on the system.
+    :kwarg bcs: optionally, a  :class:`~irksome.backend.Backend.DirichletBC`
+         object (or iterable thereof) containing (possibly time-dependent)
+         boundary conditions imposed on the system.
     :kwarg deriv_type: A string indicating how to integrate terms with time derivatives.
         Valid values are:
         - `"weak"`: Time derivatives act on the test function (integrating by parts once).
@@ -150,7 +150,7 @@ def getFormDiscGalerkin(F, L, Qdefault, t, dt, u0, stages, bcs=None, deriv_type=
     On output, we return a tuple consisting of two parts:
 
        - Fnew, the :class:`Form` corresponding to the DG-in-Time discretized problem
-       - `bcnew`, a list of :class:`DirichletBC` objects to be posed
+       - `bcnew`, a list of :class:`~irksome.backend.Backend.DirichletBC` objects to be posed
          on the Galerkin-in-time solution,
     """
     num_stages = L.space_dimension()
@@ -209,7 +209,7 @@ class DiscontinuousGalerkinTimeStepper(StageCoupledTimeStepper):
         a variable referring to the current time step size.
     :arg u0: A :class:`Function` containing the current
         state of the problem to be solved.
-    :arg bcs: An iterable of :class:`.DirichletBC` containing
+    :arg bcs: An iterable of :class:`~irksome.backend.Backend.DirichletBC` containing
         the strongly-enforced boundary conditions.  Irksome will
         manipulate these to obtain boundary conditions for each
         stage of the method.

--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -3,7 +3,6 @@ from FIAT import (Bernstein,
                   GaussLobattoLegendre, GaussRadau)
 from ufl import as_ufl, as_tensor
 from .base_time_stepper import StageCoupledTimeStepper
-from .bcs import stage2spaces4bc
 from .labeling import split_quadrature, as_form
 from .ufl.estimate_degrees import TimeDegreeEstimator, get_degree_mapping
 from .ufl.deriv import TimeDerivative, expand_time_derivatives
@@ -190,7 +189,7 @@ def getFormDiscGalerkin(F, L, Qdefault, t, dt, u0, stages, bcs=None, deriv_type=
             gq = np.array([replace(g0, {t: t + c*dt}) for c in qpts])
             g_np = proj @ gq
             for i in range(num_stages):
-                Vbigi = stage2spaces4bc(bc, V, Vbig, i)
+                Vbigi = backend_cls.stage2spaces4bc(bc, V, Vbig, i)
                 bcsnew.append(bc.reconstruct(V=Vbigi, g=as_tensor(g_np[i])))
     return Fnew, bcsnew
 
@@ -224,15 +223,16 @@ class DiscontinuousGalerkinTimeStepper(StageCoupledTimeStepper):
     :arg nullspace: An optional nullspace object.
     """
     def __init__(self, F, scheme, t, dt, u0, bcs=None, basis_type=None,
-                 quadrature=None, **kwargs):
+                 quadrature=None, backend="firedrake", **kwargs):
         order = self.order = scheme.order
         assert order >= 0, "DG must be order >= 0"
 
         self.basis_type = basis_type = scheme.basis_type
         self.deriv_type = scheme.deriv_type
 
-        V = u0.function_space()
-        self.num_fields = len(V)
+        backend_cls = get_backend(backend)
+        V = backend_cls.get_function_space(u0)
+        self.num_fields = backend_cls.get_number_of_fields(V)
 
         self.el = getElement(basis_type, order)
         num_stages = self.el.space_dimension()

--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -299,8 +299,8 @@ class DiscontinuousGalerkinTimeStepper(StageCoupledTimeStepper):
                                    max_quadrature_degree=max_quadrature_degree)
 
     def _update(self):
-        stages_np = np.array(self.stages.subfunctions, dtype=object)
-        for i, u0bit in enumerate(self.u0.subfunctions):
+        stages_np = np.array(self._backend.extract_subfunctions(self.stages), dtype=object)
+        for i, u0bit in enumerate(self._backend.extract_subfunctions(self.u0)):
             u0bit.assign(stages_np[i::self.num_fields] @ self.update_b)
 
     def tabulate_poly(self, sample_points):

--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -300,7 +300,7 @@ class DiscontinuousGalerkinTimeStepper(StageCoupledTimeStepper):
 
     def _update(self):
         stages_np = np.array((self.stages.subfunctions), dtype=object)
-        for i, u0bit in enumerate((self.u0.subfunctions)):
+        for i, u0bit in enumerate(self.u0.subfunctions):
             u0bit.assign(stages_np[i::self.num_fields] @ self.update_b)
 
     def tabulate_poly(self, sample_points):

--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -156,7 +156,7 @@ def getFormDiscGalerkin(F, L, Qdefault, t, dt, u0, stages, bcs=None, deriv_type=
     num_stages = L.space_dimension()
     backend_cls = get_backend(backend)
     V = backend_cls.get_function_space(u0)
-    Vbig = backend_cls.get_function_space(stages)
+    Vbig = stages.function_space()
     test = backend_cls.TestFunction(Vbig)
 
     degree_mapping = get_degree_mapping(as_form(F), L.degree(), L.degree(), t=t, timedep_coeffs=(u0,))

--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -232,7 +232,7 @@ class DiscontinuousGalerkinTimeStepper(StageCoupledTimeStepper):
 
         backend_cls = get_backend(backend)
         V = backend_cls.get_function_space(u0)
-        self.num_fields = backend_cls.get_number_of_fields(V)
+        self.num_fields = len(V)
 
         self.el = getElement(basis_type, order)
         num_stages = self.el.space_dimension()
@@ -299,8 +299,8 @@ class DiscontinuousGalerkinTimeStepper(StageCoupledTimeStepper):
                                    max_quadrature_degree=max_quadrature_degree)
 
     def _update(self):
-        stages_np = np.array(self._backend.extract_subfunctions(self.stages), dtype=object)
-        for i, u0bit in enumerate(self._backend.extract_subfunctions(self.u0)):
+        stages_np = np.array((self.stages.subfunctions), dtype=object)
+        for i, u0bit in enumerate((self.u0.subfunctions)):
             u0bit.assign(stages_np[i::self.num_fields] @ self.update_b)
 
     def tabulate_poly(self, sample_points):

--- a/irksome/discontinuous_galerkin_stepper.py
+++ b/irksome/discontinuous_galerkin_stepper.py
@@ -299,7 +299,7 @@ class DiscontinuousGalerkinTimeStepper(StageCoupledTimeStepper):
                                    max_quadrature_degree=max_quadrature_degree)
 
     def _update(self):
-        stages_np = np.array((self.stages.subfunctions), dtype=object)
+        stages_np = np.array(self.stages.subfunctions, dtype=object)
         for i, u0bit in enumerate(self.u0.subfunctions):
             u0bit.assign(stages_np[i::self.num_fields] @ self.update_b)
 

--- a/irksome/galerkin_stepper.py
+++ b/irksome/galerkin_stepper.py
@@ -386,7 +386,7 @@ class ContinuousPetrovGalerkinTimeStepper(StageCoupledTimeStepper):
                                max_quadrature_degree=max_quadrature_degree)
 
     def _update(self):
-        for u0bit, expr in zip(self.u0.subfunctions, self.u_update):
+        for u0bit, expr in zip(self._backend.extract_subfunctions(self.u0), self.u_update):
             u0bit.assign(expr)
 
     def set_update_expressions(self):
@@ -398,12 +398,12 @@ class ContinuousPetrovGalerkinTimeStepper(StageCoupledTimeStepper):
         i0, = self.trial_el.entity_dofs()[0][0]
         self.u_update = []
         for i in range(self.num_fields):
-            ks = list(self.stages.subfunctions[i::self.num_fields])
+            ks = list(self._backend.extract_subfunctions(self.stages)[i::self.num_fields])
             if self.aux_indices and i in self.aux_indices:
                 wts = update_test
             else:
                 wts = update_trial
-                ks.insert(i0, self.u0.subfunctions[i])
+                ks.insert(i0, self._backend.extract_subfunctions(self.u0)[i])
             self.u_update.append(sum(w * k for w, k in zip(wts, ks)))
 
     def set_initial_guess(self):
@@ -423,8 +423,8 @@ class ContinuousPetrovGalerkinTimeStepper(StageCoupledTimeStepper):
 
         dof = self._backend.Constant(0)
         for k in range(self.num_stages):
-            for i, u0bit in enumerate(self.u0.subfunctions):
-                sbit = self.stages.subfunctions[self.num_fields*k+i]
+            for i, u0bit in enumerate(self._backend.extract_subfunctions(self.u0)):
+                sbit = self._backend.extract_subfunctions(self.stages)[self.num_fields*k+i]
                 if self.aux_indices and i in self.aux_indices:
                     dof.assign(test_dofs[k])
                 else:

--- a/irksome/galerkin_stepper.py
+++ b/irksome/galerkin_stepper.py
@@ -385,7 +385,7 @@ class ContinuousPetrovGalerkinTimeStepper(StageCoupledTimeStepper):
                                max_quadrature_degree=max_quadrature_degree)
 
     def _update(self):
-        for u0bit, expr in zip((self.u0.subfunctions), self.u_update):
+        for u0bit, expr in zip(self.u0.subfunctions, self.u_update):
             u0bit.assign(expr)
 
     def set_update_expressions(self):
@@ -397,12 +397,12 @@ class ContinuousPetrovGalerkinTimeStepper(StageCoupledTimeStepper):
         i0, = self.trial_el.entity_dofs()[0][0]
         self.u_update = []
         for i in range(self.num_fields):
-            ks = list((self.stages.subfunctions)[i::self.num_fields])
+            ks = list(self.stages.subfunctions[i::self.num_fields])
             if self.aux_indices and i in self.aux_indices:
                 wts = update_test
             else:
                 wts = update_trial
-                ks.insert(i0, (self.u0.subfunctions)[i])
+                ks.insert(i0, self.u0.subfunctions[i])
             self.u_update.append(sum(w * k for w, k in zip(wts, ks)))
 
     def set_initial_guess(self):
@@ -422,8 +422,8 @@ class ContinuousPetrovGalerkinTimeStepper(StageCoupledTimeStepper):
 
         dof = self._backend.Constant(0)
         for k in range(self.num_stages):
-            for i, u0bit in enumerate((self.u0.subfunctions)):
-                sbit = (self.stages.subfunctions)[self.num_fields*k+i]
+            for i, u0bit in enumerate(self.u0.subfunctions):
+                sbit = self.stages.subfunctions[self.num_fields*k+i]
                 if self.aux_indices and i in self.aux_indices:
                     dof.assign(test_dofs[k])
                 else:

--- a/irksome/galerkin_stepper.py
+++ b/irksome/galerkin_stepper.py
@@ -5,7 +5,6 @@ from ufl.classes import Zero
 from ufl import as_ufl, as_tensor
 
 from .base_time_stepper import StageCoupledTimeStepper
-from .bcs import bc2space, stage2spaces4bc
 from .ufl.deriv import TimeDerivative, expand_time_derivatives
 from .ufl.estimate_degrees import TimeDegreeEstimator, get_degree_mapping
 from .labeling import split_quadrature, as_form
@@ -231,7 +230,7 @@ def getFormGalerkin(F, L_trial, L_test, Qdefault, t, dt, u0, stages, bcs=None, b
             g = as_ufl(bc._original_arg)
             if isinstance(g, Zero):
                 return [g]*len(test_dicts)
-            ucur = bc2space(bc, u0)
+            ucur = backend_cls.bc2space(bc, u0)
             gq = np.array([replace(g, {t: t + q * dt}) - phi0 * ucur
                            for phi0, q in zip(trial_vals0, qpts)])
             return dot(trial_proj, gq)
@@ -247,7 +246,7 @@ def getFormGalerkin(F, L_trial, L_test, Qdefault, t, dt, u0, stages, bcs=None, b
         else:
             g_np = bc_data(bc)
         for i in range(num_stages):
-            Vbigi = stage2spaces4bc(bc, V, Vbig, i)
+            Vbigi = backend_cls.stage2spaces4bc(bc, V, Vbig, i)
             bcsnew.append(bc.reconstruct(V=Vbigi, g=as_tensor(g_np[i])))
     return Fnew, bcsnew
 

--- a/irksome/galerkin_stepper.py
+++ b/irksome/galerkin_stepper.py
@@ -386,7 +386,7 @@ class ContinuousPetrovGalerkinTimeStepper(StageCoupledTimeStepper):
                                max_quadrature_degree=max_quadrature_degree)
 
     def _update(self):
-        for u0bit, expr in zip(self._backend.extract_subfunctions(self.u0), self.u_update):
+        for u0bit, expr in zip((self.u0.subfunctions), self.u_update):
             u0bit.assign(expr)
 
     def set_update_expressions(self):
@@ -398,12 +398,12 @@ class ContinuousPetrovGalerkinTimeStepper(StageCoupledTimeStepper):
         i0, = self.trial_el.entity_dofs()[0][0]
         self.u_update = []
         for i in range(self.num_fields):
-            ks = list(self._backend.extract_subfunctions(self.stages)[i::self.num_fields])
+            ks = list((self.stages.subfunctions)[i::self.num_fields])
             if self.aux_indices and i in self.aux_indices:
                 wts = update_test
             else:
                 wts = update_trial
-                ks.insert(i0, self._backend.extract_subfunctions(self.u0)[i])
+                ks.insert(i0, (self.u0.subfunctions)[i])
             self.u_update.append(sum(w * k for w, k in zip(wts, ks)))
 
     def set_initial_guess(self):
@@ -423,8 +423,8 @@ class ContinuousPetrovGalerkinTimeStepper(StageCoupledTimeStepper):
 
         dof = self._backend.Constant(0)
         for k in range(self.num_stages):
-            for i, u0bit in enumerate(self._backend.extract_subfunctions(self.u0)):
-                sbit = self._backend.extract_subfunctions(self.stages)[self.num_fields*k+i]
+            for i, u0bit in enumerate((self.u0.subfunctions)):
+                sbit = (self.stages.subfunctions)[self.num_fields*k+i]
                 if self.aux_indices and i in self.aux_indices:
                     dof.assign(test_dofs[k])
                 else:

--- a/irksome/galerkin_stepper.py
+++ b/irksome/galerkin_stepper.py
@@ -157,7 +157,7 @@ def getFormGalerkin(F, L_trial, L_test, Qdefault, t, dt, u0, stages, bcs=None, b
     assert L_test.get_reference_element() == L_trial.get_reference_element()
     assert L_trial.space_dimension() == L_test.space_dimension() + 1
     backend_cls = get_backend(backend)
-    Vbig = backend_cls.get_function_space(stages)
+    Vbig = stages.function_space()
     test = backend_cls.TestFunction(Vbig)
     Constant = backend_cls.Constant
 
@@ -170,7 +170,7 @@ def getFormGalerkin(F, L_trial, L_test, Qdefault, t, dt, u0, stages, bcs=None, b
                for Q, Fcur in splitting.items())
 
     # Oh, honey, is it the boundary conditions?
-    V = u0.function_space()
+    V = backend_cls.get_function_space(u0)
     if bcs is None:
         bcs = []
     bcs = backend_cls.extract_bcs(bcs)
@@ -293,8 +293,7 @@ class ContinuousPetrovGalerkinTimeStepper(StageCoupledTimeStepper):
                  bc_type=None, aux_indices=None, backend: str = "firedrake", **kwargs):
         self.order = scheme.order
         self.basis_type = scheme.basis_type
-        self.backend = backend
-        backend_cls = get_backend(backend)
+        self._backend = backend_cls = get_backend(backend)
         V = backend_cls.get_function_space(u0)
 
         self.num_fields = len(V)

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -246,7 +246,7 @@ class RadauIIAIMEXMethod:
             nullspace=nsp, **kwargs)
 
         num_fields = len(backend_cls.get_function_space(u0))
-        u0split = (u0.subfunctions)
+        u0split = u0.subfunctions
         for i, u0bit in enumerate(u0split):
             for s in range(self.num_stages):
                 ii = s * num_fields + i

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -271,7 +271,7 @@ class RadauIIAIMEXMethod:
 
         ns = self.num_stages
         nf = self.num_fields
-        u0split = (self.u0.subfunctions)
+        u0split = self.u0.subfunctions
         for i, u0bit in enumerate(u0split):
             u0bit.assign(self.UU_old_split[(ns-1)*nf + i])
 
@@ -518,9 +518,9 @@ class DIRKIMEXMethod:
             g.assign(u0)
             # Update g with contributions from previous stages
             for j in range(i):
-                ksplit = (ks[j].subfunctions)
-                k_hat_split = (k_hat_s[j].subfunctions)
-                for gbit, kbit, k_hat_bit in zip((g.subfunctions), ksplit, k_hat_split):
+                ksplit = ks[j].subfunctions
+                k_hat_split = k_hat_s[j].subfunctions
+                for gbit, kbit, k_hat_bit in zip(g.subfunctions, ksplit, k_hat_split):
                     gbit += dtc * (float(AA[i, j]) * kbit + float(A_hat[i, j]) * k_hat_bit)
 
             # Solve for current stage
@@ -541,7 +541,7 @@ class DIRKIMEXMethod:
             ks[i].assign(k)
 
             # Update the solution for next stage
-            for ghatbit, gbit, kbit in zip((ghat.subfunctions), (g.subfunctions), (ks[i].subfunctions)):
+            for ghatbit, gbit, kbit in zip(ghat.subfunctions, g.subfunctions, ks[i].subfunctions):
                 ghatbit.assign(gbit)
                 ghatbit += dtc * float(AA[i, i]) * kbit
 
@@ -583,7 +583,7 @@ class DIRKIMEXMethod:
         ks[0].assign(k)
 
         # Update the solution for second stage
-        for ghatbit, gbit, kbit in zip((ghat.subfunctions), (g.subfunctions), (ks[0].subfunctions)):
+        for ghatbit, gbit, kbit in zip(ghat.subfunctions, g.subfunctions, ks[0].subfunctions):
             ghatbit.assign(gbit)
             ghatbit += dtc * float(AA[0, 0]) * kbit
 
@@ -608,8 +608,8 @@ class DIRKIMEXMethod:
 
         # Final solution update
         for i in range(ns):
-            for u0bit, kbit, k_hat_bit in zip((u0.subfunctions), (ks[i].subfunctions),
-                                              (k_hat_s[i].subfunctions)):
+            for u0bit, kbit, k_hat_bit in zip(u0.subfunctions, ks[i].subfunctions,
+                                              k_hat_s[i].subfunctions):
                 u0bit += dtc * (float(BB[i]) * kbit + float(B_hat[i]) * k_hat_bit)
 
     # Last part of advance for the case where last explicit stage is not used
@@ -625,15 +625,15 @@ class DIRKIMEXMethod:
 
         # Final solution update
         for i in range(ns):
-            for u0bit, kbit, k_hat_bit in zip((u0.subfunctions), (ks[i].subfunctions),
-                                              (k_hat_s[i].subfunctions)):
+            for u0bit, kbit, k_hat_bit in zip(u0.subfunctions, ks[i].subfunctions,
+                                              k_hat_s[i].subfunctions):
                 u0bit += dtc * (BB[i] * kbit + B_hat[i] * k_hat_bit)
 
     # Last part of advance for the case where last implicit stage is new solution
     def _finalize_stiffly_accurate(self):
         khat, ghat, chat = self.kgchat
         u0 = self.u0
-        for u0bit, ghatbit in zip((u0.subfunctions), (ghat.subfunctions)):
+        for u0bit, ghatbit in zip(u0.subfunctions, ghat.subfunctions):
             u0bit.assign(ghatbit)
 
     def solver_stats(self):

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -208,7 +208,7 @@ class RadauIIAIMEXMethod:
 
         self.UU = UU
         self.UU_old = UU_old = backend_cls.Function(backend_cls.get_function_space(UU))
-        self.UU_old_split = backend_cls.extract_subfunctions(UU_old)
+        self.UU_old_split = UU_old.subfunctions
         self.bigBCs = bigBCs
 
         Fit, Fprop = getFormExplicit(
@@ -245,8 +245,8 @@ class RadauIIAIMEXMethod:
             solver_parameters=prop_solver_parameters,
             nullspace=nsp, **kwargs)
 
-        num_fields = self._backend.get_number_of_fields(self._backend.get_function_space(u0))
-        u0split = self._backend.extract_subfunctions(u0)
+        num_fields = len(self._backend.get_function_space(u0))
+        u0split = (u0.subfunctions)
         for i, u0bit in enumerate(u0split):
             for s in range(self.num_stages):
                 ii = s * num_fields + i
@@ -271,7 +271,7 @@ class RadauIIAIMEXMethod:
 
         ns = self.num_stages
         nf = self.num_fields
-        u0split = self._backend.extract_subfunctions(self.u0)
+        u0split = (self.u0.subfunctions)
         for i, u0bit in enumerate(u0split):
             u0bit.assign(self.UU_old_split[(ns-1)*nf + i])
 
@@ -417,7 +417,7 @@ class DIRKIMEXMethod:
         self.u0 = u0
         self.t = t
         self.dt = dt
-        self.num_fields = backend_cls.get_number_of_fields(V)
+        self.num_fields = len(V)
         self.ks = [backend_cls.Function(V) for _ in range(self.num_stages)]
         self.k_hat_s = [backend_cls.Function(V) for _ in range(self.num_stages)]
 
@@ -518,9 +518,9 @@ class DIRKIMEXMethod:
             g.assign(u0)
             # Update g with contributions from previous stages
             for j in range(i):
-                ksplit = self._backend.extract_subfunctions(ks[j])
-                k_hat_split = self._backend.extract_subfunctions(k_hat_s[j])
-                for gbit, kbit, k_hat_bit in zip(self._backend.extract_subfunctions(g), ksplit, k_hat_split):
+                ksplit = (ks[j].subfunctions)
+                k_hat_split = (k_hat_s[j].subfunctions)
+                for gbit, kbit, k_hat_bit in zip((g.subfunctions), ksplit, k_hat_split):
                     gbit += dtc * (float(AA[i, j]) * kbit + float(A_hat[i, j]) * k_hat_bit)
 
             # Solve for current stage
@@ -541,7 +541,7 @@ class DIRKIMEXMethod:
             ks[i].assign(k)
 
             # Update the solution for next stage
-            for ghatbit, gbit, kbit in zip(self._backend.extract_subfunctions(ghat), self._backend.extract_subfunctions(g), self._backend.extract_subfunctions(ks[i])):
+            for ghatbit, gbit, kbit in zip((ghat.subfunctions), (g.subfunctions), (ks[i].subfunctions)):
                 ghatbit.assign(gbit)
                 ghatbit += dtc * float(AA[i, i]) * kbit
 
@@ -583,7 +583,7 @@ class DIRKIMEXMethod:
         ks[0].assign(k)
 
         # Update the solution for second stage
-        for ghatbit, gbit, kbit in zip(self._backend.extract_subfunctions(ghat), self._backend.extract_subfunctions(g), self._backend.extract_subfunctions(ks[0])):
+        for ghatbit, gbit, kbit in zip((ghat.subfunctions), (g.subfunctions), (ks[0].subfunctions)):
             ghatbit.assign(gbit)
             ghatbit += dtc * float(AA[0, 0]) * kbit
 
@@ -608,8 +608,8 @@ class DIRKIMEXMethod:
 
         # Final solution update
         for i in range(ns):
-            for u0bit, kbit, k_hat_bit in zip(self._backend.extract_subfunctions(u0), self._backend.extract_subfunctions(ks[i]),
-                                              self._backend.extract_subfunctions(k_hat_s[i])):
+            for u0bit, kbit, k_hat_bit in zip((u0.subfunctions), (ks[i].subfunctions),
+                                              (k_hat_s[i].subfunctions)):
                 u0bit += dtc * (float(BB[i]) * kbit + float(B_hat[i]) * k_hat_bit)
 
     # Last part of advance for the case where last explicit stage is not used
@@ -625,15 +625,15 @@ class DIRKIMEXMethod:
 
         # Final solution update
         for i in range(ns):
-            for u0bit, kbit, k_hat_bit in zip(self._backend.extract_subfunctions(u0), self._backend.extract_subfunctions(ks[i]),
-                                              self._backend.extract_subfunctions(k_hat_s[i])):
+            for u0bit, kbit, k_hat_bit in zip((u0.subfunctions), (ks[i].subfunctions),
+                                              (k_hat_s[i].subfunctions)):
                 u0bit += dtc * (BB[i] * kbit + B_hat[i] * k_hat_bit)
 
     # Last part of advance for the case where last implicit stage is new solution
     def _finalize_stiffly_accurate(self):
         khat, ghat, chat = self.kgchat
         u0 = self.u0
-        for u0bit, ghatbit in zip(self._backend.extract_subfunctions(u0), self._backend.extract_subfunctions(ghat)):
+        for u0bit, ghatbit in zip((u0.subfunctions), (ghat.subfunctions)):
             u0bit.assign(ghatbit)
 
     def solver_stats(self):

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -3,7 +3,6 @@ import numpy as np
 from ufl import Form, as_ufl, dx, inner
 
 from .backend import get_backend
-from .bcs import bc2space
 from .constant import MeshConstant, vecconst
 from .stage_value import getFormStage
 from .tools import (AI, IA, extract_timedep_arguments, reshape, replace,
@@ -380,9 +379,9 @@ def getFormsDIRKIMEX(F, Fexp, ks, khats, butch, t, dt, u0, bcs=None, backend="fi
             bcnew.append(bc.reconstruct(g=0))
             continue
 
-        gdat = bcarg_stage - bc2space(bc, u0)
+        gdat = bcarg_stage - backend_cls.bc2space(bc, u0)
         for i in range(num_stages):
-            gdat -= dt*(a_vals[i]*bc2space(bc, ks[i]) + ahat_vals[i]*bc2space(bc, khats[i]))
+            gdat -= dt*(a_vals[i]*backend_cls.bc2space(bc, ks[i]) + ahat_vals[i]*backend_cls.bc2space(bc, khats[i]))
 
         gdat /= dt*d_val
         bcnew.append(bc.reconstruct(g=gdat))
@@ -414,11 +413,11 @@ class DIRKIMEXMethod:
         self.butcher_tableau = butcher_tableau
         self.num_stages = butcher_tableau.num_stages
 
-        self.V = V = u0.function_space()
+        self.V = V = backend_cls.get_function_space(u0)
         self.u0 = u0
         self.t = t
         self.dt = dt
-        self.num_fields = len(u0.function_space())
+        self.num_fields = backend_cls.get_number_of_fields(V)
         self.ks = [backend_cls.Function(V) for _ in range(self.num_stages)]
         self.k_hat_s = [backend_cls.Function(V) for _ in range(self.num_stages)]
 

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -6,7 +6,7 @@ from .backend import get_backend
 from .constant import MeshConstant, vecconst
 from .stage_value import getFormStage
 from .tools import (AI, IA, extract_timedep_arguments, reshape, replace,
-                    getNullspace, get_stage_space)
+                    get_stage_space)
 from .tableaux.ButcherTableaux import RadauIIA
 from .ufl.deriv import TimeDerivative, expand_time_derivatives
 
@@ -202,13 +202,13 @@ class RadauIIAIMEXMethod:
             F, butcher_tableau, t, dt, u0, UU, bcs,
             splitting=splitting, backend=backend)
 
-        nsp = getNullspace(backend_cls.get_function_space(u0),
-                           backend_cls.get_function_space(UU),
-                           self.num_stages, nullspace)
+        nsp = backend_cls.getNullspace(backend_cls.get_function_space(u0),
+                                       backend_cls.get_function_space(UU),
+                                       self.num_stages, nullspace)
 
         self.UU = UU
         self.UU_old = UU_old = backend_cls.Function(backend_cls.get_function_space(UU))
-        self.UU_old_split = UU_old.subfunctions
+        self.UU_old_split = backend_cls.extract_subfunctions(UU_old)
         self.bigBCs = bigBCs
 
         Fit, Fprop = getFormExplicit(
@@ -245,8 +245,8 @@ class RadauIIAIMEXMethod:
             solver_parameters=prop_solver_parameters,
             nullspace=nsp, **kwargs)
 
-        num_fields = len(self.u0.function_space())
-        u0split = u0.subfunctions
+        num_fields = self._backend.get_number_of_fields(self._backend.get_function_space(u0))
+        u0split = self._backend.extract_subfunctions(u0)
         for i, u0bit in enumerate(u0split):
             for s in range(self.num_stages):
                 ii = s * num_fields + i
@@ -271,7 +271,7 @@ class RadauIIAIMEXMethod:
 
         ns = self.num_stages
         nf = self.num_fields
-        u0split = self.u0.subfunctions
+        u0split = self._backend.extract_subfunctions(self.u0)
         for i, u0bit in enumerate(u0split):
             u0bit.assign(self.UU_old_split[(ns-1)*nf + i])
 
@@ -518,9 +518,9 @@ class DIRKIMEXMethod:
             g.assign(u0)
             # Update g with contributions from previous stages
             for j in range(i):
-                ksplit = ks[j].subfunctions
-                k_hat_split = k_hat_s[j].subfunctions
-                for gbit, kbit, k_hat_bit in zip(g.subfunctions, ksplit, k_hat_split):
+                ksplit = self._backend.extract_subfunctions(ks[j])
+                k_hat_split = self._backend.extract_subfunctions(k_hat_s[j])
+                for gbit, kbit, k_hat_bit in zip(self._backend.extract_subfunctions(g), ksplit, k_hat_split):
                     gbit += dtc * (float(AA[i, j]) * kbit + float(A_hat[i, j]) * k_hat_bit)
 
             # Solve for current stage
@@ -541,7 +541,7 @@ class DIRKIMEXMethod:
             ks[i].assign(k)
 
             # Update the solution for next stage
-            for ghatbit, gbit, kbit in zip(ghat.subfunctions, g.subfunctions, ks[i].subfunctions):
+            for ghatbit, gbit, kbit in zip(self._backend.extract_subfunctions(ghat), self._backend.extract_subfunctions(g), self._backend.extract_subfunctions(ks[i])):
                 ghatbit.assign(gbit)
                 ghatbit += dtc * float(AA[i, i]) * kbit
 
@@ -583,7 +583,7 @@ class DIRKIMEXMethod:
         ks[0].assign(k)
 
         # Update the solution for second stage
-        for ghatbit, gbit, kbit in zip(ghat.subfunctions, g.subfunctions, ks[0].subfunctions):
+        for ghatbit, gbit, kbit in zip(self._backend.extract_subfunctions(ghat), self._backend.extract_subfunctions(g), self._backend.extract_subfunctions(ks[0])):
             ghatbit.assign(gbit)
             ghatbit += dtc * float(AA[0, 0]) * kbit
 
@@ -608,8 +608,8 @@ class DIRKIMEXMethod:
 
         # Final solution update
         for i in range(ns):
-            for u0bit, kbit, k_hat_bit in zip(u0.subfunctions, ks[i].subfunctions,
-                                              k_hat_s[i].subfunctions):
+            for u0bit, kbit, k_hat_bit in zip(self._backend.extract_subfunctions(u0), self._backend.extract_subfunctions(ks[i]),
+                                              self._backend.extract_subfunctions(k_hat_s[i])):
                 u0bit += dtc * (float(BB[i]) * kbit + float(B_hat[i]) * k_hat_bit)
 
     # Last part of advance for the case where last explicit stage is not used
@@ -625,15 +625,15 @@ class DIRKIMEXMethod:
 
         # Final solution update
         for i in range(ns):
-            for u0bit, kbit, k_hat_bit in zip(u0.subfunctions, ks[i].subfunctions,
-                                              k_hat_s[i].subfunctions):
+            for u0bit, kbit, k_hat_bit in zip(self._backend.extract_subfunctions(u0), self._backend.extract_subfunctions(ks[i]),
+                                              self._backend.extract_subfunctions(k_hat_s[i])):
                 u0bit += dtc * (BB[i] * kbit + B_hat[i] * k_hat_bit)
 
     # Last part of advance for the case where last implicit stage is new solution
     def _finalize_stiffly_accurate(self):
         khat, ghat, chat = self.kgchat
         u0 = self.u0
-        for u0bit, ghatbit in zip(u0.subfunctions, ghat.subfunctions):
+        for u0bit, ghatbit in zip(self._backend.extract_subfunctions(u0), self._backend.extract_subfunctions(ghat)):
             u0bit.assign(ghatbit)
 
     def solver_stats(self):

--- a/irksome/imex.py
+++ b/irksome/imex.py
@@ -42,7 +42,7 @@ def getFormExplicit(Fexp, butch, u0, UU, t, dt, splitting=None, backend="firedra
     v, u = extract_timedep_arguments(Fexp, u0)
     V = backend_cls.get_function_space(v)
     assert V == backend_cls.get_function_space(u0)
-    Vbig = backend_cls.get_function_space(UU)
+    Vbig = UU.function_space()
     VV = backend_cls.TestFunction(Vbig)
 
     num_stages = butch.num_stages
@@ -203,11 +203,11 @@ class RadauIIAIMEXMethod:
             splitting=splitting, backend=backend)
 
         nsp = backend_cls.getNullspace(backend_cls.get_function_space(u0),
-                                       backend_cls.get_function_space(UU),
+                                       UU.function_space(),
                                        self.num_stages, nullspace)
 
         self.UU = UU
-        self.UU_old = UU_old = backend_cls.Function(backend_cls.get_function_space(UU))
+        self.UU_old = UU_old = backend_cls.Function(UU.function_space())
         self.UU_old_split = UU_old.subfunctions
         self.bigBCs = bigBCs
 
@@ -245,7 +245,7 @@ class RadauIIAIMEXMethod:
             solver_parameters=prop_solver_parameters,
             nullspace=nsp, **kwargs)
 
-        num_fields = len(self._backend.get_function_space(u0))
+        num_fields = len(backend_cls.get_function_space(u0))
         u0split = (u0.subfunctions)
         for i, u0bit in enumerate(u0split):
             for s in range(self.num_stages):

--- a/irksome/multistep.py
+++ b/irksome/multistep.py
@@ -3,7 +3,6 @@ from .ufl.manipulation import split_time_derivative_terms, remove_time_derivativ
 from .ufl.deriv import expand_time_derivatives
 from .base_time_stepper import BaseTimeStepper
 from .tableaux.multistep_tableaux import MultistepTableau
-from .bcs import stage2spaces4bc
 from .tools import replace
 from ufl import Form
 from ufl.constantvalue import as_ufl
@@ -114,7 +113,7 @@ class MultistepTimeStepper(BaseTimeStepper):
                 for bc in self.orig_bcs:
                     bcarg = as_ufl(bc._original_arg)
                     bcarg_startup = replace(bcarg, {self.t: self.startup_t})
-                    bc_space = stage2spaces4bc(bc, V, V, 0)
+                    bc_space = self._backend.stage2spaces4bc(bc, V, V, 0)
                     startup_bcs.extend(bc.reconstruct(V=bc_space, g=bcarg_startup))
 
             self.startup_TS = TimeStepper(F_startup, butcher_tableau, self.startup_t, startup_dt, self.u0, bcs=startup_bcs, **stepper_kwargs)
@@ -157,7 +156,7 @@ class MultistepTimeStepper(BaseTimeStepper):
         for bc in bcs:
             bcarg = as_ufl(bc._original_arg)
             new_bcarg = replace(bcarg, {t: t + dt})
-            bc_space = stage2spaces4bc(bc, V, V, 0)
+            bc_space = self._backend.stage2spaces4bc(bc, V, V, 0)
             bcsnew.extend(bc.reconstruct(V=bc_space, g=new_bcarg))
 
         return Fnew, bcsnew

--- a/irksome/multistep.py
+++ b/irksome/multistep.py
@@ -103,7 +103,7 @@ class MultistepTimeStepper(BaseTimeStepper):
 
             F_startup = replace(self.F, {self.t: self.startup_t})
             v, = F_startup.arguments()
-            V = v.function_space()
+            V = self._backend.get_function_space(v)
 
             # grab a copy of the boundary conditions w.r.t. startup_t
             startup_bcs = []

--- a/irksome/nystrom_dirk_stepper.py
+++ b/irksome/nystrom_dirk_stepper.py
@@ -3,7 +3,6 @@ from ufl.constantvalue import as_ufl
 
 from .ufl.deriv import Dt, expand_time_derivatives
 from .tools import extract_timedep_arguments, replace
-from .bcs import bc2space
 from .constant import MeshConstant, vecconst
 from .nystrom_stepper import butcher_to_nystrom, NystromTableau
 from .backend import get_backend
@@ -65,8 +64,8 @@ def getFormDIRKNystrom(F, ks, tableau, t, dt, u0, ut0, bcs=None, bc_type=None, b
                 bcnew.append(bc)
             else:
                 bcarg_stage = replace(as_ufl(bcarg), {t: t+c*dt})
-                gdat = bcarg_stage - bc2space(bc, u0) - c*dt*bc2space(bc, ut0)
-                gdat -= sum(bc2space(bc, ks[i]) * (abar_vals[i] * dt**2) for i in range(num_stages))
+                gdat = bcarg_stage - backend_cls.bc2space(bc, u0) - c*dt*backend_cls.bc2space(bc, ut0)
+                gdat -= sum(backend_cls.bc2space(bc, ks[i]) * (abar_vals[i] * dt**2) for i in range(num_stages))
                 gdat /= d_val * dt**2
                 bcnew.append(bc.reconstruct(g=gdat))
     elif bc_type == "dDAE":
@@ -84,8 +83,8 @@ def getFormDIRKNystrom(F, ks, tableau, t, dt, u0, ut0, bcs=None, bc_type=None, b
             else:
                 bcprime = expand_time_derivatives(Dt(as_ufl(bcarg)), t=t, timedep_coefs=(u0,))
                 bcprime_stage = replace(bcprime, {t: t+c*dt})
-                gdat = bcprime_stage - bc2space(bc, ut0)
-                gdat -= sum(bc2space(bc, ks[i]) * (abar_vals[i] * dt) for i in range(num_stages))
+                gdat = bcprime_stage - backend_cls.bc2space(bc, ut0)
+                gdat -= sum(backend_cls.bc2space(bc, ks[i]) * (abar_vals[i] * dt) for i in range(num_stages))
                 gdat /= d_val * dt
                 bcnew.append(bc.reconstruct(g=gdat))
 

--- a/irksome/nystrom_dirk_stepper.py
+++ b/irksome/nystrom_dirk_stepper.py
@@ -145,7 +145,7 @@ class DIRKNystromTimeStepper:
         self.ut0 = ut0
         self.t = t
         self.dt = dt
-        self.num_fields = len(backend_cls.get_function_space(u0))
+        self.num_fields = len(V)
         self.ks = [backend_cls.Function(V) for _ in range(num_stages)]
 
         stage_F, self.kgac, bcnew, (abar_vals, d_val) = getFormDIRKNystrom(

--- a/irksome/nystrom_stepper.py
+++ b/irksome/nystrom_stepper.py
@@ -89,7 +89,7 @@ def getFormNystrom(F, tableau, t, dt, u0, ut0, stages,
     c = vecconst(tableau.c)
 
     num_stages = tableau.num_stages
-    Vbig = stages.function_space
+    Vbig = stages.function_space()
     test = backend_cls.TestFunction(Vbig)
 
     v_np = reshape(test, (num_stages, *u0.ufl_shape))

--- a/irksome/nystrom_stepper.py
+++ b/irksome/nystrom_stepper.py
@@ -188,9 +188,9 @@ class StageDerivativeNystromTimeStepper(StageCoupledTimeStepper):
                          tableau.num_stages, bcs=bcs,
                          bc_type=bc_type, backend=backend, **kwargs)
 
-        self.updateb = vecconst(tableau.b)
-        self.updatebbar = vecconst(tableau.bbar)
-        self.num_fields = self._backend.get_number_of_fields(self._backend.get_function_space(u0))
+        self.updateb = vecconst(tableau.b, backend=backend)
+        self.updatebbar = vecconst(tableau.bbar, backend=backend)
+        self.num_fields = len(self._backend.get_function_space(u0))
 
     def _update(self):
         b = self.updateb
@@ -201,9 +201,9 @@ class StageDerivativeNystromTimeStepper(StageCoupledTimeStepper):
 
         # Note: order matters here.  derivative update doesn't
         # depend on old solution value.
-        kp = self._backend.extract_subfunctions(self.stages)
-        for i, (u0bit, ut0bit) in enumerate(zip(self._backend.extract_subfunctions(self.u0),
-                                                self._backend.extract_subfunctions(self.ut0))):
+        kp = (self.stages.subfunctions)
+        for i, (u0bit, ut0bit) in enumerate(zip((self.u0.subfunctions),
+                                                (self.ut0.subfunctions))):
             u0bit += (ut0bit * dt
                       + sum(kp[nf * s + i] * (bbar[s] * dt**2)
                             for s in range(ns)))

--- a/irksome/nystrom_stepper.py
+++ b/irksome/nystrom_stepper.py
@@ -201,9 +201,9 @@ class StageDerivativeNystromTimeStepper(StageCoupledTimeStepper):
 
         # Note: order matters here.  derivative update doesn't
         # depend on old solution value.
-        kp = self.stages.subfunctions
-        for i, (u0bit, ut0bit) in enumerate(zip(self.u0.subfunctions,
-                                                self.ut0.subfunctions)):
+        kp = self._backend.extract_subfunctions(self.stages)
+        for i, (u0bit, ut0bit) in enumerate(zip(self._backend.extract_subfunctions(self.u0),
+                                                self._backend.extract_subfunctions(self.ut0))):
             u0bit += (ut0bit * dt
                       + sum(kp[nf * s + i] * (bbar[s] * dt**2)
                             for s in range(ns)))

--- a/irksome/nystrom_stepper.py
+++ b/irksome/nystrom_stepper.py
@@ -89,7 +89,7 @@ def getFormNystrom(F, tableau, t, dt, u0, ut0, stages,
     c = vecconst(tableau.c)
 
     num_stages = tableau.num_stages
-    Vbig = backend_cls.get_function_space(stages)
+    Vbig = stages.function_space
     test = backend_cls.TestFunction(Vbig)
 
     v_np = reshape(test, (num_stages, *u0.ufl_shape))

--- a/irksome/nystrom_stepper.py
+++ b/irksome/nystrom_stepper.py
@@ -201,9 +201,9 @@ class StageDerivativeNystromTimeStepper(StageCoupledTimeStepper):
 
         # Note: order matters here.  derivative update doesn't
         # depend on old solution value.
-        kp = (self.stages.subfunctions)
-        for i, (u0bit, ut0bit) in enumerate(zip((self.u0.subfunctions),
-                                                (self.ut0.subfunctions))):
+        kp = self.stages.subfunctions
+        for i, (u0bit, ut0bit) in enumerate(zip(self.u0.subfunctions,
+                                                self.ut0.subfunctions)):
             u0bit += (ut0bit * dt
                       + sum(kp[nf * s + i] * (bbar[s] * dt**2)
                             for s in range(ns)))

--- a/irksome/nystrom_stepper.py
+++ b/irksome/nystrom_stepper.py
@@ -1,5 +1,5 @@
 from .base_time_stepper import StageCoupledTimeStepper
-from .bcs import BCStageData, bc2space
+from .bcs import BCStageData
 from .ufl.deriv import Dt, TimeDerivative, expand_time_derivatives
 from .backend import get_backend
 from .tools import dot, extract_timedep_arguments, reshape, replace
@@ -130,8 +130,8 @@ def getFormNystrom(F, tableau, t, dt, u0, ut0, stages,
 
         def bc2gcur(bc, i):
             gorig = as_ufl(bc._original_arg)
-            ucur = bc2space(bc, u0)
-            utcur = bc2space(bc, ut0)
+            ucur = backend_cls.bc2space(bc, u0)
+            utcur = backend_cls.bc2space(bc, ut0)
             gcur = (1/dt**2) * sum((replace(gorig, {t: t + c[j]*dt}) - ucur - utcur * (dt * c[j])) * A1inv[i, j]
                                    for j in range(num_stages))
             return gcur
@@ -158,7 +158,7 @@ def getFormNystrom(F, tableau, t, dt, u0, ut0, stages,
         def bc2gcur(bc, i):
             gorig = as_ufl(bc._original_arg)
             gfoo = expand_time_derivatives(Dt(gorig, 1), t=t, timedep_coeffs=(u0,))
-            utcur = bc2space(bc, ut0)
+            utcur = backend_cls.bc2space(bc, ut0)
             gcur = (1/dt) * sum((replace(gfoo, {t: t + c_ddae[j]*dt}) - utcur) * A1inv[i, j]
                                 for j in range(num_stages))
             return gcur
@@ -177,7 +177,7 @@ def getFormNystrom(F, tableau, t, dt, u0, ut0, stages,
 
 class StageDerivativeNystromTimeStepper(StageCoupledTimeStepper):
     def __init__(self, F, tableau, t, dt, u0, ut0,
-                 bcs=None, bc_type="DAE", **kwargs):
+                 bcs=None, bc_type="DAE", backend="firedrake", **kwargs):
         self.ut0 = ut0
         if not isinstance(tableau, NystromTableau):
             tableau = butcher_to_nystrom(tableau)
@@ -186,11 +186,11 @@ class StageDerivativeNystromTimeStepper(StageCoupledTimeStepper):
 
         super().__init__(F, t, dt, u0,
                          tableau.num_stages, bcs=bcs,
-                         bc_type=bc_type, **kwargs)
+                         bc_type=bc_type, backend=backend, **kwargs)
 
         self.updateb = vecconst(tableau.b)
         self.updatebbar = vecconst(tableau.bbar)
-        self.num_fields = len(u0.function_space())
+        self.num_fields = self._backend.get_number_of_fields(self._backend.get_function_space(u0))
 
     def _update(self):
         b = self.updateb

--- a/irksome/stage_derivative.py
+++ b/irksome/stage_derivative.py
@@ -7,7 +7,7 @@ from .tools import AI, dot, extract_timedep_arguments, fields_to_components, rep
 from .ufl.deriv import Dt, TimeDerivative, expand_time_derivatives
 from .backend import get_backend
 
-from .bcs import EmbeddedBCData, BCStageData, stage2spaces4bc, bc2space
+from .bcs import EmbeddedBCData, BCStageData
 
 from .base_time_stepper import StageCoupledTimeStepper
 from .tableaux.ButcherTableaux import CollocationButcherTableau
@@ -76,7 +76,7 @@ def getForm(F, butch, t, dt, u0, stages, bcs=None, bc_type=None, splitting=AI, a
     # s-way product space for the stage variables
     num_stages = butch.num_stages
     Vbig = backend_cls.get_function_space(stages)
-    test = backend_cls.TestFunction(Vbig)
+    test = as_tensor(backend_cls.TestFunction(Vbig))
 
     # set up the pieces we need to work with to do our substitutions
     v_np = reshape(test, (num_stages, *v.ufl_shape))
@@ -127,7 +127,7 @@ def getForm(F, butch, t, dt, u0, stages, bcs=None, bc_type=None, splitting=AI, a
             if isinstance(bc, backend_cls.EquationBCSplit):
                 F_bc_orig = expand_time_derivatives(bc.f, t=t, timedep_coeffs=(u,))
                 F_bc_new = replace(F_bc_orig, repl[i])
-                Vbigi = stage2spaces4bc(bc, V, Vbig, i)
+                Vbigi = backend_cls.stage2spaces4bc(bc, V, Vbig, i)
                 return backend_cls.EquationBC(
                     F_bc_new == 0, stages, bc.sub_domain, V=Vbigi,
                     bcs=[bc2stagebc(innerbc, i) for innerbc in backend_cls.extract_bcs(bc.bcs)])
@@ -135,10 +135,10 @@ def getForm(F, butch, t, dt, u0, stages, bcs=None, bc_type=None, splitting=AI, a
                 gcur = bc._original_arg
                 if gcur != 0:
                     gorig = as_ufl(gcur)
-                    ucur = bc2space(bc, u0)
+                    ucur = backend_cls.bc2space(bc, u0)
                     gcur = (1/dt) * sum((replace(gorig, {t: t + c[j]*dt}) - ucur) * A1inv[i, j]
                                         for j in range(num_stages))
-                return BCStageData(bc, gcur, u0, stages, i)
+                return BCStageData(bc, gcur, u0, stages, i, backend=backend)
     else:
         raise ValueError(f"Unrecognised bc_type: {bc_type}")
 
@@ -157,8 +157,8 @@ class StageDerivativeTimeStepper(StageCoupledTimeStepper):
     :arg F: a :class:`ufl.Form` instance describing the semi-discrete problem.
     :arg butcher_tableau: A :class:`ButcherTableau` instance giving
         the Runge-Kutta method to be used for time marching.
-    :arg t: a :class:`Constant` or :class:`Function`
-        on the Real space over the same mesh as ``u0``.  This serves as
+    :arg t: a :class:`Constant` or :class:`Function` on the Real space
+        over the same mesh as ``u0``.  This serves as
         a variable referring to the current time.
     :arg dt: a :class:`Constant` or :class:`Function`
         on the Real space over the same mesh as ``u0``.  This serves as
@@ -196,7 +196,7 @@ class StageDerivativeTimeStepper(StageCoupledTimeStepper):
         self.butcher_tableau = butcher_tableau
         A1, A2 = splitting(butcher_tableau.A)
         try:
-            self.updateb = vecconst(numpy.linalg.solve(A2.T, butcher_tableau.b))
+            self.updateb = vecconst(numpy.linalg.solve(A2.T, butcher_tableau.b), backend=backend)
         except numpy.linalg.LinAlgError:
             raise NotImplementedError("A=A1 A2 splitting needs A2 invertible")
 
@@ -209,7 +209,7 @@ class StageDerivativeTimeStepper(StageCoupledTimeStepper):
                          butcher_tableau=butcher_tableau,
                          sample_points=sample_points,
                          backend=backend, **kwargs)
-        self.num_fields = len(self._backend.get_function_space(u0))
+        self.num_fields = self._backend.get_number_of_fields(self._backend.get_function_space(u0))
 
     def _update(self):
         """Assuming the algebraic problem for the RK stages has been
@@ -233,7 +233,7 @@ class StageDerivativeTimeStepper(StageCoupledTimeStepper):
                        self.t, self.dt, self.u0,
                        stages, bcs, self.bc_type,
                        splitting=self.splitting,
-                       aux_indices=self.aux_indices)
+                       aux_indices=self.aux_indices, backend=self._backend)
 
     def tabulate_poly(self, sample_points):
         if not isinstance(self.butcher_tableau, CollocationButcherTableau):

--- a/irksome/stage_derivative.py
+++ b/irksome/stage_derivative.py
@@ -76,7 +76,7 @@ def getForm(F, butch, t, dt, u0, stages, bcs=None, bc_type=None, splitting=AI, a
     # s-way product space for the stage variables
     num_stages = butch.num_stages
     Vbig = stages.function_space()
-    test = as_tensor(backend_cls.TestFunction(Vbig))
+    test = backend_cls.TestFunction(Vbig)
 
     # set up the pieces we need to work with to do our substitutions
     v_np = reshape(test, (num_stages, *v.ufl_shape))

--- a/irksome/stage_derivative.py
+++ b/irksome/stage_derivative.py
@@ -222,7 +222,7 @@ class StageDerivativeTimeStepper(StageCoupledTimeStepper):
 
         # Note: this now catches the optimized/stiffly accurate case as b[s] == Zero() will get dropped
         for i, u0bit in enumerate(self.u0.subfunctions):
-            u0bit += sum((self.stages.subfunctions)[nf * s + i] * (b[s] * dt) for s in range(ns))
+            u0bit += sum(self.stages.subfunctions[nf * s + i] * (b[s] * dt) for s in range(ns))
 
     def get_form_and_bcs(self, stages, F=None, bcs=None, tableau=None):
         if bcs is None:

--- a/irksome/stage_derivative.py
+++ b/irksome/stage_derivative.py
@@ -222,8 +222,8 @@ class StageDerivativeTimeStepper(StageCoupledTimeStepper):
 
         # Note: this now catches the optimized/stiffly accurate case as b[s] == Zero() will get dropped
 
-        for i, u0bit in enumerate(self.u0.subfunctions):
-            u0bit += sum(self.stages.subfunctions[nf * s + i] * (b[s] * dt) for s in range(ns))
+        for i, u0bit in enumerate(self._backend.extract_subfunctions(self.u0)):
+            u0bit += sum(self._backend.extract_subfunctions(self.stages)[nf * s + i] * (b[s] * dt) for s in range(ns))
 
     def get_form_and_bcs(self, stages, F=None, bcs=None, tableau=None):
         if bcs is None:
@@ -354,7 +354,7 @@ class AdaptiveTimeStepper(StageDerivativeTimeStepper):
         backend_cls = self._backend
         dtc = float(self.dt)
         delb = self.delb
-        ws = self.stages.subfunctions
+        ws = backend_cls.extract_subfunctions(self.stages)
         nf = self.num_fields
         ns = self.num_stages
         u0 = self.u0
@@ -370,7 +370,7 @@ class AdaptiveTimeStepper(StageDerivativeTimeStepper):
             f_solver.solve()
 
         # Accumulate delta-b terms over stages
-        error_func_bits = error_func.subfunctions
+        error_func_bits = backend_cls.extract_subfunctions(error_func)
         for s in range(ns):
             for i, e in enumerate(error_func_bits):
                 e += dtc*float(delb[s])*ws[nf*s+i]

--- a/irksome/stage_derivative.py
+++ b/irksome/stage_derivative.py
@@ -75,7 +75,7 @@ def getForm(F, butch, t, dt, u0, stages, bcs=None, bc_type=None, splitting=AI, a
 
     # s-way product space for the stage variables
     num_stages = butch.num_stages
-    Vbig = backend_cls.get_function_space(stages)
+    Vbig = stages.function_space()
     test = as_tensor(backend_cls.TestFunction(Vbig))
 
     # set up the pieces we need to work with to do our substitutions
@@ -359,10 +359,11 @@ class AdaptiveTimeStepper(StageDerivativeTimeStepper):
         u0 = self.u0
 
         # Initialize e to be gamma*h*f(old value of u)
-        error_func = backend_cls.Function(backend_cls.get_function_space(u0))
+        V = backend_cls.get_function_space(u0)
+        error_func = backend_cls.Function(V)
         # Only do the hard stuff if gamma0 is not zero
         if self.gamma0 != 0.0:
-            error_test = backend_cls.TestFunction(backend_cls.get_function_space(u0))
+            error_test = backend_cls.TestFunction(V)
             f_form = inner(error_func, error_test)*dx-self.gamma0*dtc*self.dtless_form
             f_problem = backend_cls.create_variational_problem(f_form, error_func, bcs=self.embbc)
             f_solver = backend_cls.create_variational_solver(f_problem, solver_parameters=self.gamma0_params)

--- a/irksome/stage_derivative.py
+++ b/irksome/stage_derivative.py
@@ -209,7 +209,7 @@ class StageDerivativeTimeStepper(StageCoupledTimeStepper):
                          butcher_tableau=butcher_tableau,
                          sample_points=sample_points,
                          backend=backend, **kwargs)
-        self.num_fields = self._backend.get_number_of_fields(self._backend.get_function_space(u0))
+        self.num_fields = len(self._backend.get_function_space(u0))
 
     def _update(self):
         """Assuming the algebraic problem for the RK stages has been
@@ -221,9 +221,8 @@ class StageDerivativeTimeStepper(StageCoupledTimeStepper):
         nf = self.num_fields
 
         # Note: this now catches the optimized/stiffly accurate case as b[s] == Zero() will get dropped
-
-        for i, u0bit in enumerate(self._backend.extract_subfunctions(self.u0)):
-            u0bit += sum(self._backend.extract_subfunctions(self.stages)[nf * s + i] * (b[s] * dt) for s in range(ns))
+        for i, u0bit in enumerate(self.u0.subfunctions):
+            u0bit += sum((self.stages.subfunctions)[nf * s + i] * (b[s] * dt) for s in range(ns))
 
     def get_form_and_bcs(self, stages, F=None, bcs=None, tableau=None):
         if bcs is None:
@@ -329,7 +328,7 @@ class AdaptiveTimeStepper(StageDerivativeTimeStepper):
         self.onscale_factor = onscale_factor
         self.safety_factor = safety_factor
 
-        self.error_func = self._backend.Function(u0.function_space())
+        self.error_func = self._backend.Function(self._backend.get_function_space(u0))
         self.tol = tol
         self.err_old = 0.0
         self.contreject = 0
@@ -354,23 +353,23 @@ class AdaptiveTimeStepper(StageDerivativeTimeStepper):
         backend_cls = self._backend
         dtc = float(self.dt)
         delb = self.delb
-        ws = backend_cls.extract_subfunctions(self.stages)
+        ws = self.stages.subfunctions
         nf = self.num_fields
         ns = self.num_stages
         u0 = self.u0
 
         # Initialize e to be gamma*h*f(old value of u)
-        error_func = backend_cls.Function(u0.function_space())
+        error_func = backend_cls.Function(backend_cls.get_function_space(u0))
         # Only do the hard stuff if gamma0 is not zero
         if self.gamma0 != 0.0:
-            error_test = backend_cls.TestFunction(u0.function_space())
+            error_test = backend_cls.TestFunction(backend_cls.get_function_space(u0))
             f_form = inner(error_func, error_test)*dx-self.gamma0*dtc*self.dtless_form
             f_problem = backend_cls.create_variational_problem(f_form, error_func, bcs=self.embbc)
             f_solver = backend_cls.create_variational_solver(f_problem, solver_parameters=self.gamma0_params)
             f_solver.solve()
 
         # Accumulate delta-b terms over stages
-        error_func_bits = backend_cls.extract_subfunctions(error_func)
+        error_func_bits = error_func.subfunctions
         for s in range(ns):
             for i, e in enumerate(error_func_bits):
                 e += dtc*float(delb[s])*ws[nf*s+i]

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -212,13 +212,13 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
         ns = self.num_stages
         scale = self.update_scale
         bAinv = self.bAinv
-        for i, u0bit in enumerate(self.u0.subfunctions):
+        for i, u0bit in enumerate(self._backend.extract_subfunctions(self.u0)):
             u0bit *= scale
-            u0bit += sum(self.stages.subfunctions[nf * s + i] * bAinv[s] for s in range(ns))
+            u0bit += sum(self._backend.extract_subfunctions(self.stages)[nf * s + i] * bAinv[s] for s in range(ns))
 
     def _update_stiff_acc(self):
-        for i, u0bit in enumerate(self.u0.subfunctions):
-            u0bit.assign(self.stages.subfunctions[self.num_fields*(self.num_stages-1)+i])
+        for i, u0bit in enumerate(self._backend.extract_subfunctions(self.u0)):
+            u0bit.assign(self._backend.extract_subfunctions(self.stages)[self.num_fields*(self.num_stages-1)+i])
 
     def get_update_solver(self, update_solver_parameters):
         # only form update stuff if we need it
@@ -260,8 +260,8 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
         self.u0.assign(self.unew)
 
     def _update_collocation(self):
-        stage_vals = numpy.array(self.u0.subfunctions + self.stages.subfunctions, dtype=object)
-        for i, u0bit in enumerate(self.u0.subfunctions):
+        stage_vals = numpy.array(self._backend.extract_subfunctions(self.u0) + self._backend.extract_subfunctions(self.stages), dtype=object)
+        for i, u0bit in enumerate(self._backend.extract_subfunctions(self.u0)):
             u0bit.assign(stage_vals[i::self.num_fields] @ self.collocation_vander)
 
     def get_form_and_bcs(self, stages, F=None, bcs=None, tableau=None):
@@ -277,8 +277,8 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
     def set_initial_guess(self):
         """Set a constant-in-time initial guess"""
         for k in range(self.num_stages):
-            for i, u0bit in enumerate(self.u0.subfunctions):
-                sbit = self.stages.subfunctions[self.num_fields * k + i]
+            for i, u0bit in enumerate(self._backend.extract_subfunctions(self.u0)):
+                sbit = self._backend.extract_subfunctions(self.stages)[self.num_fields * k + i]
                 sbit.assign(u0bit)
 
     def tabulate_poly(self, sample_points):

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -212,12 +212,12 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
         ns = self.num_stages
         scale = self.update_scale
         bAinv = self.bAinv
-        for i, u0bit in enumerate((self.u0.subfunctions)):
+        for i, u0bit in enumerate(self.u0.subfunctions):
             u0bit *= scale
             u0bit += sum(self.stages.subfunctions[nf * s + i] * bAinv[s] for s in range(ns))
 
     def _update_stiff_acc(self):
-        for i, u0bit in enumerate((self.u0.subfunctions)):
+        for i, u0bit in enumerate(self.u0.subfunctions):
             u0bit.assign(self.stages.subfunctions[self.num_fields*(self.num_stages-1)+i])
 
     def get_update_solver(self, update_solver_parameters):

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -212,13 +212,13 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
         ns = self.num_stages
         scale = self.update_scale
         bAinv = self.bAinv
-        for i, u0bit in enumerate(self._backend.extract_subfunctions(self.u0)):
+        for i, u0bit in enumerate((self.u0.subfunctions)):
             u0bit *= scale
-            u0bit += sum(self._backend.extract_subfunctions(self.stages)[nf * s + i] * bAinv[s] for s in range(ns))
+            u0bit += sum((self.stages.subfunctions)[nf * s + i] * bAinv[s] for s in range(ns))
 
     def _update_stiff_acc(self):
-        for i, u0bit in enumerate(self._backend.extract_subfunctions(self.u0)):
-            u0bit.assign(self._backend.extract_subfunctions(self.stages)[self.num_fields*(self.num_stages-1)+i])
+        for i, u0bit in enumerate((self.u0.subfunctions)):
+            u0bit.assign((self.stages.subfunctions)[self.num_fields*(self.num_stages-1)+i])
 
     def get_update_solver(self, update_solver_parameters):
         # only form update stuff if we need it
@@ -260,8 +260,8 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
         self.u0.assign(self.unew)
 
     def _update_collocation(self):
-        stage_vals = numpy.array(self._backend.extract_subfunctions(self.u0) + self._backend.extract_subfunctions(self.stages), dtype=object)
-        for i, u0bit in enumerate(self._backend.extract_subfunctions(self.u0)):
+        stage_vals = numpy.array((self.u0.subfunctions) + (self.stages.subfunctions), dtype=object)
+        for i, u0bit in enumerate((self.u0.subfunctions)):
             u0bit.assign(stage_vals[i::self.num_fields] @ self.collocation_vander)
 
     def get_form_and_bcs(self, stages, F=None, bcs=None, tableau=None):
@@ -277,8 +277,8 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
     def set_initial_guess(self):
         """Set a constant-in-time initial guess"""
         for k in range(self.num_stages):
-            for i, u0bit in enumerate(self._backend.extract_subfunctions(self.u0)):
-                sbit = self._backend.extract_subfunctions(self.stages)[self.num_fields * k + i]
+            for i, u0bit in enumerate((self.u0.subfunctions)):
+                sbit = (self.stages.subfunctions)[self.num_fields * k + i]
                 sbit.assign(u0bit)
 
     def tabulate_poly(self, sample_points):

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -6,7 +6,6 @@ from FIAT.barycentric_interpolation import LagrangePolynomialSet
 
 from ufl import Form, as_tensor, as_ufl, dx, inner
 
-from .bcs import stage2spaces4bc
 from .tableaux.ButcherTableaux import CollocationButcherTableau
 from .ufl.deriv import expand_time_derivatives
 from .ufl.manipulation import split_time_derivative_terms, remove_time_derivatives
@@ -150,7 +149,7 @@ def getFormStage(F, butch, t, dt, u0, stages, bcs=None, splitting=AI, vandermond
             g_np = Vander_inv[1:, 1:] @ g_np
 
         for i in range(num_stages):
-            Vbigi = stage2spaces4bc(bc, V, Vbig, i)
+            Vbigi = backend_cls.stage2spaces4bc(bc, V, Vbig, i)
             bcsnew.extend(bc.reconstruct(V=Vbigi, g=as_tensor(g_np[i])))
     return Fnew, bcsnew
 

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -214,11 +214,11 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
         bAinv = self.bAinv
         for i, u0bit in enumerate((self.u0.subfunctions)):
             u0bit *= scale
-            u0bit += sum((self.stages.subfunctions)[nf * s + i] * bAinv[s] for s in range(ns))
+            u0bit += sum(self.stages.subfunctions[nf * s + i] * bAinv[s] for s in range(ns))
 
     def _update_stiff_acc(self):
         for i, u0bit in enumerate((self.u0.subfunctions)):
-            u0bit.assign((self.stages.subfunctions)[self.num_fields*(self.num_stages-1)+i])
+            u0bit.assign(self.stages.subfunctions[self.num_fields*(self.num_stages-1)+i])
 
     def get_update_solver(self, update_solver_parameters):
         # only form update stuff if we need it
@@ -260,8 +260,8 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
         self.u0.assign(self.unew)
 
     def _update_collocation(self):
-        stage_vals = numpy.array((self.u0.subfunctions) + (self.stages.subfunctions), dtype=object)
-        for i, u0bit in enumerate((self.u0.subfunctions)):
+        stage_vals = numpy.array(self.u0.subfunctions + self.stages.subfunctions, dtype=object)
+        for i, u0bit in enumerate(self.u0.subfunctions):
             u0bit.assign(stage_vals[i::self.num_fields] @ self.collocation_vander)
 
     def get_form_and_bcs(self, stages, F=None, bcs=None, tableau=None):
@@ -277,8 +277,8 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
     def set_initial_guess(self):
         """Set a constant-in-time initial guess"""
         for k in range(self.num_stages):
-            for i, u0bit in enumerate((self.u0.subfunctions)):
-                sbit = (self.stages.subfunctions)[self.num_fields * k + i]
+            for i, u0bit in enumerate(self.u0.subfunctions):
+                sbit = self.stages.subfunctions[self.num_fields * k + i]
                 sbit.assign(u0bit)
 
     def tabulate_poly(self, sample_points):

--- a/irksome/stage_value.py
+++ b/irksome/stage_value.py
@@ -78,7 +78,7 @@ def getFormStage(F, butch, t, dt, u0, stages, bcs=None, splitting=AI, vandermond
     v, u = extract_timedep_arguments(F, u0)
     backend_cls = get_backend(backend)
     V = backend_cls.get_function_space(v)
-    assert V == u0.function_space()
+    assert V == backend_cls.get_function_space(u0)
 
     c = vecconst(butch.c, backend=backend)
     bA1, bA2 = splitting(butch.A)
@@ -91,7 +91,7 @@ def getFormStage(F, butch, t, dt, u0, stages, bcs=None, splitting=AI, vandermond
 
     # s-way product space for the stage variables
     num_stages = butch.num_stages
-    Vbig = backend_cls.get_function_space(stages)
+    Vbig = stages.function_space()
     test = backend_cls.TestFunction(Vbig)
 
     # set up the pieces we need to work with to do our substitutions
@@ -231,7 +231,7 @@ class StageValueTimeStepper(StageCoupledTimeStepper):
         dt = self.dt
         u0 = self.u0
         v, u = extract_timedep_arguments(F, u0)
-        unew = backend_cls.Function(u.function_space())
+        unew = backend_cls.Function(backend_cls.get_function_space(u))
         Fupdate = inner(unew - self.u0, v) * dx
 
         split_form = split_time_derivative_terms(F, t=t, timedep_coeffs=(u,))

--- a/irksome/tools.py
+++ b/irksome/tools.py
@@ -1,5 +1,6 @@
 from .backend import get_backend
 import numpy
+import ufl
 from ufl.algorithms.analysis import extract_type
 from ufl.classes import Variable
 from ufl import as_tensor, replace as ufl_replace
@@ -79,48 +80,6 @@ def fields_to_components(V, fields):
     return components
 
 
-def getNullspace(V, Vbig, num_stages, nullspace):
-    """
-    Computes the nullspace for a multi-stage method.
-
-    :arg V: The :class:`FunctionSpace` on which the original time-dependent PDE is posed.
-    :arg Vbig: The multi-stage :class:`FunctionSpace` for the stage problem
-    :arg num_stages: The number of stages in the RK method
-    :arg nullspace: The nullspace for the original problem.
-
-    On output, we produce a :class:`MixedVectorSpaceBasis` defining the nullspace
-    for the multistage problem.
-    """
-    from firedrake import VectorSpaceBasis, MixedVectorSpaceBasis
-
-    num_fields = len(V)
-    if nullspace is None:
-        nspnew = None
-    else:
-        if isinstance(nullspace, (MixedVectorSpaceBasis, VectorSpaceBasis)):
-            nullspace = [(field, basis) for field, basis in enumerate(nullspace)
-                         if isinstance(basis, VectorSpaceBasis)]
-        try:
-            nullspace.sort()
-        except AttributeError:
-            raise AttributeError("Nullspace entries must be of form (idx, VSP), where idx is a non-negative integer")
-        if (nullspace[-1][0] > num_fields) or (nullspace[0][0] < 0):
-            raise ValueError("At least one index for nullspaces is out of range")
-        nspnew = []
-        nsp_comp = len(nullspace)
-        for i in range(num_stages):
-            count = 0
-            for j in range(num_fields):
-                if count < nsp_comp and j == nullspace[count][0]:
-                    nspnew.append(nullspace[count][1])
-                    count += 1
-                else:
-                    nspnew.append(Vbig.sub(j + num_fields * i))
-        nspnew = MixedVectorSpaceBasis(Vbig, nspnew)
-
-    return nspnew
-
-
 def replace(e, mapping):
     """A wrapper for ufl.replace that allows numpy arrays and skips
     substitution into sub-expressions wrapped by :func:`~irksome.lag`."""
@@ -169,3 +128,18 @@ def get_lagrange_permutation(L):
     perm = numpy.argsort(c)
 
     return c[perm], perm
+
+
+def get_sub(u: ufl.FunctionSpace | ufl.Coefficient, indices: tuple[int, ...]) -> ufl.FunctionSpace | ufl.Coefficient:
+    """Recursively access the subfunction of a mixed function space or the space itself, given the indices of the subspace.
+
+    Args:
+        u: A coefficient in a mixed function space
+        indices: A tuple of integers giving the indices of the subspace to access. For example
+            if u is in a mixed space (V1, V2, V3), then get_sub(u, (0, 2)) will return the third subfunction of u in V1,
+            i.e. `u.sub(0).sub(2)`.
+    """
+    for i in indices:
+        if i is not None:
+            u = u.sub(i)
+    return u

--- a/tests/test_dolfinx.py
+++ b/tests/test_dolfinx.py
@@ -92,6 +92,7 @@ def test_stokes(num_stages):
         "mat_mumps_icntl_25": 0,
         "snes_atol": 1e-8,
         "snes_rtol": 1e-8,
+        "snes_monitor": None,
         "petsc_options_prefix": f"IrkSomeStokesSolver{num_stages}",
     }
     linear_stepper = StageDerivativeTimeStepper(
@@ -118,7 +119,6 @@ def test_stokes(num_stages):
             float(t) + float(dt) > end_time
         ):  # To avoid floating point issues at end of simulation.
             dt.assign(end_time - float(t))
-
         linear_stepper.advance()
         t.assign(float(t) + float(dt))
         z0.x.array[:] = z.x.array[vel_to_mixed]
@@ -126,5 +126,8 @@ def test_stokes(num_stages):
 
         error = norm(z0 - uexact, norm_type="L2", mesh=msh)
         assert error < 2e-10, f"Error {error} exceeds tolerance at timestep {float(t)}"
+    msh.comm.Barrier()  # Ensure all processes have finished before cleaning up
     del linear_stepper
+    msh.comm.Barrier()
     gc.collect()
+    msh.comm.Barrier()

--- a/tests/test_dolfinx.py
+++ b/tests/test_dolfinx.py
@@ -3,6 +3,9 @@ import gc
 
 from mpi4py import MPI
 from petsc4py import PETSc
+
+dolfinx = pytest.importorskip("dolfinx")
+
 import basix.ufl
 
 from ufl import div, grad, inner, dx, as_vector, split, SpatialCoordinate, TestFunctions
@@ -11,8 +14,6 @@ from irksome import GaussLegendre, Dt, MeshConstant
 from irksome.backends.dolfinx import dirichletbc, norm
 from irksome.stage_derivative import StageDerivativeTimeStepper
 from irksome.tools import AI
-
-dolfinx = pytest.importorskip("dolfinx")
 
 
 @pytest.mark.parametrize("num_stages", [1, 2, 3, 4])
@@ -124,6 +125,6 @@ def test_stokes(num_stages):
         z0.x.scatter_forward()
 
         error = norm(z0 - uexact, norm_type="L2", mesh=msh)
-        assert error < 1e-10, f"Error {error} exceeds tolerance at timestep {float(t)}"
+        assert error < 2e-10, f"Error {error} exceeds tolerance at timestep {float(t)}"
     del linear_stepper
     gc.collect()

--- a/tests/test_dolfinx.py
+++ b/tests/test_dolfinx.py
@@ -1,0 +1,135 @@
+import pytest
+
+
+from mpi4py import MPI
+from petsc4py import PETSc
+import basix.ufl
+
+from ufl import div, grad, inner, dx, as_vector, split, SpatialCoordinate, TestFunctions
+
+from irksome import GaussLegendre, Dt, MeshConstant
+from irksome.backends.dolfinx import dirichletbc, norm
+from irksome.stage_derivative import StageDerivativeTimeStepper
+from irksome.tools import AI
+
+dolfinx = pytest.importorskip("dolfinx")
+
+
+@pytest.mark.parametrize("num_stages", [1, 2, 3])
+def test_stokes(num_stages):
+    butcher_tableau = GaussLegendre(num_stages=num_stages)
+
+    N = 13
+    msh = dolfinx.mesh.create_unit_square(MPI.COMM_WORLD, N, N)
+    msh.topology.create_connectivity(msh.topology.dim - 1, msh.topology.dim)
+    boundary_facets = dolfinx.mesh.exterior_facet_indices(msh.topology)
+
+    el_u = basix.ufl.element("Lagrange", msh.basix_cell(), 3, shape=(msh.geometry.dim,))
+    el_p = basix.ufl.element("Lagrange", msh.basix_cell(), 2)
+    el_me = basix.ufl.mixed_element([el_u, el_p])
+    W = dolfinx.fem.functionspace(msh, el_me)
+
+    MC = MeshConstant(msh, backend="dolfinx")
+    t = MC.Constant(0.0)
+    dt = MC.Constant(1.0 / N)
+    (x, y) = SpatialCoordinate(msh)
+
+    Q, Q_to_W = W.sub(1).collapse()
+    nsp = dolfinx.fem.Function(W)
+    nsp.x.array[Q_to_W] = 1
+    nullspace = [nsp.x]
+    dolfinx.la.orthonormalize(nullspace)
+    nsp = PETSc.NullSpace().create(
+        vectors=[n.petsc_vec for n in nullspace], comm=msh.comm
+    )
+
+    uexact = as_vector([x * t + y**2, -y * t + t * (x**2)])
+    pexact = x + y * t ** (2 * num_stages)
+
+    u_rhs = Dt(uexact) - div(grad(uexact)) + grad(pexact)
+    p_rhs = -div(uexact)
+
+    z = dolfinx.fem.Function(W)
+    u, p = split(z)
+    (v, q) = TestFunctions(W)
+    F = (
+        inner(Dt(u), v) * dx
+        + inner(grad(u), grad(v)) * dx
+        - inner(p, div(v)) * dx
+        - inner(div(u), q) * dx
+        - inner(u_rhs, v) * dx
+        - inner(p_rhs, q) * dx
+    )
+
+    boundary_dofs = dolfinx.fem.locate_dofs_topological(
+        W.sub(0), msh.topology.dim - 1, boundary_facets
+    )
+
+    # Dirichlet BCs (irksome style with UFL expression)
+    bc = dirichletbc(uexact, boundary_dofs, W.sub(0))
+    bcs = [bc]
+
+    # Initial conditions
+    bc_expr = dolfinx.fem.Expression(uexact, W.sub(0).element.interpolation_points)
+    z.sub(0).interpolate(bc_expr)
+    p_avg = msh.comm.allreduce(
+        dolfinx.fem.assemble_scalar(dolfinx.fem.form(pexact * dx)), op=MPI.SUM
+    )
+    z.sub(1).interpolate(
+        dolfinx.fem.Expression(pexact - p_avg, W.sub(1).element.interpolation_points)
+    )
+
+    solver_parameters = {
+        "ksp_type": "preonly",
+        "pc_type": "lu",
+        # "snes_monitor": None,
+        "snes_error_if_not_converged": True,
+        # "ksp_monitor": None,
+        "snes_max_iter": 50,
+        "pc_factor_mat_solver_type": "mumps",
+        "ksp_error_if_not_converged": True,
+        "snes_linesearch_type": "none",
+        "mat_mumps_icntl_24": 1,
+        "mat_mumps_icntl_25": 0,
+        "snes_atol": 1e-8,
+        "snes_rtol": 1e-8,
+        "petsc_options_prefix": f"IrkSomeStokesSolver{num_stages}",
+    }
+    print(
+        f"Rank {MPI.COMM_WORLD.rank}: {solver_parameters['petsc_options_prefix']} {num_stages=}",
+        flush=True,
+    )
+    linear_stepper = StageDerivativeTimeStepper(
+        F,
+        butcher_tableau,
+        t,
+        dt,
+        z,
+        bcs=bcs,
+        Fp=None,
+        bc_type="DAE",
+        splitting=AI,
+        solver_parameters=solver_parameters,
+        # nullspace=nsp,
+        backend="dolfinx",
+    )
+
+    z0 = z.sub(0).collapse()
+
+    V, vel_to_mixed = W.sub(0).collapse()
+
+    end_time = 1.0
+    while float(t) < end_time - 1e-10:
+        if (
+            float(t) + float(dt) > end_time
+        ):  # To avoid floating point issues at end of simulation.
+            dt.assign(end_time - float(t))
+
+        linear_stepper.advance()
+
+        t.assign(float(t) + float(dt))
+        z0.x.array[:] = z.x.array[vel_to_mixed]
+        z0.x.scatter_forward()
+
+        error = norm(z0 - uexact, norm_type="L2", mesh=msh)
+        assert error < 1e-10, f"Error {error} exceeds tolerance at timestep {float(t)}"

--- a/tests/test_dolfinx.py
+++ b/tests/test_dolfinx.py
@@ -1,5 +1,5 @@
 import pytest
-
+import gc
 
 from mpi4py import MPI
 from petsc4py import PETSc
@@ -15,7 +15,7 @@ from irksome.tools import AI
 dolfinx = pytest.importorskip("dolfinx")
 
 
-@pytest.mark.parametrize("num_stages", [1, 2, 3])
+@pytest.mark.parametrize("num_stages", [1, 2, 3, 4])
 def test_stokes(num_stages):
     butcher_tableau = GaussLegendre(num_stages=num_stages)
 
@@ -34,7 +34,7 @@ def test_stokes(num_stages):
     dt = MC.Constant(1.0 / N)
     (x, y) = SpatialCoordinate(msh)
 
-    Q, Q_to_W = W.sub(1).collapse()
+    _, Q_to_W = W.sub(1).collapse()
     nsp = dolfinx.fem.Function(W)
     nsp.x.array[Q_to_W] = 1
     nullspace = [nsp.x]
@@ -82,9 +82,7 @@ def test_stokes(num_stages):
     solver_parameters = {
         "ksp_type": "preonly",
         "pc_type": "lu",
-        # "snes_monitor": None,
         "snes_error_if_not_converged": True,
-        # "ksp_monitor": None,
         "snes_max_iter": 50,
         "pc_factor_mat_solver_type": "mumps",
         "ksp_error_if_not_converged": True,
@@ -95,10 +93,6 @@ def test_stokes(num_stages):
         "snes_rtol": 1e-8,
         "petsc_options_prefix": f"IrkSomeStokesSolver{num_stages}",
     }
-    print(
-        f"Rank {MPI.COMM_WORLD.rank}: {solver_parameters['petsc_options_prefix']} {num_stages=}",
-        flush=True,
-    )
     linear_stepper = StageDerivativeTimeStepper(
         F,
         butcher_tableau,
@@ -110,13 +104,12 @@ def test_stokes(num_stages):
         bc_type="DAE",
         splitting=AI,
         solver_parameters=solver_parameters,
-        # nullspace=nsp,
+        nullspace=nsp,  # Nullspace doesn't do anything for this solver setup, but we include it to check the code path
         backend="dolfinx",
     )
-
     z0 = z.sub(0).collapse()
 
-    V, vel_to_mixed = W.sub(0).collapse()
+    _, vel_to_mixed = W.sub(0).collapse()
 
     end_time = 1.0
     while float(t) < end_time - 1e-10:
@@ -126,10 +119,11 @@ def test_stokes(num_stages):
             dt.assign(end_time - float(t))
 
         linear_stepper.advance()
-
         t.assign(float(t) + float(dt))
         z0.x.array[:] = z.x.array[vel_to_mixed]
         z0.x.scatter_forward()
 
         error = norm(z0 - uexact, norm_type="L2", mesh=msh)
         assert error < 1e-10, f"Error {error} exceeds tolerance at timestep {float(t)}"
+    del linear_stepper
+    gc.collect()

--- a/tests/test_dolfinx.py
+++ b/tests/test_dolfinx.py
@@ -2,11 +2,11 @@ import pytest
 import gc
 
 from mpi4py import MPI
-from petsc4py import PETSc
 
 dolfinx = pytest.importorskip("dolfinx")
 
 import basix.ufl
+import numpy as np
 
 from ufl import div, grad, inner, dx, as_vector, split, SpatialCoordinate, TestFunctions
 
@@ -32,17 +32,10 @@ def test_stokes(num_stages):
 
     MC = MeshConstant(msh, backend="dolfinx")
     t = MC.Constant(0.0)
+    t.name = "t"
     dt = MC.Constant(1.0 / N)
+    dt.name = "dt"
     (x, y) = SpatialCoordinate(msh)
-
-    _, Q_to_W = W.sub(1).collapse()
-    nsp = dolfinx.fem.Function(W)
-    nsp.x.array[Q_to_W] = 1
-    nullspace = [nsp.x]
-    dolfinx.la.orthonormalize(nullspace)
-    nsp = PETSc.NullSpace().create(
-        vectors=[n.petsc_vec for n in nullspace], comm=msh.comm
-    )
 
     uexact = as_vector([x * t + y**2, -y * t + t * (x**2)])
     pexact = x + y * t ** (2 * num_stages)
@@ -66,18 +59,20 @@ def test_stokes(num_stages):
         W.sub(0), msh.topology.dim - 1, boundary_facets
     )
 
+    msh.topology.create_connectivity(0, msh.topology.dim)
+    corner_vertex = dolfinx.mesh.locate_entities(msh, 0, lambda x: np.isclose(x[0], 0) & np.isclose(x[1], 0))
+    corner_dof = dolfinx.fem.locate_dofs_topological(W.sub(1), 0, corner_vertex)
+
     # Dirichlet BCs (irksome style with UFL expression)
     bc = dirichletbc(uexact, boundary_dofs, W.sub(0))
-    bcs = [bc]
+    bc_p = dirichletbc(pexact, corner_dof, W.sub(1))
+    bcs = [bc, bc_p]
 
     # Initial conditions
     bc_expr = dolfinx.fem.Expression(uexact, W.sub(0).element.interpolation_points)
     z.sub(0).interpolate(bc_expr)
-    p_avg = msh.comm.allreduce(
-        dolfinx.fem.assemble_scalar(dolfinx.fem.form(pexact * dx)), op=MPI.SUM
-    )
     z.sub(1).interpolate(
-        dolfinx.fem.Expression(pexact - p_avg, W.sub(1).element.interpolation_points)
+        dolfinx.fem.Expression(pexact, W.sub(1).element.interpolation_points)
     )
 
     solver_parameters = {
@@ -106,7 +101,6 @@ def test_stokes(num_stages):
         bc_type="DAE",
         splitting=AI,
         solver_parameters=solver_parameters,
-        nullspace=nsp,  # Nullspace doesn't do anything for this solver setup, but we include it to check the code path
         backend="dolfinx",
     )
     z0 = z.sub(0).collapse()


### PR DESCRIPTION
Current example:
```python
from mpi4py import MPI
import dolfinx
import ufl
from irksome import GaussLegendre, Dt, MeshConstant
from irksome.tools import get_stage_space
from irksome.backends.dolfinx import dirichletbc
from ufl import pi, atan, div, grad, inner, dx

butcher_tableau = GaussLegendre(3)
N = 25

x0 = 0.0
x1 = 1.0
y0 = 0.0
y1 = 1.0
msh = dolfinx.mesh.create_rectangle(MPI.COMM_WORLD, [[x0, y0], [x1, y1]], [N, N])
msh.topology.create_connectivity(msh.topology.dim-1, msh.topology.dim)
boundary_facets = dolfinx.mesh.exterior_facet_indices(msh.topology)

import basix
el_u = basix.ufl.element("Lagrange", msh.basix_cell(), 3, shape=(2, ))
el_p = basix.ufl.element("Lagrange", msh.basix_cell(), 2)
el_me = basix.ufl.mixed_element([el_u, el_p])
V = dolfinx.fem.functionspace(msh, el_me)

MC = MeshConstant(msh, backend="dolfinx")
t = MC.Constant(0.0)
dt = MC.Constant(1.0/N)
(x, y) = ufl.SpatialCoordinate(msh)

uexact = ufl.as_vector([x*t + y**2, -y*t+t*(x**2)])
pexact = x + y * t

u_rhs = Dt(uexact) - div(grad(uexact)) + grad(pexact)
p_rhs = -div(uexact)

z = dolfinx.fem.Function(V)
u, p = ufl.split(z)
(v, q) = ufl.TestFunctions(V)
F = (inner(Dt(u), v)*dx
         + inner(grad(u), grad(v))*dx
         - inner(p, div(v))*dx
         - inner(div(u), q)*dx
         - inner(u_rhs, v)*dx
         - inner(p_rhs, q)*dx)

V0, vel_to_mixed = V.sub(0).collapse()
u_bndry = dolfinx.fem.Function(V0)
boundary_dofs = dolfinx.fem.locate_dofs_topological(V.sub(0), msh.topology.dim-1, boundary_facets)

# Dirichlet BCs (irksome style with UFL expression)
bc = dirichletbc(uexact, boundary_dofs, V.sub(0))
bcs = [bc]

# Initial conditions
bc_expr = dolfinx.fem.Expression(uexact, V0.element.interpolation_points)
z.sub(0).interpolate(bc_expr)
p_avg = msh.comm.allreduce(dolfinx.fem.assemble_scalar(dolfinx.fem.form(pexact*dx)), op=MPI.SUM)
z.sub(1).interpolate(dolfinx.fem.Expression(pexact - p_avg, V.sub(1).element.interpolation_points))

# Get the function space for the stage-coupled problem and a function to hold the stages we're computing::

Vbig = get_stage_space(V, butcher_tableau.num_stages, backend="dolfinx")


from irksome.stage_derivative import StageDerivativeTimeStepper
from irksome.tools import AI
solver_parameters={"ksp_type": "preonly", "pc_type": "lu", "snes_monitor": None, "snes_error_if_not_converged": True,
                   "ksp_monitor": None, "pc_factor_mat_solver_type": "mumps", "ksp_error_if_not_converged": True,
                   "snes_linesearch_type": "none", "snes_atol": 1e-6, "snes_rtol": 1e-6,}
linear_stepper = StageDerivativeTimeStepper(F, butcher_tableau, t, dt, z, bcs=bcs, Fp=None, bc_type="DAE", splitting=AI,
                        solver_parameters=solver_parameters, backend="dolfinx")



z0 = z.sub(0).collapse()
from irksome.backends.dolfinx import norm

vtx_writer = dolfinx.io.VTXWriter(msh.comm, "u.bp", [z0])
while (float(t) < 1.0):
    if (float(t) + float(dt) > 1.0):
        dt.assign(1.0 - float(t))

    linear_stepper.advance()
   
    t.assign(float(t) + float(dt))
    z0.x.array[:] = z.x.array[vel_to_mixed]
    print(float(t), norm(z0 - uexact, norm_type="L2", mesh=msh))

    vtx_writer.write(float(t))

vtx_writer.close()

```
yielding
```bash
  0 SNES Function norm 2.628910798689e+01
    Residual norms for IrkSomeNonlinearSolver solve.
    0 KSP Residual norm 2.628910798689e+01
    1 KSP Residual norm 8.363923372515e-11
  1 SNES Function norm 3.207662837548e-10
0.04 5.6988105101383e-13
  0 SNES Function norm 1.146402455530e-09
0.08 1.139756886231989e-12
  0 SNES Function norm 2.139827450962e-09
0.12 1.709633325903377e-12
  0 SNES Function norm 3.147274382645e-09
0.16 2.279509704869097e-12
  0 SNES Function norm 4.156139454916e-09
0.2 2.8493868564501198e-12
  0 SNES Function norm 5.166390614290e-09
0.24000000000000002 3.4192637476834183e-12
  0 SNES Function norm 6.177585589014e-09
0.28 3.989139664175302e-12
  0 SNES Function norm 7.187370843984e-09
0.32 4.5590150578856276e-12
  0 SNES Function norm 8.200157550565e-09
0.36 5.128892543807577e-12
  0 SNES Function norm 9.213584563652e-09
0.39999999999999997 5.6987686007035005e-12
  0 SNES Function norm 1.022984523014e-08
0.43999999999999995 6.2686443013185104e-12
  0 SNES Function norm 1.124585047155e-08
0.4799999999999999 6.838520398463383e-12
  0 SNES Function norm 1.226083027922e-08
0.5199999999999999 7.408397569733516e-12
  0 SNES Function norm 1.327911253601e-08
0.5599999999999999 7.978274417410176e-12
  0 SNES Function norm 1.428597988681e-08
0.6 8.548152913355833e-12
  0 SNES Function norm 1.530143609914e-08
0.64 9.118030854926313e-12
  0 SNES Function norm 1.631849684223e-08
0.68 9.68790820180424e-12
  0 SNES Function norm 1.734039035222e-08
0.7200000000000001 1.0257786706595296e-11
  0 SNES Function norm 1.834692931804e-08
0.7600000000000001 1.0827665299417611e-11
  0 SNES Function norm 1.936313759971e-08
0.8000000000000002 1.1397543502629376e-11
  0 SNES Function norm 2.037335836291e-08
0.8400000000000002 1.1967422222746218e-11
  0 SNES Function norm 2.138769548656e-08
0.8800000000000002 1.2537299634104374e-11
  0 SNES Function norm 2.240155145837e-08
0.9200000000000003 1.310717844458346e-11
  0 SNES Function norm 2.341800344063e-08
0.9600000000000003 1.3677054877347251e-11
  0 SNES Function norm 2.442371423194e-08
1.0 1.424693228356048e-11
```