### PR TITLE
Raise error for invalid `stage_type`

### DIFF
--- a/irksome/stepper.py
+++ b/irksome/stepper.py
@@ -234,3 +234,8 @@ def TimeStepper(F, method, t, dt, u0, **kwargs):
         return DIRKIMEXMethod(
             Fimp, Fexp, method, t, dt, u0, bcs,
             solver_parameters, mass_parameters, appctx, nullspace, **base_kwargs)
+    else:
+        raise ValueError(
+            f"Unknown stage_type: {stage_type}. "
+            f"Valid stage types are: {list(valid_kwargs_per_stage_type.keys())}."
+        )


### PR DESCRIPTION
Otherwise if you are silly and pass something like `stage_type="stage_deriv"` to the `TimeStepper` function then it just silently returns `None` instead of an actual object.