### PR TITLE
Nonlinear preconditioning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     runs-on: [self-hosted, Linux]
     container:
-      image: firedrakeproject/firedrake-vanilla-default:latest
+      image: firedrakeproject/firedrake-vanilla-default:dev-release
     steps:
       - name: Fix HOME
         # For unknown reasons GitHub actions overwrite HOME to /github/home

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,12 @@ concurrency:
 
 jobs:
   test:
+    strategy:
+      matrix:
+        version: [2026.4.0, dev-release]
     runs-on: [self-hosted, Linux]
     container:
-      image: firedrakeproject/firedrake-vanilla-default:dev-release
+      image: firedrakeproject/firedrake-vanilla-default:${{ matrix.version }}
     steps:
       - name: Fix HOME
         # For unknown reasons GitHub actions overwrite HOME to /github/home

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   test:
     strategy:
       matrix:
-        version: [2026.4.0, dev-release]
+        version: [latest, dev-release]
     runs-on: [self-hosted, Linux]
     container:
       image: firedrakeproject/firedrake-vanilla-default:${{ matrix.version }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
     name: Build docs
     runs-on: [self-hosted, Linux]
     container:
-      image: firedrakeproject/firedrake-vanilla-default:latest
+      image: firedrakeproject/firedrake-vanilla-default:dev-release
     steps:
       - name: Fix HOME
         # For unknown reasons GitHub actions overwrite HOME to /github/home

--- a/irksome/__init__.py
+++ b/irksome/__init__.py
@@ -101,6 +101,7 @@ try:
         RanaDU,
         RanaLD,
         IRKAuxiliaryOperatorPC,
+        IRKAuxiliaryOperatorSNES,
     )
     from .stepper import TimeStepper
 
@@ -115,6 +116,7 @@ try:
         "RanaDU",
         "RanaLD",
         "IRKAuxiliaryOperatorPC",
+        "IRKAuxiliaryOperatorSNES",
         "TimeStepper",
     ]
 

--- a/irksome/pc.py
+++ b/irksome/pc.py
@@ -82,13 +82,13 @@ class IRKAuxiliaryOperatorPC(AuxiliaryOperatorPC):
 
 
 class IRKAuxiliaryOperatorSNES(AuxiliaryOperatorSNES):
-    """Base class that inherits from Firedrake's :class:`AuxiliaryOperatorSNES`
+    """Base class that inherits from Firedrake's auxiliary operator SNES
     and provides the nonlinear form associated with an auxiliary Form and/or
     approximate Butcher matrix (which are provided by subclasses). This is the
     nonlinear analogue of :class:`IRKAuxiliaryOperatorPC`.
 
     Options for the inner solve are specified using the ``"aux_"`` prefix, as
-    for :class:`AuxiliaryOperatorSNES`.
+    for the base auxiliary operator SNES.
     """
 
     def getNewForm(self, snes, u0, test):

--- a/irksome/pc.py
+++ b/irksome/pc.py
@@ -2,7 +2,7 @@ import copy
 
 import numpy
 from .labeling import as_form
-from firedrake import AuxiliaryOperatorPC, derivative
+from firedrake import AuxiliaryOperatorPC, AuxiliaryOperatorSNES, derivative
 from firedrake.dmhooks import get_appctx
 
 
@@ -79,6 +79,65 @@ class IRKAuxiliaryOperatorPC(AuxiliaryOperatorPC):
         Jnew = derivative(Fnew, w, du=trial)
 
         return Jnew, bcnew
+
+
+class IRKAuxiliaryOperatorSNES(AuxiliaryOperatorSNES):
+    """Base class that inherits from Firedrake's :class:`AuxiliaryOperatorSNES`
+    and provides the nonlinear form associated with an auxiliary Form and/or
+    approximate Butcher matrix (which are provided by subclasses). This is the
+    nonlinear analogue of :class:`IRKAuxiliaryOperatorPC`.
+
+    Options for the inner solve are specified using the ``"aux_"`` prefix, as
+    for :class:`AuxiliaryOperatorSNES`.
+    """
+
+    def getNewForm(self, snes, u0, test):
+        """Derived classes can optionally provide an auxiliary semidiscrete
+        Form, expressed in terms of the current state ``u0`` and a ``test``
+        function over the same (single-stage) function space."""
+        raise NotImplementedError
+
+    def getAtilde(self, A):
+        """Derived classes produce a typically structured
+        approximation to A."""
+        raise NotImplementedError
+
+    def form(self, snes, w0, w, test):
+        """Implements the interface for AuxiliaryOperatorSNES.
+
+        :arg snes: the PETSc SNES object.
+        :arg w0: the current iterate of the stages (unused by default, but
+            available to subclasses that wish to lag terms).
+        :arg w: the stages to be solved for at the next iterate; the auxiliary
+            residual is built in terms of this Function.
+        :arg test: the test function over the stage space (unused; the time
+            stepper builds its own test function).
+        """
+        appctx = self.get_appctx(snes)
+        stepper = appctx["stepper"]
+        butcher = stepper.butcher_tableau
+        F = as_form(stepper.F)
+        u0 = stepper.u0
+        bcs = stepper.orig_bcs
+        v0, = F.arguments()
+
+        try:
+            # use new Form if provided
+            F, bcs = self.getNewForm(snes, u0, v0)
+        except NotImplementedError:
+            pass
+
+        try:
+            # use new ButcherTableau if provided
+            Atilde = self.getAtilde(butcher.A)
+            butcher = copy.deepcopy(butcher)
+            butcher.A = Atilde
+        except NotImplementedError:
+            pass
+
+        Fnew, bcnew = stepper.get_form_and_bcs(w, tableau=butcher, F=F, bcs=bcs)
+
+        return Fnew, bcnew
 
 
 class RanaBase(IRKAuxiliaryOperatorPC):

--- a/irksome/pc.py
+++ b/irksome/pc.py
@@ -7,10 +7,16 @@ from firedrake.dmhooks import get_appctx
 
 try:
     from firedrake import AuxiliaryOperatorSNES
-    _has_auxopsnes = True
+    has_auxiliary_operator_snes = True
 except ImportError:
-    AuxiliaryOperatorSNES = object
-    _has_auxopsnes = False
+    has_auxiliary_operator_snes = False
+
+    class AuxiliaryOperatorSNES:
+        def __init__(self, *args, **kwargs):
+            raise NotImplementedError(
+                "IRKAuxiliaryOperatorSNES requires firedrake.AuxiliaryOperatorSNES,"
+                " which this version of Firedrake does not provide; please upgrade."
+            )
 
 
 # Oddly, we can't turn pivoting off in scipy?

--- a/irksome/pc.py
+++ b/irksome/pc.py
@@ -2,8 +2,15 @@ import copy
 
 import numpy
 from .labeling import as_form
-from firedrake import AuxiliaryOperatorPC, AuxiliaryOperatorSNES, derivative
+from firedrake import AuxiliaryOperatorPC, derivative
 from firedrake.dmhooks import get_appctx
+
+try:
+    from firedrake import AuxiliaryOperatorSNES
+    _has_auxopsnes = True
+except ImportError:
+    AuxiliaryOperatorSNES = object
+    _has_auxopsnes = False
 
 
 # Oddly, we can't turn pivoting off in scipy?

--- a/tests/test_npc.py
+++ b/tests/test_npc.py
@@ -1,4 +1,5 @@
 import pytest
+from petsc4py import PETSc
 import firedrake
 from firedrake import (
     Constant, Function, FunctionSpace, SpatialCoordinate,
@@ -99,9 +100,15 @@ def test_npc_stefan():
     method = BackwardEuler()
     stepper = TimeStepper(F, method, t, dt, T, **params)
 
+    reasons = [
+        PETSc.SNES.ConvergedReason.CONVERGED_FNORM_ABS,
+        PETSc.SNES.ConvergedReason.CONVERGED_FNORM_RELATIVE,
+        PETSc.SNES.ConvergedReason.CONVERGED_SNORM_RELATIVE,
+    ]
+
     final_time = 20.0
     num_steps = int(final_time / float(dt))
     for _ in range(num_steps):
         stepper.advance()
         t.assign(t + dt)
-        assert stepper.solver.snes.getConvergedReason() > 0
+        assert stepper.solver.snes.getConvergedReason() in reasons

--- a/tests/test_npc.py
+++ b/tests/test_npc.py
@@ -3,8 +3,8 @@ from petsc4py import PETSc
 import firedrake
 from firedrake import (
     Constant, Function, FunctionSpace, SpatialCoordinate,
-    TestFunction, UnitIntervalMesh, conditional, exp, cos,
-    ds, dx, grad, inner
+    TestFunction, UnitIntervalMesh, exp, cos, ds, dx,
+    grad, inner
 )
 from irksome import BackwardEuler, Dt, IRKAuxiliaryOperatorSNES, TimeStepper, lag
 

--- a/tests/test_npc.py
+++ b/tests/test_npc.py
@@ -3,8 +3,8 @@ from petsc4py import PETSc
 import firedrake
 from firedrake import (
     Constant, Function, FunctionSpace, SpatialCoordinate,
-    TestFunction, UnitIntervalMesh, conditional, cos, ds,
-    dx, grad, inner
+    TestFunction, UnitIntervalMesh, conditional, exp, cos,
+    ds, dx, grad, inner
 )
 from irksome import BackwardEuler, Dt, IRKAuxiliaryOperatorSNES, TimeStepper, lag
 
@@ -23,10 +23,13 @@ k_solid = Constant(2.0)
 k_liquid = Constant(1.0)
 h = Constant(0.01)            # Robin penalty length scale
 dT = Constant(0.25)           # amplitude of the boundary oscillation
+T_scale = Constant(5e-4)      # scale for transition between solid and liquid
 
 
 def stefan_conductivity(T):
-    return conditional(T <= T_m, k_solid, k_liquid)
+    r = exp(-T / T_scale)
+    s = 1 / (1 + r)
+    return k_solid * (1 - s) + s * k_liquid
 
 
 def stefan_form(T, q, t, k):
@@ -69,10 +72,18 @@ def test_npc_stefan_newton_fails():
     isn't differentiable."""
     F, t, dt, T = stefan_setup()
     method = BackwardEuler()
-    params = {"solver_parameters": {"snes_type": "newtonls"}}
+    params = {
+        "solver_parameters": {
+            "snes_type": "newtonls",
+            "snes_linesearch_type": "bt",
+            "snes_monitor": None,
+        },
+    }
     stepper = TimeStepper(F, method, t, dt, T, **params)
     with pytest.raises(firedrake.ConvergenceError):
-        for _ in range(20):
+        final_time = 20.0
+        num_steps = int(final_time / float(dt))
+        for step in range(num_steps):
             stepper.advance()
             t.assign(float(t) + float(dt))
 
@@ -83,14 +94,14 @@ def test_npc_stefan():
     F, t, dt, T = stefan_setup()
     params = {
         "solver_parameters": {
-            "snes_type": "anderson",
-            "snes_rtol": 1e-8,
+            "snes_type": "ngmres",
+            "snes_monitor": None,
             "snes_max_it": 100,
             "npc": {
                 "snes_type": "python",
                 "snes_python_type": "test_npc.StefanLagAuxSNES",
                 "aux": {
-                    "snes_type": "newtonls",
+                    "snes_type": "ksponly",
                     "ksp_type": "cg",
                     "pc_type": "lu",
                 },
@@ -103,12 +114,11 @@ def test_npc_stefan():
     reasons = [
         PETSc.SNES.ConvergedReason.CONVERGED_FNORM_ABS,
         PETSc.SNES.ConvergedReason.CONVERGED_FNORM_RELATIVE,
-        PETSc.SNES.ConvergedReason.CONVERGED_SNORM_RELATIVE,
     ]
 
     final_time = 20.0
     num_steps = int(final_time / float(dt))
-    for _ in range(num_steps):
+    for step in range(num_steps):
         stepper.advance()
         t.assign(t + dt)
         assert stepper.solver.snes.getConvergedReason() in reasons

--- a/tests/test_npc.py
+++ b/tests/test_npc.py
@@ -1,0 +1,107 @@
+import pytest
+import firedrake
+from firedrake import (
+    Constant, Function, FunctionSpace, SpatialCoordinate,
+    TestFunction, UnitIntervalMesh, conditional, cos, ds,
+    dx, grad, inner
+)
+from irksome import BackwardEuler, Dt, IRKAuxiliaryOperatorSNES, TimeStepper, lag
+
+# Stefan problem: a two-phase heat equation with a discontinuous conductivity
+#
+#   k(T) = k_solid  if T <= T_m  else  k_liquid.
+#
+# The fully implicit residual is not differentiable in T, so Newton's method
+# fails. Lagging the conductivity to the start of the timestep gives a residual
+# with a well-defined Jacobian. Here we use the lagged residual as a nonlinear
+# preconditioner so that the outer solver converges to the fully implicit
+# problem.
+
+T_m = Constant(0.0)
+k_solid = Constant(2.0)
+k_liquid = Constant(1.0)
+h = Constant(0.01)            # Robin penalty length scale
+dT = Constant(0.25)           # amplitude of the boundary oscillation
+
+
+def stefan_conductivity(T):
+    return conditional(T <= T_m, k_solid, k_liquid)
+
+
+def stefan_form(T, q, t, k):
+    """Robin residual with the oscillating boundary temperatures."""
+    T_1 = Constant(-1.0)
+    T_2 = Constant(1.0) + dT * cos(t)
+    F_cells = (Dt(T) * q + k * inner(grad(T), grad(q))) * dx
+    F_boundaries = k / h * (T - T_1) * q * ds(1) + k / h * (T - T_2) * q * ds(2)
+    return F_cells + F_boundaries
+
+
+class StefanLagAuxSNES(IRKAuxiliaryOperatorSNES):
+    """Precondition the fully implicit Stefan problem with the residual whose
+    conductivity is lagged to the start of the timestep."""
+    def getNewForm(self, snes, T, q):
+        t = self.get_appctx(snes)["stepper"].t
+        k = lag(stefan_conductivity(T))
+        return stefan_form(T, q, t, k), None
+
+
+def stefan_setup():
+    nx = 64
+    mesh = UnitIntervalMesh(nx)
+    Q = FunctionSpace(mesh, "CG", 1)
+    x, = SpatialCoordinate(mesh)
+
+    T = Function(Q)
+    T.interpolate((1 - x) * Constant(-1.0) + x * Constant(1.0))
+
+    t = Constant(0.0)
+    dt = Constant(0.1)
+    q = TestFunction(Q)
+    k = stefan_conductivity(T)   # NOTE: this is the fully implicit form
+    F = stefan_form(T, q, t, k)
+    return F, t, dt, T
+
+
+def test_npc_stefan_newton_fails():
+    """Newton's method fails on the fully implicit Stefan problem because it
+    isn't differentiable."""
+    F, t, dt, T = stefan_setup()
+    method = BackwardEuler()
+    params = {"solver_parameters": {"snes_type": "newtonls"}}
+    stepper = TimeStepper(F, method, t, dt, T, **params)
+    with pytest.raises(firedrake.ConvergenceError):
+        for _ in range(20):
+            stepper.advance()
+            t.assign(float(t) + float(dt))
+
+
+def test_npc_stefan():
+    """The lagged residual, used as a nonlinear preconditioner, drives the
+    fully implicit Stefan problem to convergence where Newton fails."""
+    F, t, dt, T = stefan_setup()
+    params = {
+        "solver_parameters": {
+            "snes_type": "anderson",
+            "snes_rtol": 1e-8,
+            "snes_max_it": 100,
+            "npc": {
+                "snes_type": "python",
+                "snes_python_type": "test_npc.StefanLagAuxSNES",
+                "aux": {
+                    "snes_type": "newtonls",
+                    "ksp_type": "cg",
+                    "pc_type": "lu",
+                },
+            },
+        },
+    }
+    method = BackwardEuler()
+    stepper = TimeStepper(F, method, t, dt, T, **params)
+
+    final_time = 20.0
+    num_steps = int(final_time / float(dt))
+    for _ in range(num_steps):
+        stepper.advance()
+        t.assign(t + dt)
+        assert stepper.solver.snes.getConvergedReason() > 0

--- a/tests/test_npc.py
+++ b/tests/test_npc.py
@@ -6,7 +6,7 @@ from firedrake import (
     TestFunction, UnitIntervalMesh, exp, cos, ds, dx,
     grad, inner
 )
-from irksome import BackwardEuler, Dt, TimeStepper, lag, pc
+from irksome import BackwardEuler, Dt, IRKAuxiliaryOperatorSNES, TimeStepper, lag
 
 # Stefan problem: a two-phase heat equation with a discontinuous conductivity
 #
@@ -39,6 +39,15 @@ def stefan_form(T, q, t, k):
     F_cells = (Dt(T) * q + k * inner(grad(T), grad(q))) * dx
     F_boundaries = k / h * (T - T_1) * q * ds(1) + k / h * (T - T_2) * q * ds(2)
     return F_cells + F_boundaries
+
+
+class StefanLagAuxSNES(IRKAuxiliaryOperatorSNES):
+    """Precondition the fully implicit Stefan problem with the residual whose
+    conductivity is lagged to the start of the timestep."""
+    def getNewForm(self, snes, T, q):
+        t = self.get_appctx(snes)["stepper"].t
+        k = lag(stefan_conductivity(T))
+        return stefan_form(T, q, t, k), None
 
 
 def stefan_setup():
@@ -79,16 +88,10 @@ def test_npc_stefan_newton_fails():
             t.assign(float(t) + float(dt))
 
 
-class StefanLagAuxSNES(pc.IRKAuxiliaryOperatorSNES):
-    """Precondition the fully implicit Stefan problem with the residual whose
-    conductivity is lagged to the start of the timestep."""
-    def getNewForm(self, snes, T, q):
-        t = self.get_appctx(snes)["stepper"].t
-        k = lag(stefan_conductivity(T))
-        return stefan_form(T, q, t, k), None
-
-
-@pytest.mark.xfail(not pc._has_auxopsnes, reason="Old Firedrake")
+@pytest.mark.skipif(
+    not hasattr(firedrake, "AuxiliaryOperatorSNES"),
+    reason="Firedrake does not provide AuxiliaryOperatorSNES",
+)
 def test_npc_stefan():
     """The lagged residual, used as a nonlinear preconditioner, drives the
     fully implicit Stefan problem to convergence where Newton fails."""

--- a/tests/test_npc.py
+++ b/tests/test_npc.py
@@ -6,7 +6,7 @@ from firedrake import (
     TestFunction, UnitIntervalMesh, exp, cos, ds, dx,
     grad, inner
 )
-from irksome import BackwardEuler, Dt, IRKAuxiliaryOperatorSNES, TimeStepper, lag
+from irksome import BackwardEuler, Dt, TimeStepper, lag, pc
 
 # Stefan problem: a two-phase heat equation with a discontinuous conductivity
 #
@@ -23,7 +23,7 @@ k_solid = Constant(2.0)
 k_liquid = Constant(1.0)
 h = Constant(0.01)            # Robin penalty length scale
 dT = Constant(0.25)           # amplitude of the boundary oscillation
-T_scale = Constant(5e-4)      # scale for transition between solid and liquid
+T_scale = Constant(1e-3)      # scale for transition between solid and liquid
 
 
 def stefan_conductivity(T):
@@ -39,15 +39,6 @@ def stefan_form(T, q, t, k):
     F_cells = (Dt(T) * q + k * inner(grad(T), grad(q))) * dx
     F_boundaries = k / h * (T - T_1) * q * ds(1) + k / h * (T - T_2) * q * ds(2)
     return F_cells + F_boundaries
-
-
-class StefanLagAuxSNES(IRKAuxiliaryOperatorSNES):
-    """Precondition the fully implicit Stefan problem with the residual whose
-    conductivity is lagged to the start of the timestep."""
-    def getNewForm(self, snes, T, q):
-        t = self.get_appctx(snes)["stepper"].t
-        k = lag(stefan_conductivity(T))
-        return stefan_form(T, q, t, k), None
 
 
 def stefan_setup():
@@ -88,6 +79,16 @@ def test_npc_stefan_newton_fails():
             t.assign(float(t) + float(dt))
 
 
+class StefanLagAuxSNES(pc.IRKAuxiliaryOperatorSNES):
+    """Precondition the fully implicit Stefan problem with the residual whose
+    conductivity is lagged to the start of the timestep."""
+    def getNewForm(self, snes, T, q):
+        t = self.get_appctx(snes)["stepper"].t
+        k = lag(stefan_conductivity(T))
+        return stefan_form(T, q, t, k), None
+
+
+@pytest.mark.xfail(not pc._has_auxopsnes, reason="Old Firedrake")
 def test_npc_stefan():
     """The lagged residual, used as a nonlinear preconditioner, drives the
     fully implicit Stefan problem to convergence where Newton fails."""


### PR DESCRIPTION
Firedrake can use PETSc's nonlinear preconditioning features through the `AuxiliaryOperatorSNES` class. This patch adds a class `IRKAuxiliarySNES` which is almost identical to `IRKAuxiliaryOperatorPC` so that Irksome can use nonlinear preconditioning.

I added a test case based on the Stefan problem. This is similar to the test case for lagging that I used in #228. But now the lagged form is a preconditioner to the fully implicit form.