### PR TITLE
sanitise __repr__ for tableaux

### DIFF
--- a/irksome/tableaux/ButcherTableaux.py
+++ b/irksome/tableaux/ButcherTableaux.py
@@ -218,7 +218,6 @@ class LobattoIIIC(ButcherTableau):
                                for k in range(num_stages-1)])
             A[i, 1:] = numpy.linalg.solve(mat, rhs)
 
-        self.num_stages = num_stages
         super(LobattoIIIC, self).__init__(A, b, btilde, c, 2 * num_stages - 2, embedded_order, gamma0)
 
     def __repr__(self):

--- a/irksome/tableaux/ButcherTableaux.py
+++ b/irksome/tableaux/ButcherTableaux.py
@@ -65,8 +65,8 @@ class ButcherTableau(object):
     def is_fully_implicit(self):
         return self.is_implicit and not self.is_diagonally_implicit
 
-    def __str__(self):
-        return str(self.__class__).split(".")[-1][:-2]+"()"
+    def __repr__(self):
+        return type(self).__name__ + "()"
 
 
 class CollocationButcherTableau(ButcherTableau):
@@ -115,7 +115,11 @@ class CollocationButcherTableau(ButcherTableau):
         gamma0 = 0
         embedded_order = num_stages-1
 
+        self._l_repr = repr(L)
         super(CollocationButcherTableau, self).__init__(A, b, btilde, c, order, embedded_order, gamma0)
+
+    def __repr__(self):
+        return f"{type(self).__name__}({self._l_repr}, {self.order})"
 
 
 class GaussLegendre(CollocationButcherTableau):
@@ -131,8 +135,8 @@ class GaussLegendre(CollocationButcherTableau):
         L = FIAT.GaussLegendre(U, num_stages - 1)
         super(GaussLegendre, self).__init__(L, 2 * num_stages)
 
-    def __str__(self):
-        return "GaussLegendre(%d)" % self.num_stages
+    def __repr__(self):
+        return f"{type(self).__name__}({self.num_stages})"
 
 
 class LobattoIIIA(CollocationButcherTableau):
@@ -148,8 +152,8 @@ class LobattoIIIA(CollocationButcherTableau):
         L = FIAT.GaussLobattoLegendre(U, num_stages - 1)
         super(LobattoIIIA, self).__init__(L, 2 * num_stages - 2)
 
-    def __str__(self):
-        return "LobattoIIIA(%d)" % self.num_stages
+    def __repr__(self):
+        return f"{type(self).__name__}({self.num_stages})"
 
 
 class RadauIIA(CollocationButcherTableau):
@@ -172,8 +176,8 @@ class RadauIIA(CollocationButcherTableau):
             self.btilde = numpy.array([4763/13500-numpy.sqrt(503/3071), 4763/13500+numpy.sqrt(503/3071), 263/13500], dtype='float')
             self.gamma0 = 1237.0/4500
 
-    def __str__(self):
-        return "RadauIIA(%d)" % self.num_stages
+    def __repr__(self):
+        return f"{type(self).__name__}({self.num_stages})"
 
 
 class BackwardEuler(RadauIIA):
@@ -181,8 +185,8 @@ class BackwardEuler(RadauIIA):
     def __init__(self):
         super(BackwardEuler, self).__init__(1)
 
-    def __str__(self):
-        return ButcherTableau.__str__(self)
+    def __repr__(self):
+        return ButcherTableau.__repr__(self)
 
 
 class LobattoIIIC(ButcherTableau):
@@ -214,10 +218,11 @@ class LobattoIIIC(ButcherTableau):
                                for k in range(num_stages-1)])
             A[i, 1:] = numpy.linalg.solve(mat, rhs)
 
+        self.num_stages = num_stages
         super(LobattoIIIC, self).__init__(A, b, btilde, c, 2 * num_stages - 2, embedded_order, gamma0)
 
-    def __str__(self):
-        return "LobattoIIIC(%d)" % self.num_stages
+    def __repr__(self):
+        return f"{type(self).__name__}({self.num_stages})"
 
 
 class PareschiRusso(ButcherTableau):
@@ -230,8 +235,8 @@ class PareschiRusso(ButcherTableau):
         c = numpy.array([x, 1-x])
         super(PareschiRusso, self).__init__(A, b, None, c, 2, None, None)
 
-    def __str__(self):
-        return "PareschiRusso(%f)" % self.x
+    def __repr__(self):
+        return f"{type(self).__name__}({self.x})"
 
 
 class QinZhang(PareschiRusso):
@@ -239,8 +244,8 @@ class QinZhang(PareschiRusso):
     def __init__(self):
         super(QinZhang, self).__init__(0.25)
 
-    def __str__(self):
-        return "QinZhang()"
+    def __repr__(self):
+        return ButcherTableau.__repr__(self)
 
 
 class Alexander(ButcherTableau):
@@ -257,5 +262,5 @@ class Alexander(ButcherTableau):
         c = numpy.array([x, (1+x)/2.0, 1])
         super(Alexander, self).__init__(A, b, None, c, 3, None, None)
 
-    def __str__(self):
-        return "Alexander()"
+    def __repr__(self):
+        return ButcherTableau.__repr__(self)

--- a/irksome/tableaux/ars_dirk_imex_tableaux.py
+++ b/irksome/tableaux/ars_dirk_imex_tableaux.py
@@ -107,5 +107,11 @@ class ARS_DIRK_IMEX(DIRK_IMEX):
         A = self._pad_matrix(A, "lr")
         b = np.append(np.zeros(1), b)
         c = np.append(np.zeros(1), c)
+        self.ns_imp = ns_imp
+        self.ns_exp = ns_exp
 
         super(ARS_DIRK_IMEX, self).__init__(A, b, c, A_hat, b_hat, c_hat, order)
+
+    def __repr__(self):
+        return f"{type(self).__name__}"\
+            f"{self.ns_imp, self.ns_exp, self.order}"

--- a/irksome/tableaux/multistep_tableaux.py
+++ b/irksome/tableaux/multistep_tableaux.py
@@ -10,10 +10,11 @@ class MultistepTableau(object):
     :arg a: a 1d array containing the coefficients of the previous steps
     :arg b: a 1d array containing the weights of the right hand side of the method
     """
-    def __init__(self, a, b):
+    def __init__(self, a, b, order=None):
 
         self.a = a
         self.b = b
+        self.order = order
 
     @property
     def num_total_steps(self):
@@ -33,23 +34,28 @@ class MultistepTableau(object):
     def is_implicit(self):
         return not self.is_explicit
 
+    def __repr__(self):
+        return type(self).__name__ + \
+            f"({'' if self.order is None else self.order})"
+
+
 
 class BDF(MultistepTableau):
     def __init__(self, order):
         a, b = get_weights_BDF(order)
-        super().__init__(a, b)
+        super().__init__(a, b, order)
 
 
 class AdamsMoulton(MultistepTableau):
     def __init__(self, order):
         a, b = get_weights_AM(order)
-        super().__init__(a, b)
+        super().__init__(a, b, order)
 
 
 class AdamsBashforth(MultistepTableau):
     def __init__(self, order):
         a, b = get_weights_AB(order)
-        super().__init__(a, b)
+        super().__init__(a, b, order)
 
 
 def get_weights_BDF(order):

--- a/irksome/tableaux/multistep_tableaux.py
+++ b/irksome/tableaux/multistep_tableaux.py
@@ -39,7 +39,6 @@ class MultistepTableau(object):
             f"({'' if self.order is None else self.order})"
 
 
-
 class BDF(MultistepTableau):
     def __init__(self, order):
         a, b = get_weights_BDF(order)

--- a/irksome/tableaux/pep_explicit_rk.py
+++ b/irksome/tableaux/pep_explicit_rk.py
@@ -66,5 +66,9 @@ class PEPRK(ButcherTableau):
             A, b, c = pepdict[ns, order, peporder]
         except KeyError:
             raise NotImplementedError("No PEP method for that combination of stages, order and pseudo-energy preserving order")
+        self.ns = ns
         self.peporder = peporder
         super(PEPRK, self).__init__(A, b, None, c, order, None, None)
+
+    def __repr__(self):
+        return f"{type(self).__name__}{self.ns, self.order, self.peporder}"

--- a/irksome/tableaux/sspk_tableau.py
+++ b/irksome/tableaux/sspk_tableau.py
@@ -65,8 +65,12 @@ class SSPButcherTableau(ButcherTableau):
         # Zero pad to match expectations of ExplicitTimeStepper
         A_ = np.zeros((A.shape[0]+1, A.shape[1]+1), dtype=A.dtype)
         A_[1:, :-1] = A
+        self.ns = ns
 
         super(SSPButcherTableau, self).__init__(A_, b, None, c, order, None, None)
+
+    def __repr__(self):
+        return f"{type(self).__name__}{self.order, self.ns}"
 
 
 class SSPK_DIRK_IMEX(DIRK_IMEX):
@@ -82,4 +86,12 @@ class SSPK_DIRK_IMEX(DIRK_IMEX):
         except KeyError:
             raise NotImplementedError("No SSPk DIRK-IMEX method for that combination of SSP order, implicit and explicit stages, and IMEX order")
 
+        self.ssp_order = ssp_order
+        self.ns_imp = ns_imp
+        self.ns_exp = ns_exp
+
         super(SSPK_DIRK_IMEX, self).__init__(A, b, c, A_hat, b_hat, c_hat, order)
+
+    def __repr__(self):
+        return f"{type(self).__name__}"\
+            f"{self.ssp_order, self.ns_imp, self.ns_exp, self.order}"

--- a/irksome/tableaux/wso_dirk_tableaux.py
+++ b/irksome/tableaux/wso_dirk_tableaux.py
@@ -179,5 +179,9 @@ class WSODIRK(ButcherTableau):
             A, b, c = wsodict[ns, order, ws_order]
         except KeyError:
             raise NotImplementedError("No WSO DIRK method for that combination of stages, order and weak stage order")
+        self.ns = ns
         self.ws_order = ws_order
         super(WSODIRK, self).__init__(A, b, None, c, order, None, None)
+
+    def __repr__(self):
+        return f"{type(self).__name__}{self.ns, self.order, self.ws_order}"


### PR DESCRIPTION
ButcherTableaux defined `__str__` not `__repr__` which is backwards because the latter falls back to the former but not vice versa.

This PR fixes that and also gives all the public tableau types `__repr__` in a sane way.